### PR TITLE
docs: backfill review learnings log for merged PRs

### DIFF
--- a/docs/review-preflight.md
+++ b/docs/review-preflight.md
@@ -23,4 +23,5 @@ If a PR had no substantive review nits, add a row with `Nit observed = none` and
 
 | Date (UTC) | PR | Type | Nit observed | Preventive rule added |
 | --- | --- | --- | --- | --- |
-| _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| 2026-02-20 | [#39](https://github.com/curdriceaurora/wordle-local/pull/39) | docs+schema | Docs/schema parity gaps, ambiguous replay wording, missing conditional invariant for `won` vs `attempts`, key/date consistency wording gaps. | Added mandatory preflight checks for contract parity, conditional invariants, deterministic wording, redundancy consistency, and recovery specificity. |
+| 2026-02-20 | [#40](https://github.com/curdriceaurora/wordle-local/pull/40) | process/docs | none | no change |


### PR DESCRIPTION
## Summary
- backfill merged PR learnings log entries for:
  - #39
  - #40
- maintain the new requirement to iteratively update `docs/review-preflight.md` after successful merges

## Scope
- docs only (`docs/review-preflight.md`)
- no runtime or API changes

## Notes
- #39 captured substantive nit categories and preventive rule reinforcement
- #40 had no substantive review nits

## Testing
- not run (docs-only update)
