### PR TITLE
docs: roadmap sequencing for LibreOffice provider epic

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ There is no admin UI. Use the API endpoints below.
 - Share link doesn’t work: make sure the link wasn’t truncated and is from the Create screen.
 
 ## Roadmap (Exploratory)
-We are evaluating a larger Admin Platform expansion that includes an Admin UI, dictionary lifecycle management, and selected runtime settings controls.
+We are evaluating two exploratory tracks that are intentionally outside the current core scope:
+- Admin Platform expansion (Admin UI, dictionary lifecycle management, and selected runtime settings controls): https://github.com/curdriceaurora/wordle-local/issues/6
+- LibreOffice English variant sourcing (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) via Admin import flows, with Hunspell-based guess handling and curated answer policy: https://github.com/curdriceaurora/wordle-local/issues/17
 
-This is intentionally not in the current core scope and is tracked as an Epic with linked sub-issues:
-- https://github.com/curdriceaurora/wordle-local/issues/6
+This second track is planned after foundational Admin Platform work in #6.
 
 Whether it ships next will depend on adoption signals and community feedback.
 Current priority remains a stable, simple local-hosted gameplay experience.


### PR DESCRIPTION
## Summary
This PR is planning/docs-only and does **not** change runtime behavior.

### What changed
- Created the new planning Epic: #17
- Created and linked the blocked sub-issues: #18–#27
- Added sequencing cross-links between #6 and #17
- Updated README roadmap to reference both exploratory tracks and dependency order

## Scope
- Documentation and GitHub issue/project planning only
- No API changes
- No application code changes

## Verification
- Confirmed Epic #17 checklist links #18–#27
- Confirmed #6 and #17 include sequencing comments
- Confirmed README roadmap references #6 and #17

## Testing
Not run (docs and GitHub metadata updates only).
