### PR TITLE
process: add PR preflight checklist and merge-learning log

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+## Summary
+- Issue: #<issue-number>
+- Scope: <one-sentence objective>
+- Epic: #<epic-number>
+
+## In Scope
+- <item>
+- <item>
+
+## Out of Scope
+- <item>
+- <item>
+
+## Risk Review
+- Primary risks:
+  - <risk>
+  - <risk>
+- Mitigations:
+  - <mitigation>
+  - <mitigation>
+
+## Review-Nit Preflight (Required)
+- [ ] Docs and schema/API constraints are consistent (or explicitly documented where enforcement differs).
+- [ ] Conditional invariants are encoded (`if/then/else`) or explicitly delegated to implementation checks.
+- [ ] Ambiguous wording removed (deterministic tie-breaks, ordering, and timestamp semantics).
+- [ ] Redundant fields have explicit consistency rules.
+- [ ] Normalization/recovery rules include invalid examples and drop behavior.
+- [ ] JSON/file formatting conventions verified (including trailing newline for JSON files).
+- [ ] `docs/review-preflight.md` checklist reviewed before requesting review.
+
+## Validation
+- [ ] `npm test`
+- [ ] `npm run test:ui` (if UI touched)
+- [ ] `npm run test:all` (if cross-surface behavior changed)
+- Notes:
+  - <what changed in tests>
+
+## Review Focus
+1. <high-risk area>
+2. <policy/edge-case>
+3. <compatibility concern>
+
+## Post-Merge Learning Update (Required)
+- [ ] After merge, update `docs/review-preflight.md` -> **Merged PR Learnings Log** with any review nits and the preventive rule added.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,9 @@ Thanks for your interest in contributing!
 - Describe the user impact and any UI changes.
 - Include screenshots or recordings for UI tweaks when helpful.
 - Call out any follow-up work or known limitations.
+- Use the repository PR template.
+- Complete the mandatory preflight in `docs/review-preflight.md` before requesting review.
+- After merge, add an entry to `docs/review-preflight.md` under **Merged PR Learnings Log** for any review nits and preventive rule updates.
 
 ## License and Rights
 By submitting a contribution, you agree to dedicate your work to the public domain under CC0‑1.0. You represent that you have the right to do so and that your contribution does not infringe on third‑party rights.

--- a/docs/review-preflight.md
+++ b/docs/review-preflight.md
@@ -1,0 +1,26 @@
+# PR Review Preflight
+
+## Why
+This project now treats review-nit reduction as a first-class quality goal. The checklist below is required before requesting review on each PR.
+
+## Mandatory Preflight Checklist
+1. Contract parity: docs, schema, and endpoint behavior describe the same constraints.
+2. Enforcement clarity: if schema cannot enforce a rule, docs explicitly say implementation enforces it.
+3. Deterministic wording: no ambiguous terms such as "latest" or "newest" without exact tie-break/ordering rules.
+4. Conditional invariants: state-dependent fields are validated (schema or implementation).
+5. Redundancy checks: duplicate facts (for example, key/date pairs) have explicit consistency rules.
+6. Recovery rules: malformed or partial data behavior is explicit and testable.
+7. File conventions: JSON formatting and trailing newline conventions are preserved.
+
+## Review Comment Handling Standard
+1. Triage every comment as `must-fix`, `follow-up issue`, or `decline with rationale`.
+2. Reply with commit hash + validation command when code/docs changed.
+3. Do not leave unresolved threads when merging.
+
+## Merged PR Learnings Log
+Update this table after every successful PR merge.
+If a PR had no substantive review nits, add a row with `Nit observed = none` and `Preventive rule added = no change`.
+
+| Date (UTC) | PR | Type | Nit observed | Preventive rule added |
+| --- | --- | --- | --- | --- |
+| _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |


### PR DESCRIPTION
## Summary
- Issue: process hardening for PR quality loop
- Scope: add a repository PR template and a persistent review-preflight/learning document.
- Epic: #29 (quality process support)

## In Scope
- add `.github/pull_request_template.md` with mandatory preflight + post-merge learning step
- add `docs/review-preflight.md` checklist and merged-PR learnings log
- update `CONTRIBUTING.md` to require the workflow

## Out of Scope
- code/runtime behavior changes
- API/schema behavior changes

## Risk Review
- Primary risks:
  - process overhead if checklist is too heavy
  - inconsistent post-merge updates if not followed
- Mitigations:
  - concise checklist focused on review-nit drivers
  - explicit post-merge requirement in both template and contributing guide

## Review-Nit Preflight (Required)
- [x] Docs and schema/API constraints are consistent (or explicitly documented where enforcement differs).
- [x] Conditional invariants are encoded (`if/then/else`) or explicitly delegated to implementation checks.
- [x] Ambiguous wording removed (deterministic tie-breaks, ordering, and timestamp semantics).
- [x] Redundant fields have explicit consistency rules.
- [x] Normalization/recovery rules include invalid examples and drop behavior.
- [x] JSON/file formatting conventions verified (including trailing newline for JSON files).
- [x] `docs/review-preflight.md` checklist reviewed before requesting review.

## Validation
- [ ] `npm test`
- [ ] `npm run test:ui` (if UI touched)
- [ ] `npm run test:all` (if cross-surface behavior changed)
- Notes:
  - Not run (docs/template/process-only change)

## Review Focus
1. Clarity and enforceability of checklist language
2. Whether the post-merge learning loop is practical
3. Any missing review-nit categories we should include

## Post-Merge Learning Update (Required)
- [ ] After merge, update `docs/review-preflight.md` -> **Merged PR Learnings Log** with any review nits and the preventive rule added.
