### PR TITLE
Issue #23: add family-safe answer filtering for provider answers

### DIFF
--- a/docs/provider-import-contract.md
+++ b/docs/provider-import-contract.md
@@ -166,6 +166,50 @@ Gotchas:
 2. Allowlist entries that are not in guess pool are ignored and counted in metadata for auditability.
 3. If base+irregular selection yields an empty answer pool, generation fails closed.
 
+## Family-Safe Activation Filter (Issue #23)
+After policy generation, answer activation applies family-safety filtering under:
+- `data/providers/<variant>/<commit>/answer-pool-active.txt`
+- `data/providers/<variant>/<commit>/answer-filter.json`
+
+Filtering modes:
+- `denylist-only` (default): remove words listed in `family-denylist.txt`.
+- `allowlist-required` (optional strict mode): after denylist filtering, keep only words explicitly listed in `family-allowlist.txt`.
+
+Why this stage is separate:
+- It keeps lexical policy (`#22`) independent from family moderation policy.
+- Families can tune safety controls without rebuilding the earlier import/expansion stages.
+- Metadata provides explainability for why answer counts changed.
+
+Input files:
+- source answers: `answer-pool.txt` (from `#22`)
+- denylist: `family-denylist.txt` (optional, variant+commit scoped)
+- allowlist: `family-allowlist.txt` (required only when `allowlist-required` mode is selected)
+
+`answer-filter.json` contract:
+- `schemaVersion`
+- `variant`
+- `commit`
+- `filterMode`
+- `sourceAnswerPoolPath`
+- `denylistPath`
+- `allowlistPath`
+- `counts`:
+  - `inputAnswers`
+  - `inputFilteredOut`
+  - `denylistEntries`
+  - `denylistFilteredOut`
+  - `denylistMatched`
+  - `allowlistEntries`
+  - `allowlistFilteredOut`
+  - `allowlistExcluded`
+  - `activatedAnswers`
+- `generatedAt`
+
+Gotchas:
+1. `allowlist-required` fails closed if the allowlist file is missing.
+2. Invalid/non-`A-Z` list entries are ignored and counted in `*FilteredOut` metrics.
+3. If filtering removes all candidate answers, activation fails closed to avoid silent unsafe defaults.
+
 ## Related Issues
 - Epic: `#17`
 - Next dependent stories: `#19`, `#21`, `#22`, `#23`, `#24`, `#26`

--- a/lib/provider-answer-filter.js
+++ b/lib/provider-answer-filter.js
@@ -1,0 +1,337 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  MAX_WORD_LENGTH,
+  MIN_WORD_LENGTH,
+  SUPPORTED_VARIANT_IDS,
+  WORD_PATTERN,
+  normalizeCommit: normalizeSharedCommit,
+  normalizeRelativePath: normalizeSharedRelativePath,
+  normalizeVariant: normalizeSharedVariant,
+  resolveWithinRoot: resolveWithinSharedRoot,
+  writeFileAtomic: writeSharedFileAtomic,
+  writeJsonAtomic: writeSharedJsonAtomic
+} = require("./provider-artifact-shared");
+
+const fsp = fs.promises;
+
+const DEFAULT_PROVIDER_ROOT = path.join(__dirname, "..", "data", "providers");
+const DEFAULT_DENYLIST_FILE = "family-denylist.txt";
+const DEFAULT_ALLOWLIST_FILE = "family-allowlist.txt";
+const SUPPORTED_VARIANTS = new Set(SUPPORTED_VARIANT_IDS);
+
+const FILTER_MODES = Object.freeze({
+  DENYLIST_ONLY: "denylist-only",
+  ALLOWLIST_REQUIRED: "allowlist-required"
+});
+
+class ProviderAnswerFilterError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = "ProviderAnswerFilterError";
+    this.code = code;
+    this.retriable = options.retriable === true;
+    if (options.cause) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+function createError(code, message, options) {
+  return new ProviderAnswerFilterError(code, message, options);
+}
+
+function normalizeVariant(variant) {
+  return normalizeSharedVariant(variant, {
+    supportedVariants: SUPPORTED_VARIANTS,
+    errorFactory: createError
+  });
+}
+
+function normalizeCommit(commit) {
+  return normalizeSharedCommit(commit, {
+    errorFactory: createError
+  });
+}
+
+function normalizeRelativePath(relativePath, fieldName) {
+  return normalizeSharedRelativePath(relativePath, {
+    fieldName,
+    errorCode: "INVALID_PATH",
+    errorFactory: createError
+  });
+}
+
+function resolveWithinRoot(root, relativePath, fieldName) {
+  return resolveWithinSharedRoot(root, relativePath, {
+    fieldName,
+    errorCode: "INVALID_PATH",
+    errorFactory: createError
+  });
+}
+
+async function writeFileAtomic(filePath, content) {
+  await writeSharedFileAtomic(filePath, content, {
+    errorCode: "PERSISTENCE_WRITE_FAILED",
+    errorFactory: createError
+  });
+}
+
+async function writeJsonAtomic(filePath, payload) {
+  await writeSharedJsonAtomic(filePath, payload, {
+    errorCode: "PERSISTENCE_WRITE_FAILED",
+    errorFactory: createError
+  });
+}
+
+function normalizeFilterMode(filterMode) {
+  const value = String(filterMode || FILTER_MODES.DENYLIST_ONLY).trim();
+  if (!Object.values(FILTER_MODES).includes(value)) {
+    throw new ProviderAnswerFilterError(
+      "INVALID_FILTER_MODE",
+      `filterMode must be one of ${Object.values(FILTER_MODES).join(", ")}.`
+    );
+  }
+  return value;
+}
+
+function parseWords(rawText, options = {}) {
+  const words = new Set();
+  let filteredCount = 0;
+  const allowComments = options.allowComments === true;
+  const lines = String(rawText || "").split(/\r?\n/);
+
+  for (const line of lines) {
+    const value = String(line || "").trim();
+    if (!value) {
+      continue;
+    }
+    if (allowComments && value.startsWith("#")) {
+      continue;
+    }
+    const normalized = value.toUpperCase();
+    if (!WORD_PATTERN.test(normalized)) {
+      filteredCount += 1;
+      continue;
+    }
+    if (normalized.length < MIN_WORD_LENGTH || normalized.length > MAX_WORD_LENGTH) {
+      filteredCount += 1;
+      continue;
+    }
+    words.add(normalized);
+  }
+
+  return {
+    words,
+    filteredCount
+  };
+}
+
+function readJson(filePath, kind) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    throw new ProviderAnswerFilterError(
+      "SOURCE_MANIFEST_MISSING",
+      `Could not read ${kind} at ${filePath}.`,
+      { cause: err }
+    );
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new ProviderAnswerFilterError(
+      "INVALID_MANIFEST",
+      `Invalid JSON in ${kind} at ${filePath}.`,
+      { cause: err }
+    );
+  }
+}
+
+function readGeneratedAt(variantRoot, variant, commit) {
+  const sourceManifest = readJson(path.join(variantRoot, "source-manifest.json"), "source-manifest");
+  if (!sourceManifest || typeof sourceManifest !== "object" || Array.isArray(sourceManifest)) {
+    throw new ProviderAnswerFilterError("INVALID_MANIFEST", "source-manifest payload must be an object.");
+  }
+  if (sourceManifest.manifestType !== "provider-source-fetch") {
+    throw new ProviderAnswerFilterError(
+      "INVALID_MANIFEST",
+      "source-manifest manifestType must be provider-source-fetch."
+    );
+  }
+  if (sourceManifest.provider?.variant !== variant) {
+    throw new ProviderAnswerFilterError(
+      "INVALID_MANIFEST",
+      `source-manifest variant mismatch: expected ${variant}.`
+    );
+  }
+  if (sourceManifest.provider?.commit !== commit) {
+    throw new ProviderAnswerFilterError(
+      "INVALID_MANIFEST",
+      `source-manifest commit mismatch: expected ${commit}.`
+    );
+  }
+
+  const generatedAt = String(sourceManifest.retrievedAt || "");
+  if (!generatedAt || Number.isNaN(Date.parse(generatedAt))) {
+    throw new ProviderAnswerFilterError(
+      "INVALID_MANIFEST",
+      "source-manifest must include a valid retrievedAt timestamp."
+    );
+  }
+  return generatedAt;
+}
+
+async function readRequiredWordSet(filePath, kind, options = {}) {
+  let raw;
+  try {
+    raw = await fsp.readFile(filePath, "utf8");
+  } catch (err) {
+    throw new ProviderAnswerFilterError(
+      "INPUT_ARTIFACT_MISSING",
+      `Could not read ${kind} at ${filePath}.`,
+      { cause: err }
+    );
+  }
+  return parseWords(raw, options);
+}
+
+async function readOptionalWordSet(filePath, options = {}) {
+  try {
+    const raw = await fsp.readFile(filePath, "utf8");
+    return parseWords(raw, options);
+  } catch (err) {
+    if (err && err.code === "ENOENT") {
+      return {
+        words: new Set(),
+        filteredCount: 0,
+        missing: true
+      };
+    }
+    throw new ProviderAnswerFilterError(
+      "INPUT_ARTIFACT_MISSING",
+      `Could not read list file at ${filePath}.`,
+      { cause: err }
+    );
+  }
+}
+
+function toSortedArray(values) {
+  // ASCII-only word list (A-Z) uses code-point sort for deterministic cross-locale ordering.
+  return Array.from(values).sort();
+}
+
+async function buildFilteredAnswerPoolArtifacts(options) {
+  const variant = normalizeVariant(options?.variant);
+  const commit = normalizeCommit(options?.commit);
+  const filterMode = normalizeFilterMode(options?.filterMode);
+  const providerRoot = options?.providerRoot
+    ? path.resolve(options.providerRoot)
+    : DEFAULT_PROVIDER_ROOT;
+  const outputRoot = options?.outputRoot
+    ? path.resolve(options.outputRoot)
+    : providerRoot;
+  const variantRoot = path.join(providerRoot, variant, commit);
+  const outputVariantRoot = path.join(outputRoot, variant, commit);
+
+  const generatedAt = readGeneratedAt(variantRoot, variant, commit);
+
+  const answerPoolPathRelative = options?.answerPoolPath
+    ? normalizeRelativePath(options.answerPoolPath, "answerPoolPath")
+    : path.posix.join(variant, commit, "answer-pool.txt");
+  const answerPoolSource = resolveWithinRoot(providerRoot, answerPoolPathRelative, "answerPoolPath");
+  const answerPool = await readRequiredWordSet(answerPoolSource.resolved, "answer-pool");
+  if (answerPool.words.size === 0) {
+    throw new ProviderAnswerFilterError(
+      "ANSWER_POOL_EMPTY",
+      "Input answer pool is empty after normalization."
+    );
+  }
+
+  const denylistPathRelative = options?.denylistPath
+    ? normalizeRelativePath(options.denylistPath, "denylistPath")
+    : path.posix.join(variant, commit, DEFAULT_DENYLIST_FILE);
+  const denylistSource = resolveWithinRoot(providerRoot, denylistPathRelative, "denylistPath");
+  const denylist = await readOptionalWordSet(denylistSource.resolved, { allowComments: true });
+
+  const allowlistPathRelative = options?.allowlistPath
+    ? normalizeRelativePath(options.allowlistPath, "allowlistPath")
+    : path.posix.join(variant, commit, DEFAULT_ALLOWLIST_FILE);
+  const allowlistSource = resolveWithinRoot(providerRoot, allowlistPathRelative, "allowlistPath");
+  const allowlist = await readOptionalWordSet(allowlistSource.resolved, { allowComments: true });
+  if (filterMode === FILTER_MODES.ALLOWLIST_REQUIRED && allowlist.missing) {
+    throw new ProviderAnswerFilterError(
+      "ALLOWLIST_REQUIRED",
+      `allowlistPath must exist when filterMode=${FILTER_MODES.ALLOWLIST_REQUIRED}.`
+    );
+  }
+
+  const filteredAnswerPool = new Set();
+  let denylistMatched = 0;
+  let allowlistExcluded = 0;
+
+  for (const word of answerPool.words) {
+    if (denylist.words.has(word)) {
+      denylistMatched += 1;
+      continue;
+    }
+    if (filterMode === FILTER_MODES.ALLOWLIST_REQUIRED && !allowlist.words.has(word)) {
+      allowlistExcluded += 1;
+      continue;
+    }
+    filteredAnswerPool.add(word);
+  }
+
+  if (filteredAnswerPool.size === 0) {
+    throw new ProviderAnswerFilterError(
+      "FILTERED_POOL_EMPTY",
+      "Family-safe filtering removed all candidate answers."
+    );
+  }
+
+  await fsp.mkdir(outputVariantRoot, { recursive: true });
+  const activeAnswerPoolPath = path.join(outputVariantRoot, "answer-pool-active.txt");
+  await writeFileAtomic(activeAnswerPoolPath, `${toSortedArray(filteredAnswerPool).join("\n")}\n`);
+
+  const metadata = {
+    schemaVersion: 1,
+    variant,
+    commit,
+    filterMode,
+    sourceAnswerPoolPath: answerPoolSource.normalized,
+    denylistPath: denylistSource.normalized,
+    allowlistPath: allowlistSource.normalized,
+    counts: {
+      inputAnswers: answerPool.words.size,
+      inputFilteredOut: answerPool.filteredCount,
+      denylistEntries: denylist.words.size,
+      denylistFilteredOut: denylist.filteredCount,
+      denylistMatched,
+      allowlistEntries: allowlist.words.size,
+      allowlistFilteredOut: allowlist.filteredCount,
+      allowlistExcluded,
+      activatedAnswers: filteredAnswerPool.size
+    },
+    generatedAt
+  };
+
+  const filterMetadataPath = path.join(outputVariantRoot, "answer-filter.json");
+  await writeJsonAtomic(filterMetadataPath, metadata);
+
+  return {
+    variant,
+    commit,
+    filterMode,
+    activeAnswerPoolPath,
+    filterMetadataPath,
+    counts: metadata.counts
+  };
+}
+
+module.exports = {
+  FILTER_MODES,
+  ProviderAnswerFilterError,
+  buildFilteredAnswerPoolArtifacts
+};

--- a/scripts/nit-guardrails.js
+++ b/scripts/nit-guardrails.js
@@ -109,6 +109,22 @@ function run() {
       "lib/provider-pool-policy.js must reuse resolveWithinRoot for allowlist path boundary checks."
     );
   }
+  if (!providerPoolPolicy.includes("resolveWithinSharedRoot")) {
+    errors.push("lib/provider-pool-policy.js must use shared provider artifact boundary helpers.");
+  }
+
+  const providerAnswerFilter = readFile("lib/provider-answer-filter.js");
+  if (!providerAnswerFilter.includes("resolveWithinSharedRoot")) {
+    errors.push("lib/provider-answer-filter.js must use shared provider artifact boundary helpers.");
+  }
+  if (!providerAnswerFilter.includes("writeSharedFileAtomic")) {
+    errors.push("lib/provider-answer-filter.js must use shared atomic write helpers.");
+  }
+  if (providerAnswerFilter.includes("path.resolve(providerRoot, relativePath)")) {
+    errors.push(
+      "lib/provider-answer-filter.js must avoid manual providerRoot path resolution for list files."
+    );
+  }
 
   checkLanguageSchemaDictionaryCoupling(errors);
 

--- a/tests/provider-answer-filter.test.js
+++ b/tests/provider-answer-filter.test.js
@@ -1,0 +1,212 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  FILTER_MODES,
+  ProviderAnswerFilterError,
+  buildFilteredAnswerPoolArtifacts
+} = require("../lib/provider-answer-filter");
+
+const PROVIDER_REPOSITORY = "https://github.com/LibreOffice/dictionaries";
+const COMMIT = "0123456789abcdef0123456789abcdef01234567";
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "lhw-provider-answer-filter-"));
+}
+
+function writeProviderAnswerArtifacts(options = {}) {
+  const providerRoot = options.providerRoot || createTempDir();
+  const variant = options.variant || "en-US";
+  const commit = options.commit || COMMIT;
+  const variantRoot = path.join(providerRoot, variant, commit);
+  fs.mkdirSync(variantRoot, { recursive: true });
+
+  const sourceManifest = {
+    schemaVersion: 1,
+    manifestType: "provider-source-fetch",
+    provider: {
+      providerId: "libreoffice-dictionaries",
+      variant,
+      repository: PROVIDER_REPOSITORY,
+      commit,
+      dicPath: "en/en_US.dic",
+      affPath: "en/en_US.aff"
+    },
+    sourceFiles: {
+      dic: {
+        sourcePath: "en/en_US.dic",
+        localPath: path.posix.join(variant, commit, "en_US.dic"),
+        url: `${PROVIDER_REPOSITORY}/raw/${commit}/en/en_US.dic`,
+        sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        byteSize: 100
+      },
+      aff: {
+        sourcePath: "en/en_US.aff",
+        localPath: path.posix.join(variant, commit, "en_US.aff"),
+        url: `${PROVIDER_REPOSITORY}/raw/${commit}/en/en_US.aff`,
+        sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        byteSize: 100
+      }
+    },
+    retrievedAt: options.retrievedAt || "2026-02-21T00:00:00.000Z"
+  };
+  fs.writeFileSync(
+    path.join(variantRoot, "source-manifest.json"),
+    `${JSON.stringify(sourceManifest, null, 2)}\n`,
+    "utf8"
+  );
+
+  fs.writeFileSync(
+    path.join(variantRoot, "answer-pool.txt"),
+    options.answerPoolContent || "CAT\nDOG\nDOGS\nGOOSE\nWENT\nPLAY\nWALK\n",
+    "utf8"
+  );
+
+  if (options.denylistContent !== undefined) {
+    fs.writeFileSync(
+      path.join(variantRoot, "family-denylist.txt"),
+      options.denylistContent,
+      "utf8"
+    );
+  }
+
+  if (options.allowlistContent !== undefined) {
+    fs.writeFileSync(
+      path.join(variantRoot, "family-allowlist.txt"),
+      options.allowlistContent,
+      "utf8"
+    );
+  }
+
+  return {
+    providerRoot,
+    variant,
+    commit
+  };
+}
+
+describe("provider-answer-filter", () => {
+  test("applies denylist-only filter and persists metadata counts", async () => {
+    const setup = writeProviderAnswerArtifacts({
+      denylistContent: "WENT\n# keep list readable\nINVALID-WORD\n"
+    });
+    try {
+      const result = await buildFilteredAnswerPoolArtifacts({
+        variant: setup.variant,
+        commit: setup.commit,
+        providerRoot: setup.providerRoot,
+        filterMode: FILTER_MODES.DENYLIST_ONLY
+      });
+
+      const active = fs
+        .readFileSync(result.activeAnswerPoolPath, "utf8")
+        .trim()
+        .split("\n");
+      expect(active).toEqual(["CAT", "DOG", "DOGS", "GOOSE", "PLAY", "WALK"]);
+
+      const metadata = JSON.parse(fs.readFileSync(result.filterMetadataPath, "utf8"));
+      expect(metadata.filterMode).toBe(FILTER_MODES.DENYLIST_ONLY);
+      expect(metadata.counts.inputAnswers).toBe(7);
+      expect(metadata.counts.denylistEntries).toBe(1);
+      expect(metadata.counts.denylistFilteredOut).toBe(1);
+      expect(metadata.counts.denylistMatched).toBe(1);
+      expect(metadata.counts.activatedAnswers).toBe(6);
+      expect(metadata.generatedAt).toBe("2026-02-21T00:00:00.000Z");
+    } finally {
+      fs.rmSync(setup.providerRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("enforces allowlist-required mode after denylist filtering", async () => {
+    const setup = writeProviderAnswerArtifacts({
+      denylistContent: "WENT\n",
+      allowlistContent: "WENT\nGOOSE\nWALK\n"
+    });
+    try {
+      const result = await buildFilteredAnswerPoolArtifacts({
+        variant: setup.variant,
+        commit: setup.commit,
+        providerRoot: setup.providerRoot,
+        filterMode: FILTER_MODES.ALLOWLIST_REQUIRED
+      });
+
+      const active = fs
+        .readFileSync(result.activeAnswerPoolPath, "utf8")
+        .trim()
+        .split("\n");
+      expect(active).toEqual(["GOOSE", "WALK"]);
+
+      const metadata = JSON.parse(fs.readFileSync(result.filterMetadataPath, "utf8"));
+      expect(metadata.counts.denylistMatched).toBe(1);
+      expect(metadata.counts.allowlistEntries).toBe(3);
+      expect(metadata.counts.allowlistExcluded).toBe(4);
+      expect(metadata.counts.activatedAnswers).toBe(2);
+    } finally {
+      fs.rmSync(setup.providerRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when allowlist-required mode is selected without allowlist file", async () => {
+    const setup = writeProviderAnswerArtifacts({
+      denylistContent: ""
+    });
+    try {
+      await expect(
+        buildFilteredAnswerPoolArtifacts({
+          variant: setup.variant,
+          commit: setup.commit,
+          providerRoot: setup.providerRoot,
+          filterMode: FILTER_MODES.ALLOWLIST_REQUIRED
+        })
+      ).rejects.toMatchObject({
+        code: "ALLOWLIST_REQUIRED"
+      });
+    } finally {
+      fs.rmSync(setup.providerRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed when filtering removes all answers", async () => {
+    const setup = writeProviderAnswerArtifacts({
+      denylistContent: "CAT\nDOG\nDOGS\nGOOSE\nWENT\nPLAY\nWALK\n"
+    });
+    try {
+      await expect(
+        buildFilteredAnswerPoolArtifacts({
+          variant: setup.variant,
+          commit: setup.commit,
+          providerRoot: setup.providerRoot,
+          filterMode: FILTER_MODES.DENYLIST_ONLY
+        })
+      ).rejects.toMatchObject({
+        code: "FILTERED_POOL_EMPTY"
+      });
+    } finally {
+      fs.rmSync(setup.providerRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects commit values that are not strict 40-char lowercase hex", async () => {
+    const setup = writeProviderAnswerArtifacts();
+    try {
+      await expect(
+        buildFilteredAnswerPoolArtifacts({
+          variant: setup.variant,
+          commit: setup.commit.toUpperCase(),
+          providerRoot: setup.providerRoot
+        })
+      ).rejects.toMatchObject({
+        code: "INVALID_COMMIT"
+      });
+    } finally {
+      fs.rmSync(setup.providerRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("exports typed filter errors", () => {
+    const err = new ProviderAnswerFilterError("X", "failed");
+    expect(err.name).toBe("ProviderAnswerFilterError");
+    expect(err.code).toBe("X");
+  });
+});


### PR DESCRIPTION
## Summary
- add `lib/provider-answer-filter.js` for family-safe answer activation filtering on imported provider pools
- support two deterministic modes: `denylist-only` (default) and optional strict `allowlist-required`
- persist activated answer artifacts and audit metadata (`answer-pool-active.txt`, `answer-filter.json`)
- document the new filtering stage and operational gotchas in provider import contract docs
- extend nit guardrails to enforce shared provider helper usage in the new module

## Why
Issue #23 requires a moderation gate between lexical policy generation and runtime activation, with explainable counts so families can audit what was filtered and why.

## Validation
- `npm test -- tests/provider-answer-filter.test.js tests/provider-pool-policy.test.js tests/provider-hunspell.test.js`
- `npm run check`
- `npm run test:all`

Closes #23
