### PR TITLE
feat(provider): add LibreOffice fetch + checksum verification service

### DIFF
--- a/docs/review-preflight.md
+++ b/docs/review-preflight.md
@@ -27,7 +27,7 @@ This project now treats review-nit reduction as a first-class quality goal. The 
 21. Endpoint docs parity: documentation and rollout guides must match exact endpoint response contracts (status code + payload shape), not shorthand text.
 22. Schema identity consistency: new JSON schema `$id` values must follow existing repository domain/namespace conventions.
 23. Import integrity fail-closed: remote provider fetch paths must require both expected checksums (no silent no-op verification path).
-24. Atomic write resilience: JSON persistence must use unique temp paths and cleanup-on-failure for write/rename errors.
+24. Atomic write resilience: JSON persistence must use unique temp paths, cleanup-on-failure, and cross-platform replace semantics when destination files already exist (including Windows rename behavior).
 25. Manifest intent clarity: stage-specific manifests must avoid near-duplicate contract shapes unless fully aligned; include explicit type and unambiguous source-vs-local path fields.
 26. Error-branch test parity: every new runtime error code/path added in a PR must have direct test coverage.
 

--- a/lib/provider-fetch.js
+++ b/lib/provider-fetch.js
@@ -254,7 +254,31 @@ async function writeJsonAtomic(filePath, payload) {
   const tempPath = `${filePath}.${process.pid}.${nodeCrypto.randomUUID()}.tmp`;
   try {
     await fsp.writeFile(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
-    await fsp.rename(tempPath, filePath);
+    try {
+      await fsp.rename(tempPath, filePath);
+    } catch (err) {
+      // Windows can reject rename-over-existing-file; fall back to replace path.
+      if (!["EEXIST", "EPERM", "EACCES"].includes(String(err?.code || ""))) {
+        throw err;
+      }
+
+      let existingIsFile = false;
+      try {
+        const stat = await fsp.stat(filePath);
+        existingIsFile = stat.isFile();
+      } catch (statErr) {
+        if (String(statErr?.code || "") !== "ENOENT") {
+          throw err;
+        }
+      }
+
+      if (!existingIsFile) {
+        throw err;
+      }
+
+      await fsp.unlink(filePath);
+      await fsp.rename(tempPath, filePath);
+    }
   } catch (err) {
     await fsp.unlink(tempPath).catch(() => {});
     throw new ProviderFetchError(


### PR DESCRIPTION
## Summary
- adds `lib/provider-fetch.js` with an allowlisted LibreOffice fetch service for `en-GB/en-US/en-CA/en-AU/en-ZA`
- enforces commit pinning via full 40-char SHA and rejects unsupported variants
- adds SHA-256 integrity verification and fail-closed checksum mismatch behavior
- persists verified `.dic/.aff` artifacts and a `source-manifest.json` for downstream processing
- introduces friendly, typed provider errors for missing files, rate limits, upstream failures, timeout, and network errors
- adds unit coverage in `tests/provider-fetch.test.js` for success and failure scenarios

## Why
Implements #19 in Epic #17 MVP by delivering the secure remote-fetch + checksum verification foundation required before Hunspell expansion and policy processing.

## Validation
- `npm test -- tests/provider-fetch.test.js --runInBand`
- `npm run check`

Closes #19
