### PR TITLE
feat(admin): show restart-required settings as read-only in Runtime tab

### DIFF
--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -37,6 +37,7 @@ const runtimePerfLoggingEl = document.getElementById("runtimePerfLogging");
 const resetRuntimeBtnEl = document.getElementById("resetRuntimeBtn");
 const runtimeStatusEl = document.getElementById("runtimeStatus");
 const runtimeSourcesBodyEl = document.getElementById("runtimeSourcesBody");
+const runtimeLockedBodyEl = document.getElementById("runtimeLockedBody");
 
 const tabButtons = Array.from(document.querySelectorAll(".admin-tab"));
 const tabPanels = Array.from(document.querySelectorAll(".admin-slot"));
@@ -464,6 +465,48 @@ function renderRuntimeSources() {
   runtimeSourcesBodyEl.appendChild(fragment);
 }
 
+function renderLockedSettings() {
+  if (!runtimeLockedBodyEl) {
+    return;
+  }
+  runtimeLockedBodyEl.innerHTML = "";
+
+  const runtime = state.runtimeConfig;
+  if (!runtime || typeof runtime !== "object") {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 2;
+    cell.textContent = "Runtime config is not loaded yet.";
+    row.appendChild(cell);
+    runtimeLockedBodyEl.appendChild(row);
+    return;
+  }
+
+  const sec = runtime.effective?.security || {};
+  const srv = runtime.effective?.server || {};
+  const rows = [
+    { key: "security.trustProxy", value: sec.trustProxy },
+    { key: "security.trustProxyHops", value: sec.trustProxyHops },
+    { key: "security.requireAdminKey", value: sec.requireAdminKey },
+    { key: "server.jsonBodyLimit", value: srv.jsonBodyLimit },
+    { key: "server.rateLimitWindowMs", value: srv.rateLimitWindowMs },
+    { key: "server.rateLimitMax", value: srv.rateLimitMax },
+    { key: "server.adminRateLimitWindowMs", value: srv.adminRateLimitWindowMs },
+    { key: "server.adminRateLimitMax", value: srv.adminRateLimitMax },
+    { key: "server.adminWriteRateLimitWindowMs", value: srv.adminWriteRateLimitWindowMs },
+    { key: "server.adminWriteRateLimitMax", value: srv.adminWriteRateLimitMax }
+  ];
+
+  const fragment = document.createDocumentFragment();
+  rows.forEach((entry) => {
+    const row = document.createElement("tr");
+    appendCell(row, entry.key);
+    appendCell(row, entry.value ?? "-");
+    fragment.appendChild(row);
+  });
+  runtimeLockedBodyEl.appendChild(fragment);
+}
+
 function populateRuntimeFormFromState() {
   const runtime = state.runtimeConfig;
   if (!runtime) {
@@ -525,6 +568,7 @@ function renderWorkspace() {
   renderProviders();
   renderJobs();
   renderRuntimeSources();
+  renderLockedSettings();
 }
 
 function scheduleQueueRefresh() {

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -310,6 +310,19 @@
                 <tbody id="runtimeSourcesBody"></tbody>
               </table>
             </div>
+            <h4>Restart-required settings (read-only)</h4>
+            <p class="note">These values are set via environment variables and cannot be changed without a server restart.</p>
+            <div class="admin-table-wrap">
+              <table class="leaderboard-table" aria-label="Restart-required settings table">
+                <thead>
+                  <tr>
+                    <th>Setting</th>
+                    <th>Effective value</th>
+                  </tr>
+                </thead>
+                <tbody id="runtimeLockedBody"></tbody>
+              </table>
+            </div>
           </section>
 
           <div id="workspaceStatus" class="message" role="status" aria-live="polite"></div>

--- a/tests/ui/admin-shell.spec.js
+++ b/tests/ui/admin-shell.spec.js
@@ -422,6 +422,65 @@ test("admin shell saves runtime overrides and renders source metadata", async ({
   await expect(page.locator("#runtimeSourcesBody")).toContainText("override");
 });
 
+test("admin shell shows restart-required settings as read-only", async ({ page }) => {
+  const providerState = { imported: false, enabled: false, commit: "" };
+  const runtimeConfig = {
+    ok: true,
+    effective: {
+      definitions: { mode: "memory", cacheSize: 512, cacheTtlMs: 1800000, shardCacheSize: 6 },
+      limits: { providerManualMaxFileBytes: 8388608 },
+      diagnostics: { perfLogging: false },
+      security: { trustProxy: false, trustProxyHops: 1, requireAdminKey: true },
+      server: {
+        jsonBodyLimit: "1mb",
+        rateLimitWindowMs: 60000,
+        rateLimitMax: 100,
+        adminRateLimitWindowMs: 60000,
+        adminRateLimitMax: 20,
+        adminWriteRateLimitWindowMs: 60000,
+        adminWriteRateLimitMax: 10
+      }
+    },
+    overrides: {},
+    sources: {
+      definitions: { mode: "default", cacheSize: "default", cacheTtlMs: "default", shardCacheSize: "default" },
+      limits: { providerManualMaxFileBytes: "default" },
+      diagnostics: { perfLogging: "default" }
+    },
+    editable: {
+      definitions: { modeOptions: ["memory", "lazy", "indexed"], cacheSize: { min: 1, max: 4096 }, cacheTtlMs: { min: 1000, max: 86400000 }, shardCacheSize: { min: 1, max: 26 } },
+      limits: { providerManualMaxFileBytes: { min: 1048576, max: 33554432 } },
+      diagnostics: { perfLogging: true }
+    }
+  };
+
+  await page.route("**/api/admin/providers", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, providers: createProviderRows(providerState) }) })
+  );
+  await page.route("**/api/admin/jobs?limit=30", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, queue: { active: false, queued: 0, running: 0, succeeded: 0, failed: 0, canceled: 0 }, jobs: [] }) })
+  );
+  await page.route("**/api/admin/runtime-config", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(runtimeConfig) })
+  );
+
+  await page.goto("/admin", { waitUntil: "commit" });
+  await page.fill("#adminKeyInput", "demo-key");
+  await page.click("#unlockForm button[type=submit]");
+  await expect(page.locator("#shellPanel")).toBeVisible();
+
+  await page.click("#admin-tab-runtime");
+
+  const lockedTable = page.locator("#runtimeLockedBody");
+  await expect(lockedTable).toContainText("security.trustProxy");
+  await expect(lockedTable).toContainText("security.requireAdminKey");
+  await expect(lockedTable).toContainText("server.jsonBodyLimit");
+  await expect(lockedTable).toContainText("server.rateLimitMax");
+
+  await expect(page.locator("#runtimeForm input")).not.toBeDisabled();
+  await expect(page.locator("#runtimeLockedBody input")).toHaveCount(0);
+});
+
 test("admin shell shows queued imports in import queue panel", async ({ page }) => {
   const state = {
     imported: false,

--- a/tests/ui/admin-shell.spec.js
+++ b/tests/ui/admin-shell.spec.js
@@ -477,7 +477,7 @@ test("admin shell shows restart-required settings as read-only", async ({ page }
   await expect(lockedTable).toContainText("server.jsonBodyLimit");
   await expect(lockedTable).toContainText("server.rateLimitMax");
 
-  await expect(page.locator("#runtimeForm input")).not.toBeDisabled();
+  await expect(page.locator("#runtimeDefinitionsMode")).not.toBeDisabled();
   await expect(page.locator("#runtimeLockedBody input")).toHaveCount(0);
 });
 


### PR DESCRIPTION
Closes #13

## Summary
- Adds a read-only "Restart-required settings" table at the bottom of the Runtime Settings tab in the admin UI, populated from `effective.security.*` and `effective.server.*` returned by `GET /api/admin/runtime-config`
- All 10 env-controlled values (trust proxy, rate limits, body limit, admin key requirement) are visible but no inputs exist — operators can see current values without being able to change them in-browser
- Adds `renderLockedSettings()` in `app.js` and wires it into `renderWorkspace()` alongside the existing `renderRuntimeSources()` call

## Why only this change?
The rest of issue #13's acceptance criteria — editable runtime settings form, source metadata table, form submit/reset handlers, dynamic bounds from `editable` ranges — were already fully implemented in the async provider queue PR (#77). The only gap was the "restart-required settings visible but not mutable" criterion.

## Test plan
- [x] Jest suite passes (215 tests)
- [x] New Playwright test: `admin shell shows restart-required settings as read-only` — asserts `#runtimeLockedBody` contains expected setting keys and contains zero `<input>` elements
- [x] Lint clean, schema check clean, guardrails clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)