### PR TITLE
Add manual .dic/.aff upload fallback for provider imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you want admin controls or are hosting behind a VPN/proxy, see `advanced-sett
 - Visit `/admin` for the provider admin shell.
 - Unlock uses `x-admin-key` semantics and keeps the key session-scoped in memory (no browser storage persistence).
 - Provider workflows are built in:
-  - import/re-import (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) using pinned commit + required SHA-256 checksums
+  - import/re-import (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) via either remote fetch (pinned commit + required SHA-256 checksums) or manual `.dic` + `.aff` upload fallback
   - check upstream updates on demand with status outcomes (`up-to-date`, `update-available`, `unknown`, `error`)
   - enable/disable imported variants without CLI usage
 - Import uses `denylist-only` (default) or `allowlist-required` family filter modes.

--- a/advanced-settings.md
+++ b/advanced-settings.md
@@ -18,7 +18,9 @@ Set `ADMIN_KEY` to protect admin endpoints. When set, include `x-admin-key: <val
   - `POST /api/admin/providers/:variant/enable`
   - `POST /api/admin/providers/:variant/disable`
 - Import request body example:
-  - `{"variant":"en-US","commit":"<40-char-sha>","filterMode":"denylist-only","expectedChecksums":{"dic":"<sha256>","aff":"<sha256>"}}`
+  - Remote fetch: `{"sourceType":"remote-fetch","variant":"en-US","commit":"<40-char-sha>","filterMode":"denylist-only","expectedChecksums":{"dic":"<sha256>","aff":"<sha256>"}}`
+  - Manual upload fallback: `{"sourceType":"manual-upload","variant":"en-US","commit":"<optional-40-char-sha>","filterMode":"denylist-only","expectedChecksums":{"dic":"<sha256>","aff":"<sha256>"},"manualFiles":{"dicBase64":"<base64>","affBase64":"<base64>","dicFileName":"en_US.dic","affFileName":"en_US.aff"}}`
+    - If `commit` is omitted for manual uploads, the server derives a deterministic synthetic commit from file checksums.
 - Manual update-check outcomes:
   - `up-to-date` (installed commit matches latest upstream)
   - `update-available` (newer upstream commit found)
@@ -48,4 +50,6 @@ Set `ADMIN_KEY` to protect admin endpoints. When set, include `x-admin-key: <val
 - `PORT` — default 3000.
 - `HOST` — default 0.0.0.0.
 - `NODE_ENV` — `development` or `production`.
+- `JSON_BODY_LIMIT` — max JSON payload size for API requests (default `12mb`).
+- `PROVIDER_MANUAL_MAX_FILE_BYTES` — max bytes per manual upload file (default `8388608` / 8 MiB).
 - Language registry file: `data/languages.json` (auto-recovers to baked defaults if missing/invalid).

--- a/docs/provider-import-contract.md
+++ b/docs/provider-import-contract.md
@@ -18,7 +18,7 @@ This contract covers MVP variants only:
 
 MVP assumptions locked here:
 - Source repository is pinned to `https://github.com/LibreOffice/dictionaries`.
-- Import mode is remote fetch only.
+- Import mode supports both remote fetch and manual `.dic + .aff` upload fallback.
 - Allowed output character set is strict `A-Z`.
 
 ## Files
@@ -60,11 +60,16 @@ Top-level required fields:
 - `artifacts`
 - `stats`
 
+`manifestType` values:
+- `provider-source-fetch` for remote fetch imports
+- `provider-source-manual-upload` for manual file uploads
+
 ### `sourceFiles`
 Contains both source files and their integrity metadata:
 - `path` (relative path)
 - `sha256` (64 lowercase hex chars)
 - `byteSize` (positive integer)
+- `uploadFileName` (manual-upload manifests only)
 
 ### `processing`
 Tracks policy identity used to generate runtime pools:

--- a/docs/provider-rollout-checklist.md
+++ b/docs/provider-rollout-checklist.md
@@ -12,9 +12,11 @@ Provider imports add an external-source trust boundary and an admin-controlled a
 
 ## Provenance and integrity checks (required)
 1. Confirm import payload requires:
-   - pinned 40-char commit SHA
+   - `sourceType` (`remote-fetch` or `manual-upload`)
+   - pinned 40-char commit SHA for `remote-fetch` (optional for `manual-upload`)
    - `expectedChecksums.dic`
    - `expectedChecksums.aff`
+   - `manualFiles.dicBase64` + `manualFiles.affBase64` when `sourceType=manual-upload`
 2. Confirm imported commit folder includes:
    - `source-manifest.json`
    - `expanded-forms.txt`
@@ -48,12 +50,34 @@ curl -sS -X POST http://localhost:3000/api/admin/providers/import \
   -H 'content-type: application/json' \
   -H 'x-admin-key: ADMIN_KEY_VALUE' \
   -d '{
+    "sourceType":"remote-fetch",
     "variant":"en-US",
     "commit":"0123456789abcdef0123456789abcdef01234567",
     "filterMode":"denylist-only",
     "expectedChecksums":{
       "dic":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "aff":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  }'
+```
+
+```bash
+curl -sS -X POST http://localhost:3000/api/admin/providers/import \
+  -H 'content-type: application/json' \
+  -H 'x-admin-key: ADMIN_KEY_VALUE' \
+  -d '{
+    "sourceType":"manual-upload",
+    "variant":"en-US",
+    "filterMode":"denylist-only",
+    "expectedChecksums":{
+      "dic":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "aff":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "manualFiles":{
+      "dicBase64":"<base64-dic>",
+      "affBase64":"<base64-aff>",
+      "dicFileName":"en_US.dic",
+      "affFileName":"en_US.aff"
     }
   }'
 ```

--- a/docs/review-preflight.md
+++ b/docs/review-preflight.md
@@ -51,9 +51,10 @@ This project now treats review-nit reduction as a first-class quality goal. The 
 45. Provider CI gate coverage: PR CI must run a targeted provider admin UI regression test whenever provider/admin workflow files change.
 46. Update-check commit semantics: manual provider update checks must not infer “current commit” from arbitrary imported commit folders; only explicit request or active commit may drive comparison.
 47. UI state minimization: do not persist full API payloads in per-row UI state maps when only a subset is needed for rendering.
+48. Manual-upload integrity parity: provider manual upload fallback must enforce explicit `sourceType`, per-file size limits, and checksum verification parity with remote imports.
 
 ## Automation Coverage Map
-- Automated + Manual: 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47
+- Automated + Manual: 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48
 - Manual only: 3 (deterministic wording and ambiguity review still requires human check)
 
 ## Review Comment Handling Standard

--- a/lib/provider-answer-filter.js
+++ b/lib/provider-answer-filter.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const {
   MAX_WORD_LENGTH,
   MIN_WORD_LENGTH,
+  SOURCE_MANIFEST_TYPES,
   SUPPORTED_VARIANT_IDS,
   WORD_PATTERN,
   normalizeCommit: normalizeSharedCommit,
@@ -19,6 +20,7 @@ const DEFAULT_PROVIDER_ROOT = path.join(__dirname, "..", "data", "providers");
 const DEFAULT_DENYLIST_FILE = "family-denylist.txt";
 const DEFAULT_ALLOWLIST_FILE = "family-allowlist.txt";
 const SUPPORTED_VARIANTS = new Set(SUPPORTED_VARIANT_IDS);
+const SUPPORTED_SOURCE_MANIFEST_TYPES = new Set(Object.values(SOURCE_MANIFEST_TYPES));
 
 const FILTER_MODES = Object.freeze({
   DENYLIST_ONLY: "denylist-only",
@@ -155,10 +157,10 @@ function readGeneratedAt(variantRoot, variant, commit) {
   if (!sourceManifest || typeof sourceManifest !== "object" || Array.isArray(sourceManifest)) {
     throw new ProviderAnswerFilterError("INVALID_MANIFEST", "source-manifest payload must be an object.");
   }
-  if (sourceManifest.manifestType !== "provider-source-fetch") {
+  if (!SUPPORTED_SOURCE_MANIFEST_TYPES.has(String(sourceManifest.manifestType || ""))) {
     throw new ProviderAnswerFilterError(
       "INVALID_MANIFEST",
-      "source-manifest manifestType must be provider-source-fetch."
+      `source-manifest manifestType must be one of: ${Array.from(SUPPORTED_SOURCE_MANIFEST_TYPES).join(", ")}.`
     );
   }
   if (sourceManifest.provider?.variant !== variant) {

--- a/lib/provider-artifact-shared.js
+++ b/lib/provider-artifact-shared.js
@@ -8,6 +8,10 @@ const MIN_WORD_LENGTH = 3;
 const MAX_WORD_LENGTH = 12;
 const WORD_PATTERN = /^[A-Z]+$/;
 const SUPPORTED_VARIANT_IDS = Object.freeze(["en-GB", "en-US", "en-CA", "en-AU", "en-ZA"]);
+const SOURCE_MANIFEST_TYPES = Object.freeze({
+  REMOTE_FETCH: "provider-source-fetch",
+  MANUAL_UPLOAD: "provider-source-manual-upload"
+});
 const RELATIVE_PATH_PATTERN = /^(?!\/)(?!.*\.\.)[A-Za-z0-9._/-]+$/;
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/;
 const POLICY_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,32}$/;
@@ -133,6 +137,7 @@ module.exports = {
   MAX_WORD_LENGTH,
   MIN_WORD_LENGTH,
   RELATIVE_PATH_PATTERN,
+  SOURCE_MANIFEST_TYPES,
   SUPPORTED_VARIANT_IDS,
   WORD_PATTERN,
   normalizeCommit,

--- a/lib/provider-fetch.js
+++ b/lib/provider-fetch.js
@@ -1,6 +1,7 @@
 const nodeCrypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
+const { SOURCE_MANIFEST_TYPES } = require("./provider-artifact-shared");
 
 const fsp = fs.promises;
 
@@ -12,7 +13,7 @@ const CHECKSUM_PATTERN = /^[a-f0-9]{64}$/;
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
 const DEFAULT_PROVIDER_OUTPUT_ROOT = path.join(__dirname, "..", "data", "providers");
 const SOURCE_MANIFEST_FILE_NAME = "source-manifest.json";
-const SOURCE_MANIFEST_TYPE = "provider-source-fetch";
+const SOURCE_MANIFEST_TYPE = SOURCE_MANIFEST_TYPES.REMOTE_FETCH;
 const ALLOWED_VARIANTS = Object.freeze({
   "en-GB": Object.freeze({ dicPath: "en/en_GB.dic", affPath: "en/en_GB.aff" }),
   "en-US": Object.freeze({ dicPath: "en/en_US.dic", affPath: "en/en_US.aff" }),

--- a/lib/provider-hunspell.js
+++ b/lib/provider-hunspell.js
@@ -5,6 +5,7 @@ const nspell = require("nspell");
 const {
   MAX_WORD_LENGTH,
   MIN_WORD_LENGTH,
+  SOURCE_MANIFEST_TYPES,
   SUPPORTED_VARIANT_IDS,
   WORD_PATTERN,
   normalizeCommit: normalizeSharedCommit,
@@ -19,6 +20,7 @@ const fsp = fs.promises;
 
 const DEFAULT_PROVIDER_ROOT = path.join(__dirname, "..", "data", "providers");
 const SUPPORTED_VARIANTS = new Set(SUPPORTED_VARIANT_IDS);
+const SUPPORTED_SOURCE_MANIFEST_TYPES = new Set(Object.values(SOURCE_MANIFEST_TYPES));
 
 class ProviderHunspellError extends Error {
   constructor(code, message, options = {}) {
@@ -86,10 +88,10 @@ function validateSourceManifest(manifest, variant, commit) {
   if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
     throw new ProviderHunspellError("INVALID_MANIFEST", "source-manifest payload must be an object.");
   }
-  if (manifest.manifestType !== "provider-source-fetch") {
+  if (!SUPPORTED_SOURCE_MANIFEST_TYPES.has(String(manifest.manifestType || ""))) {
     throw new ProviderHunspellError(
       "INVALID_MANIFEST",
-      "source-manifest manifestType must be provider-source-fetch."
+      `source-manifest manifestType must be one of: ${Array.from(SUPPORTED_SOURCE_MANIFEST_TYPES).join(", ")}.`
     );
   }
   if (manifest.provider?.variant !== variant) {

--- a/lib/provider-manual-upload.js
+++ b/lib/provider-manual-upload.js
@@ -1,0 +1,335 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const nodeCrypto = require("node:crypto");
+
+const {
+  buildProviderDescriptor,
+  computeSha256,
+  normalizeCommit,
+  ProviderFetchError
+} = require("./provider-fetch");
+const { SOURCE_MANIFEST_TYPES } = require("./provider-artifact-shared");
+
+const fsp = fs.promises;
+
+const MANUAL_SOURCE_MANIFEST_TYPE = SOURCE_MANIFEST_TYPES.MANUAL_UPLOAD;
+const DEFAULT_PROVIDER_OUTPUT_ROOT = path.join(__dirname, "..", "data", "providers");
+const DEFAULT_MAX_MANUAL_FILE_BYTES = 8 * 1024 * 1024;
+const CHECKSUM_PATTERN = /^[a-f0-9]{64}$/;
+const SOURCE_MANIFEST_FILE_NAME = "source-manifest.json";
+
+class ProviderManualUploadError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = "ProviderManualUploadError";
+    this.code = code;
+    this.retriable = options.retriable === true;
+    if (options.cause) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+function normalizeExpectedChecksums(expectedChecksums) {
+  if (!expectedChecksums || typeof expectedChecksums !== "object" || Array.isArray(expectedChecksums)) {
+    throw new ProviderManualUploadError(
+      "CHECKSUM_REQUIRED",
+      "expectedChecksums.dic and expectedChecksums.aff are required for integrity verification."
+    );
+  }
+
+  const normalized = {
+    dic: String(expectedChecksums.dic || "").trim().toLowerCase(),
+    aff: String(expectedChecksums.aff || "").trim().toLowerCase()
+  };
+
+  if (!CHECKSUM_PATTERN.test(normalized.dic)) {
+    throw new ProviderManualUploadError(
+      "INVALID_CHECKSUM",
+      "expectedChecksums.dic must be a lowercase 64-character SHA-256 checksum."
+    );
+  }
+  if (!CHECKSUM_PATTERN.test(normalized.aff)) {
+    throw new ProviderManualUploadError(
+      "INVALID_CHECKSUM",
+      "expectedChecksums.aff must be a lowercase 64-character SHA-256 checksum."
+    );
+  }
+
+  return normalized;
+}
+
+function parseMaxManualFileBytes(value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return DEFAULT_MAX_MANUAL_FILE_BYTES;
+  }
+  return parsed;
+}
+
+function sanitizeFileName(value, fallback) {
+  const normalized = path.basename(String(value || "").trim());
+  if (!normalized) {
+    return fallback;
+  }
+  return normalized;
+}
+
+function decodeBase64File(value, fieldName) {
+  const raw = String(value || "").trim();
+  if (!raw) {
+    throw new ProviderManualUploadError(
+      "MANUAL_FILES_REQUIRED",
+      `${fieldName} is required for manual uploads.`
+    );
+  }
+
+  const normalized = raw.replace(/\s+/g, "");
+  if (!normalized || normalized.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)) {
+    throw new ProviderManualUploadError(
+      "INVALID_MANUAL_SOURCE",
+      `${fieldName} must be valid base64 data.`
+    );
+  }
+
+  let buffer;
+  try {
+    buffer = Buffer.from(normalized, "base64");
+  } catch (err) {
+    throw new ProviderManualUploadError(
+      "INVALID_MANUAL_SOURCE",
+      `${fieldName} must be valid base64 data.`,
+      { cause: err }
+    );
+  }
+
+  if (!buffer.length) {
+    throw new ProviderManualUploadError(
+      "INVALID_MANUAL_SOURCE",
+      `${fieldName} resolved to an empty file.`
+    );
+  }
+
+  return buffer;
+}
+
+function deriveSyntheticCommit(records) {
+  return nodeCrypto
+    .createHash("sha1")
+    .update(records.dic.sha256)
+    .update(":")
+    .update(records.aff.sha256)
+    .digest("hex");
+}
+
+function verifyChecksums(records, expectedChecksums) {
+  const mismatches = [];
+  ["dic", "aff"].forEach((kind) => {
+    if (records[kind].sha256 !== expectedChecksums[kind]) {
+      mismatches.push(
+        `${kind} expected=${expectedChecksums[kind]} actual=${records[kind].sha256}`
+      );
+    }
+  });
+
+  if (mismatches.length > 0) {
+    throw new ProviderManualUploadError(
+      "CHECKSUM_MISMATCH",
+      `Checksum verification failed: ${mismatches.join("; ")}`
+    );
+  }
+}
+
+async function writeManifestAtomic(filePath, payload) {
+  const tempPath = `${filePath}.${process.pid}.${nodeCrypto.randomUUID()}.tmp`;
+  try {
+    await fsp.writeFile(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    try {
+      await fsp.rename(tempPath, filePath);
+    } catch (err) {
+      if (!["EEXIST", "EPERM", "EACCES"].includes(String(err?.code || ""))) {
+        throw err;
+      }
+      await fsp.rm(filePath, { force: true });
+      await fsp.rename(tempPath, filePath);
+    }
+  } catch (err) {
+    await fsp.rm(tempPath, { force: true }).catch(() => {});
+    throw new ProviderManualUploadError(
+      "PERSISTENCE_WRITE_FAILED",
+      `Failed to persist source manifest to ${filePath}.`,
+      { cause: err }
+    );
+  }
+}
+
+async function persistManualProviderSource(options = {}) {
+  const expectedChecksums = normalizeExpectedChecksums(options.expectedChecksums);
+  const maxManualFileBytes = parseMaxManualFileBytes(options.maxManualFileBytes);
+
+  const manualFiles =
+    options.manualFiles && typeof options.manualFiles === "object" && !Array.isArray(options.manualFiles)
+      ? options.manualFiles
+      : null;
+  if (!manualFiles) {
+    throw new ProviderManualUploadError(
+      "MANUAL_FILES_REQUIRED",
+      "manualFiles.dicBase64 and manualFiles.affBase64 are required for manual uploads."
+    );
+  }
+
+  const dicBuffer = decodeBase64File(manualFiles.dicBase64, "manualFiles.dicBase64");
+  const affBuffer = decodeBase64File(manualFiles.affBase64, "manualFiles.affBase64");
+
+  if (dicBuffer.length > maxManualFileBytes) {
+    throw new ProviderManualUploadError(
+      "MANUAL_FILE_TOO_LARGE",
+      `manualFiles.dicBase64 exceeds the ${maxManualFileBytes} byte limit.`
+    );
+  }
+  if (affBuffer.length > maxManualFileBytes) {
+    throw new ProviderManualUploadError(
+      "MANUAL_FILE_TOO_LARGE",
+      `manualFiles.affBase64 exceeds the ${maxManualFileBytes} byte limit.`
+    );
+  }
+
+  const records = {
+    dic: {
+      sha256: computeSha256(dicBuffer),
+      byteSize: dicBuffer.length
+    },
+    aff: {
+      sha256: computeSha256(affBuffer),
+      byteSize: affBuffer.length
+    }
+  };
+  verifyChecksums(records, expectedChecksums);
+
+  let commit = String(options.commit || "").trim();
+  if (commit) {
+    try {
+      commit = normalizeCommit(commit);
+    } catch (err) {
+      if (err instanceof ProviderFetchError) {
+        throw new ProviderManualUploadError(err.code, err.message, { cause: err });
+      }
+      throw err;
+    }
+  } else {
+    commit = deriveSyntheticCommit(records);
+  }
+
+  let descriptor;
+  try {
+    descriptor = buildProviderDescriptor({ variant: options.variant, commit });
+  } catch (err) {
+    if (err instanceof ProviderFetchError) {
+      throw new ProviderManualUploadError(err.code, err.message, { cause: err });
+    }
+    throw err;
+  }
+
+  const outputRoot = options.outputRoot
+    ? path.resolve(options.outputRoot)
+    : DEFAULT_PROVIDER_OUTPUT_ROOT;
+  const variantRoot = path.join(outputRoot, descriptor.variant, descriptor.commit);
+
+  const dicFileName = path.basename(descriptor.dicPath);
+  const affFileName = path.basename(descriptor.affPath);
+  const dicUploadFileName = sanitizeFileName(manualFiles.dicFileName, dicFileName);
+  const affUploadFileName = sanitizeFileName(manualFiles.affFileName, affFileName);
+
+  await fsp.mkdir(variantRoot, { recursive: true });
+
+  const dicFilePath = path.join(variantRoot, dicFileName);
+  const affFilePath = path.join(variantRoot, affFileName);
+
+  try {
+    await Promise.all([
+      fsp.writeFile(dicFilePath, dicBuffer),
+      fsp.writeFile(affFilePath, affBuffer)
+    ]);
+  } catch (err) {
+    throw new ProviderManualUploadError(
+      "PERSISTENCE_WRITE_FAILED",
+      "Failed to persist uploaded provider source files.",
+      { cause: err }
+    );
+  }
+
+  const retrievedAt = new Date().toISOString();
+  const sourceFiles = {
+    dic: {
+      uploadFileName: dicUploadFileName,
+      localPath: path.posix.join(descriptor.variant, descriptor.commit, dicFileName)
+    },
+    aff: {
+      uploadFileName: affUploadFileName,
+      localPath: path.posix.join(descriptor.variant, descriptor.commit, affFileName)
+    }
+  };
+
+  const manifestPayload = {
+    schemaVersion: 1,
+    manifestType: MANUAL_SOURCE_MANIFEST_TYPE,
+    provider: {
+      providerId: descriptor.providerId,
+      variant: descriptor.variant,
+      repository: descriptor.repository,
+      commit: descriptor.commit,
+      dicPath: descriptor.dicPath,
+      affPath: descriptor.affPath
+    },
+    sourceFiles: {
+      dic: {
+        sourcePath: descriptor.dicPath,
+        localPath: sourceFiles.dic.localPath,
+        uploadFileName: sourceFiles.dic.uploadFileName,
+        sha256: records.dic.sha256,
+        byteSize: records.dic.byteSize
+      },
+      aff: {
+        sourcePath: descriptor.affPath,
+        localPath: sourceFiles.aff.localPath,
+        uploadFileName: sourceFiles.aff.uploadFileName,
+        sha256: records.aff.sha256,
+        byteSize: records.aff.byteSize
+      }
+    },
+    manualUpload: {
+      sourceType: "manual-upload",
+      commitProvided: Boolean(String(options.commit || "").trim())
+    },
+    retrievedAt
+  };
+
+  const manifestPath = path.join(variantRoot, SOURCE_MANIFEST_FILE_NAME);
+  await writeManifestAtomic(manifestPath, manifestPayload);
+
+  return {
+    descriptor,
+    retrievedAt,
+    sourceFiles: {
+      dic: {
+        path: dicFilePath,
+        sha256: records.dic.sha256,
+        byteSize: records.dic.byteSize,
+        uploadFileName: dicUploadFileName
+      },
+      aff: {
+        path: affFilePath,
+        sha256: records.aff.sha256,
+        byteSize: records.aff.byteSize,
+        uploadFileName: affUploadFileName
+      }
+    },
+    manifestPath
+  };
+}
+
+module.exports = {
+  MANUAL_SOURCE_MANIFEST_TYPE,
+  ProviderManualUploadError,
+  persistManualProviderSource
+};

--- a/lib/provider-pool-policy.js
+++ b/lib/provider-pool-policy.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const {
   MAX_WORD_LENGTH,
   MIN_WORD_LENGTH,
+  SOURCE_MANIFEST_TYPES,
   SUPPORTED_VARIANT_IDS,
   WORD_PATTERN,
   normalizeCommit: normalizeSharedCommit,
@@ -18,6 +19,7 @@ const fsp = fs.promises;
 
 const DEFAULT_PROVIDER_ROOT = path.join(__dirname, "..", "data", "providers");
 const SUPPORTED_VARIANTS = new Set(SUPPORTED_VARIANT_IDS);
+const SUPPORTED_SOURCE_MANIFEST_TYPES = new Set(Object.values(SOURCE_MANIFEST_TYPES));
 const DEFAULT_IRREGULAR_ALLOWLIST_FILE = "irregular-answer-allowlist.txt";
 
 class ProviderPoolPolicyError extends Error {
@@ -175,10 +177,10 @@ function validateSourceManifest(manifest, variant, commit) {
   if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
     throw new ProviderPoolPolicyError("INVALID_MANIFEST", "source-manifest payload must be an object.");
   }
-  if (manifest.manifestType !== "provider-source-fetch") {
+  if (!SUPPORTED_SOURCE_MANIFEST_TYPES.has(String(manifest.manifestType || ""))) {
     throw new ProviderPoolPolicyError(
       "INVALID_MANIFEST",
-      "source-manifest manifestType must be provider-source-fetch."
+      `source-manifest manifestType must be one of: ${Array.from(SUPPORTED_SOURCE_MANIFEST_TYPES).join(", ")}.`
     );
   }
   if (manifest.provider?.variant !== variant) {

--- a/public/admin/admin.css
+++ b/public/admin/admin.css
@@ -32,6 +32,11 @@
   gap: 0.8rem;
 }
 
+.admin-import-section {
+  display: grid;
+  gap: 0.6rem;
+}
+
 .admin-table-wrap {
   overflow-x: auto;
 }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -130,6 +130,12 @@
               and builds provider artifacts.
             </p>
             <form id="importForm" class="create-form" autocomplete="off">
+              <label for="importSourceType">Source</label>
+              <select id="importSourceType" name="sourceType">
+                <option value="remote-fetch">Remote fetch (default)</option>
+                <option value="manual-upload">Manual upload (.dic + .aff)</option>
+              </select>
+
               <label for="importVariant">Variant</label>
               <select id="importVariant" name="variant">
                 <option value="en-GB">English (UK)</option>
@@ -139,7 +145,7 @@
                 <option value="en-ZA">English (South Africa)</option>
               </select>
 
-              <label for="importCommit">Pinned commit (40-char SHA)</label>
+              <label for="importCommit">Commit (required for remote, optional for manual)</label>
               <input
                 id="importCommit"
                 name="commit"
@@ -151,29 +157,43 @@
                 maxlength="40"
               />
 
-              <label for="importChecksumDic">Dictionary checksum (SHA-256)</label>
-              <input
-                id="importChecksumDic"
-                name="checksumDic"
-                type="text"
-                inputmode="text"
-                spellcheck="false"
-                autocomplete="off"
-                placeholder="64-char lowercase sha256"
-                maxlength="64"
-              />
+              <div id="importRemoteFields" class="admin-import-section">
+                <label for="importChecksumDic">Dictionary checksum (SHA-256)</label>
+                <input
+                  id="importChecksumDic"
+                  name="checksumDic"
+                  type="text"
+                  inputmode="text"
+                  spellcheck="false"
+                  autocomplete="off"
+                  placeholder="64-char lowercase sha256"
+                  maxlength="64"
+                />
 
-              <label for="importChecksumAff">Affix checksum (SHA-256)</label>
-              <input
-                id="importChecksumAff"
-                name="checksumAff"
-                type="text"
-                inputmode="text"
-                spellcheck="false"
-                autocomplete="off"
-                placeholder="64-char lowercase sha256"
-                maxlength="64"
-              />
+                <label for="importChecksumAff">Affix checksum (SHA-256)</label>
+                <input
+                  id="importChecksumAff"
+                  name="checksumAff"
+                  type="text"
+                  inputmode="text"
+                  spellcheck="false"
+                  autocomplete="off"
+                  placeholder="64-char lowercase sha256"
+                  maxlength="64"
+                />
+              </div>
+
+              <div id="importManualFields" class="admin-import-section hidden">
+                <label for="importDicFile">Dictionary file (.dic)</label>
+                <input id="importDicFile" name="dicFile" type="file" accept=".dic,text/plain" />
+
+                <label for="importAffFile">Affix file (.aff)</label>
+                <input id="importAffFile" name="affFile" type="file" accept=".aff,text/plain" />
+
+                <p class="note">
+                  Checksums are generated in-browser from selected files before upload.
+                </p>
+              </div>
 
               <label for="importFilterMode">Family filter mode</label>
               <select id="importFilterMode" name="filterMode">

--- a/tests/provider-hunspell.test.js
+++ b/tests/provider-hunspell.test.js
@@ -32,7 +32,7 @@ function writeProviderSourceBundle(options = {}) {
 
   const sourceManifest = {
     schemaVersion: 1,
-    manifestType: "provider-source-fetch",
+    manifestType: options.manifestType || "provider-source-fetch",
     provider: {
       providerId: PROVIDER_ID,
       variant,
@@ -115,6 +115,23 @@ describe("provider-hunspell", () => {
       expect(rerunWords).toEqual(words);
       const rerunProcessed = fs.readFileSync(rerun.processedPath, "utf8");
       expect(rerunProcessed).toEqual(fs.readFileSync(result.processedPath, "utf8"));
+    } finally {
+      fs.rmSync(setup.providerRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts manual-upload source manifest type", async () => {
+    const setup = writeProviderSourceBundle({
+      manifestType: "provider-source-manual-upload"
+    });
+    try {
+      const result = await buildExpandedFormsArtifacts({
+        variant: setup.variant,
+        commit: setup.commit,
+        providerRoot: setup.providerRoot,
+        policyVersion: "v1"
+      });
+      expect(fs.existsSync(result.expandedFormsPath)).toBe(true);
     } finally {
       fs.rmSync(setup.providerRoot, { recursive: true, force: true });
     }

--- a/tests/provider-manual-upload.test.js
+++ b/tests/provider-manual-upload.test.js
@@ -1,0 +1,175 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { computeSha256 } = require("../lib/provider-fetch");
+const {
+  MANUAL_SOURCE_MANIFEST_TYPE,
+  persistManualProviderSource
+} = require("../lib/provider-manual-upload");
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "lhw-provider-manual-"));
+}
+
+function toBase64(text) {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
+describe("provider-manual-upload", () => {
+  test("persists manual source files with explicit commit and checksums", async () => {
+    const outputRoot = createTempDir();
+    const commit = "0123456789abcdef0123456789abcdef01234567";
+    const dicText = "2\nDOG/S\nCAT\n";
+    const affText = "SET UTF-8\nSFX S Y 1\nSFX S 0 S .\n";
+
+    try {
+      const result = await persistManualProviderSource({
+        variant: "en-US",
+        commit,
+        expectedChecksums: {
+          dic: computeSha256(Buffer.from(dicText, "utf8")),
+          aff: computeSha256(Buffer.from(affText, "utf8"))
+        },
+        manualFiles: {
+          dicBase64: toBase64(dicText),
+          affBase64: toBase64(affText),
+          dicFileName: "manual-en_US.dic",
+          affFileName: "manual-en_US.aff"
+        },
+        outputRoot
+      });
+
+      expect(result.descriptor.commit).toBe(commit);
+      expect(fs.existsSync(result.sourceFiles.dic.path)).toBe(true);
+      expect(fs.existsSync(result.sourceFiles.aff.path)).toBe(true);
+
+      const manifest = JSON.parse(fs.readFileSync(result.manifestPath, "utf8"));
+      expect(manifest.manifestType).toBe(MANUAL_SOURCE_MANIFEST_TYPE);
+      expect(manifest.provider.variant).toBe("en-US");
+      expect(manifest.provider.commit).toBe(commit);
+      expect(manifest.manualUpload.commitProvided).toBe(true);
+      expect(manifest.sourceFiles.dic.uploadFileName).toBe("manual-en_US.dic");
+      expect(manifest.sourceFiles.aff.uploadFileName).toBe("manual-en_US.aff");
+    } finally {
+      fs.rmSync(outputRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("derives deterministic synthetic commit when commit is omitted", async () => {
+    const outputRoot = createTempDir();
+    const dicText = "1\nVAULT\n";
+    const affText = "SET UTF-8\n";
+
+    try {
+      const resultA = await persistManualProviderSource({
+        variant: "en-GB",
+        expectedChecksums: {
+          dic: computeSha256(Buffer.from(dicText, "utf8")),
+          aff: computeSha256(Buffer.from(affText, "utf8"))
+        },
+        manualFiles: {
+          dicBase64: toBase64(dicText),
+          affBase64: toBase64(affText)
+        },
+        outputRoot
+      });
+
+      const resultB = await persistManualProviderSource({
+        variant: "en-GB",
+        expectedChecksums: {
+          dic: computeSha256(Buffer.from(dicText, "utf8")),
+          aff: computeSha256(Buffer.from(affText, "utf8"))
+        },
+        manualFiles: {
+          dicBase64: toBase64(dicText),
+          affBase64: toBase64(affText)
+        },
+        outputRoot
+      });
+
+      expect(resultA.descriptor.commit).toMatch(/^[a-f0-9]{40}$/);
+      expect(resultA.descriptor.commit).toBe(resultB.descriptor.commit);
+
+      const manifest = JSON.parse(fs.readFileSync(resultA.manifestPath, "utf8"));
+      expect(manifest.manualUpload.commitProvided).toBe(false);
+      expect(manifest.provider.commit).toBe(resultA.descriptor.commit);
+    } finally {
+      fs.rmSync(outputRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when manual files payload is missing", async () => {
+    await expect(
+      persistManualProviderSource({
+        variant: "en-US",
+        commit: "0123456789abcdef0123456789abcdef01234567",
+        expectedChecksums: {
+          dic: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          aff: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+      })
+    ).rejects.toMatchObject({
+      code: "MANUAL_FILES_REQUIRED"
+    });
+  });
+
+  test("fails closed when checksum verification fails", async () => {
+    await expect(
+      persistManualProviderSource({
+        variant: "en-CA",
+        commit: "0123456789abcdef0123456789abcdef01234567",
+        expectedChecksums: {
+          dic: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          aff: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        manualFiles: {
+          dicBase64: toBase64("1\nDOG\n"),
+          affBase64: toBase64("SET UTF-8\n")
+        }
+      })
+    ).rejects.toMatchObject({
+      code: "CHECKSUM_MISMATCH"
+    });
+  });
+
+  test("rejects manual files above max size limit", async () => {
+    const largePayload = Buffer.alloc(1024 * 1024 + 1, 65).toString("base64");
+
+    await expect(
+      persistManualProviderSource({
+        variant: "en-AU",
+        commit: "0123456789abcdef0123456789abcdef01234567",
+        expectedChecksums: {
+          dic: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          aff: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        manualFiles: {
+          dicBase64: largePayload,
+          affBase64: toBase64("SET UTF-8\n")
+        },
+        maxManualFileBytes: 1024 * 1024
+      })
+    ).rejects.toMatchObject({
+      code: "MANUAL_FILE_TOO_LARGE"
+    });
+
+    await expect(
+      persistManualProviderSource({
+        variant: "en-AU",
+        commit: "0123456789abcdef0123456789abcdef01234567",
+        expectedChecksums: {
+          dic: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          aff: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        manualFiles: {
+          dicBase64: toBase64("1\nDOG\n"),
+          affBase64: largePayload
+        },
+        maxManualFileBytes: 1024 * 1024
+      })
+    ).rejects.toMatchObject({
+      code: "MANUAL_FILE_TOO_LARGE"
+    });
+  });
+});

--- a/tests/ui/create-play.spec.js
+++ b/tests/ui/create-play.spec.js
@@ -39,6 +39,8 @@ test("random word generates link", async ({ page }) => {
 test("play puzzle from encoded link", async ({ page }) => {
   await page.goto("/?word=yfrqp&lang=en", gotoOptions);
   await page.waitForSelector("#board");
+  // Firefox can leave focus on non-game chrome after initial navigation; click board to bind keystrokes.
+  await page.click("#board");
   await page.keyboard.type("CRANE");
   await page.keyboard.press("Enter");
   await expect(page.locator("#message")).toContainText("Solved in 1/6");


### PR DESCRIPTION
## Summary
- add manual upload fallback for provider imports via `sourceType=manual-upload`
- keep the same integrity guarantees as remote imports (required checksums + fail-closed verification)
- persist manual source manifests with explicit provenance and optional synthetic commit derivation
- extend admin UI import flow with source-mode toggle and `.dic/.aff` file selection
- harden request limits for large admin import payloads (`JSON_BODY_LIMIT`, `PROVIDER_MANUAL_MAX_FILE_BYTES`)
- update provider pipeline modules to accept both remote and manual source manifest types
- add nit guardrails + preflight rule for manual upload integrity parity

## Why
Offline or restricted-network deployments need a non-network import path while preserving existing provider pipeline guarantees.

## Validation
- `npm run check`
- `npm run test:provider:ui`
- `npm run test:all`

## Issue
- Refs #25
