### PR TITLE
[codex] Fix UI CI flakiness across browsers

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -19,7 +19,8 @@ module.exports = defineConfig({
   workers: process.env.CI ? 1 : 2,
   use: {
     baseURL: "http://localhost:3000",
-    headless: true
+    headless: true,
+    serviceWorkers: "block"
   },
   projects: browsers.map((browserName) => ({
     name: browserName,

--- a/public/styles.css
+++ b/public/styles.css
@@ -202,6 +202,8 @@ p {
 }
 
 .admin-link {
+  display: inline-flex;
+  align-items: center;
   color: var(--text);
   text-decoration: none;
   border: 1px solid var(--chip-border);
@@ -555,7 +557,7 @@ body.high-contrast .tile.absent {
   font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
-  min-width: var(--touch-target-min);
+  min-width: 2rem;
   min-height: max(var(--touch-target-min), clamp(2.4rem, 7vw, 3.2rem));
   transition: transform 0.1s ease, background 0.15s ease;
   touch-action: manipulation;

--- a/public/styles.css
+++ b/public/styles.css
@@ -33,6 +33,7 @@
   --modal-border: rgba(148, 163, 184, 0.2);
   --modal-shadow: rgba(2, 6, 23, 0.6);
   --focus-outline: var(--accent);
+  --touch-target-min: 44.25px;
   color-scheme: dark;
 }
 
@@ -204,6 +205,7 @@ p {
   color: var(--text);
   text-decoration: none;
   border: 1px solid var(--chip-border);
+  min-height: var(--touch-target-min);
   padding: 0.6rem 1.2rem;
   border-radius: 999px;
   transition: transform 0.15s ease, border-color 0.15s ease, color 0.15s ease;
@@ -553,8 +555,8 @@ body.high-contrast .tile.absent {
   font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
-  min-width: 2rem;
-  min-height: clamp(2.4rem, 7vw, 3.2rem);
+  min-width: var(--touch-target-min);
+  min-height: max(var(--touch-target-min), clamp(2.4rem, 7vw, 3.2rem));
   transition: transform 0.1s ease, background 0.15s ease;
   touch-action: manipulation;
 }
@@ -640,6 +642,7 @@ body.high-contrast .key.absent {
   background: transparent;
   color: var(--text);
   font-size: 0.9rem;
+  min-height: var(--touch-target-min);
   padding: 0.45rem 0.9rem;
   border-radius: 999px;
   cursor: pointer;

--- a/tests/ui/create-play.spec.js
+++ b/tests/ui/create-play.spec.js
@@ -53,6 +53,7 @@ test("shows local meaning when english puzzle is solved", async ({ page }) => {
   await page.fill("#wordInput", "CRANE");
   await page.click("form#createForm button[type=submit]");
   await page.waitForSelector("#playPanel:not(.hidden)");
+  await page.click("#board");
   await page.keyboard.type("CRANE");
   await page.keyboard.press("Enter");
   await expect(page.locator("#message")).toContainText("Solved in 1/6!");
@@ -157,6 +158,7 @@ test("theme selector persists explicit light and dark preferences", async ({ pag
   await expect(page.locator("html")).toHaveClass(/theme-light/);
 
   await page.reload(gotoOptions);
+  await waitForLanguages(page);
   await expect(page.locator("#themeSelect")).toHaveValue("light");
   await expect(page.locator("html")).toHaveClass(/theme-light/);
 

--- a/tests/ui/create-play.spec.js
+++ b/tests/ui/create-play.spec.js
@@ -67,6 +67,7 @@ test("reveals a local meaning after final failed guess", async ({ page }) => {
   await page.fill("#wordInput", "CRANE");
   await page.click("form#createForm button[type=submit]");
   await page.waitForSelector("#playPanel:not(.hidden)");
+  await page.click("#board");
 
   const failedGuesses = ["SLATE", "CRATE", "STONE", "TRAIL", "ABATE", "ADORE"];
   for (let i = 0; i < failedGuesses.length; i += 1) {
@@ -88,6 +89,7 @@ test("daily mode requires a player name and updates leaderboard stats", async ({
   await page.goto(`/?word=yfrqp&lang=en&daily=1&day=${todayLocalDate()}`, gotoOptions);
   await page.waitForSelector("#playPanel:not(.hidden)");
   await expect(page.locator("#profilePanel")).toBeVisible();
+  await page.click("#board");
 
   await page.keyboard.type("CRANE");
   await page.keyboard.press("Enter");
@@ -117,6 +119,7 @@ test("strict mode enforces revealed hints", async ({ page }) => {
   await page.waitForSelector("#playPanel:not(.hidden)");
   await expect(page.locator("#updated")).toContainText("Game ready");
   await page.check("#strictToggle");
+  await page.click("#board");
   await page.keyboard.type("CRATE");
   await page.keyboard.press("Enter");
   await expect(
@@ -138,6 +141,7 @@ test("strict mode requires repeated letters when revealed", async ({ page }) => 
   await page.waitForSelector("#playPanel:not(.hidden)");
   await expect(page.locator("#updated")).toContainText("Game ready");
   await page.check("#strictToggle");
+  await page.click("#board");
   await page.keyboard.type("ALLOT");
   await page.keyboard.press("Enter");
   await expect(page.locator("#board .row:nth-child(1) .tile.present")).toHaveCount(2);


### PR DESCRIPTION
## Summary
This PR fixes the cross-browser UI test failures that were keeping CI red.

The failures came from three separate sources:
- Playwright route mocks in the admin UI tests were being bypassed by the service worker cache/interceptor layer, so those tests sometimes hit the real provider import paths instead of the mocked API responses.
- Firefox was measuring some interactive controls at `43.999...px`, which caused the 44x44 touch target checks to fail even though the intended contract was 44px minimum.
- A Firefox keyboard-focus race in the solved-word flow could leave the board unfocused after entering play mode, causing the first solve attempt to produce `Not enough letters.` instead of submitting the guess.

## Fix
The branch makes three focused changes:
- Block service workers in Playwright so UI tests always exercise the mocked network layer deterministically.
- Raise the shared minimum touch target slightly above the 44px threshold in the app stylesheet so Firefox subpixel rounding does not trip the accessibility assertions.
- Make the solved-word meaning test explicitly focus the board before typing, and wait for app initialization after reload before checking persisted theme state.

## Validation
- `npm ci`
- `UI_COVERAGE=1 npx playwright test --config=.playwright-ci-pr.config.js`

That verification passed cleanly on this branch:
- `114 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Established globally consistent minimum touch target sizing standards for interactive UI elements, improving accessibility on touch devices

* **Tests**
  * Strengthened test reliability by fixing interaction timing and data initialization sequences to ensure stable application functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->