### PR TITLE
feat(admin): data backup, export, and restore with atomic apply (#87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ If you want admin controls or are hosting behind a VPN/proxy, see `advanced-sett
 - Import uses `denylist-only` (default) or `allowlist-required` family filter modes.
 - Admin platform architecture contracts (schemas, config precedence, queue semantics): `docs/admin-platform-architecture-contract.md`.
 - Runtime settings tab edits only hot-refresh-safe overrides (`data/app-config.json`); env-defined security/infrastructure values remain read-only.
+- Data tab: download a versioned, schema-checked backup archive and restore it atomically. Operator runbook: `docs/backup-restore.md`.
 
 ## Daily Word (API)
 Daily word endpoints remain available:

--- a/data/backup-manifest.example.json
+++ b/data/backup-manifest.example.json
@@ -1,0 +1,26 @@
+{
+  "manifestVersion": 1,
+  "appVersion": "1.0.0",
+  "createdAt": "2026-05-07T12:00:00.000Z",
+  "nodeId": "example-node",
+  "files": [
+    {
+      "path": "data/leaderboard.json",
+      "bytes": 256,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "schema": {
+        "schemaPath": "data/leaderboard.schema.json",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    {
+      "path": "data/providers/en-US/abc123/en_US.dic",
+      "bytes": 1024,
+      "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "optionalSet": "providers"
+    }
+  ],
+  "optionalSets": [
+    "providers"
+  ]
+}

--- a/data/backup-manifest.schema.json
+++ b/data/backup-manifest.schema.json
@@ -15,7 +15,7 @@
   "properties": {
     "manifestVersion": {
       "type": "integer",
-      "const": 1
+      "minimum": 1
     },
     "appVersion": {
       "type": "string",

--- a/data/backup-manifest.schema.json
+++ b/data/backup-manifest.schema.json
@@ -65,7 +65,8 @@
         "schemaPath": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 256
+          "maxLength": 256,
+          "pattern": "^(?!.*\\.\\.)[A-Za-z0-9][A-Za-z0-9._/-]*$"
         },
         "sha256": {
           "$ref": "#/$defs/sha256Hex"

--- a/data/backup-manifest.schema.json
+++ b/data/backup-manifest.schema.json
@@ -15,7 +15,7 @@
   "properties": {
     "manifestVersion": {
       "type": "integer",
-      "minimum": 1
+      "const": 1
     },
     "appVersion": {
       "type": "string",

--- a/data/backup-manifest.schema.json
+++ b/data/backup-manifest.schema.json
@@ -85,7 +85,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 512,
-          "pattern": "^[A-Za-z0-9._/-]+$"
+          "pattern": "^(?!.*\\.\\.)[A-Za-z0-9][A-Za-z0-9._/-]*$"
         },
         "bytes": {
           "type": "integer",

--- a/data/backup-manifest.schema.json
+++ b/data/backup-manifest.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://local-hosted-wordle.dev/schemas/backup-manifest.schema.json",
+  "title": "Backup Archive Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "manifestVersion",
+    "appVersion",
+    "createdAt",
+    "nodeId",
+    "files",
+    "optionalSets"
+  ],
+  "properties": {
+    "manifestVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "appVersion": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "nodeId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/fileEntry"
+      }
+    },
+    "optionalSets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "providers",
+          "dictionaries"
+        ]
+      },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "sha256Hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "schemaDigest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaPath",
+        "sha256"
+      ],
+      "properties": {
+        "schemaPath": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256Hex"
+        }
+      }
+    },
+    "fileEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "bytes",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "pattern": "^[A-Za-z0-9._/-]+$"
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256Hex"
+        },
+        "schema": {
+          "$ref": "#/$defs/schemaDigest"
+        },
+        "optionalSet": {
+          "type": "string",
+          "enum": [
+            "providers",
+            "dictionaries"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/admin-platform-architecture-contract.md
+++ b/docs/admin-platform-architecture-contract.md
@@ -31,10 +31,15 @@ Out of scope:
 | `data/admin-jobs.json` | Persisted queue/job ledger for admin processing (deferred implementation) | Contract locked, runtime deferred | `data/admin-jobs.schema.json` |
 | `data/app-config.json` | Persisted runtime-safe override layer for admin settings (deferred implementation) | Contract locked, runtime deferred | `data/app-config.schema.json` |
 | `data/classes.json` | Classroom-mode classes (named containers of profile IDs) | Active | `data/classes.schema.json` |
+| Backup archives (`*.zip`) | Versioned, schema-checked snapshot of the in-scope data files | Active | `data/backup-manifest.schema.json` |
 
 Examples are provided for tooling validation:
 - `data/admin-jobs.example.json`
 - `data/app-config.example.json`
+- `data/backup-manifest.example.json`
+
+Backup/restore semantics: see [`docs/backup-restore.md`](backup-restore.md). The
+restore handler shares the single-flight admin mutex with provider import.
 
 ## Runtime Config Precedence (Locked)
 Order of precedence is deterministic:

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -108,10 +108,14 @@ mid-apply triggers a reverse rename from the rollback dir.
 
 Restore returns:
 
-- HTTP **200** with `{ ok: true, restored, filesRestored,
-  rolledBackOnError: false, warnings, reloads }` when every in-scope
-  file was swapped into place. `warnings` may contain non-fatal
-  reload notes (e.g. a single store's reload threw).
+- HTTP **200** with `{ ok: true, restored, removed, filesRestored,
+  rolledBackOnError: false, reloads, warnings }` when every in-scope
+  file was swapped into place. Per-store cache reload outcomes are
+  in `reloads` (an array of `{ name, ok, error? }` entries) — that's
+  where to look when a single store's reload throws after a
+  successful apply. `warnings` only carries archive/apply-time
+  warnings (e.g. `ROLLBACK_PARTIAL`); a successful apply normally
+  has an empty `warnings` array.
 - HTTP **400** for pre-apply validation failures (manifest invalid,
   manifest version unsupported, schema drift, malformed zip, sha256
   mismatch, path traversal). The body has

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -104,11 +104,26 @@ apply UI flow never collides with itself.
 
 Every in-scope file is byte-copied via the staging dir, validated
 against its schema, then atomically renamed into place. A failure
-mid-apply triggers a reverse rename from the rollback dir — operators
-see HTTP 200 with `partialFailure` info only when the leaderboard
-mutate succeeds but a non-fatal cleanup step fails. A genuine
-mid-write failure aborts with `rolledBackOnError: true` and leaves the
-live tree unchanged.
+mid-apply triggers a reverse rename from the rollback dir.
+
+Restore returns:
+
+- HTTP **200** with `{ ok: true, restored, filesRestored,
+  rolledBackOnError: false, warnings, reloads }` when every in-scope
+  file was swapped into place. `warnings` may contain non-fatal
+  reload notes (e.g. a single store's reload threw).
+- HTTP **400** for pre-apply validation failures (manifest invalid,
+  manifest version unsupported, schema drift, malformed zip, sha256
+  mismatch, path traversal). The body has
+  `rolledBackOnError: false` because no on-disk mutation happened.
+- HTTP **400** with `rolledBackOnError: true` for failures that
+  occurred after at least one file had been swapped — the rewind
+  ran and the live tree is byte-equal to its pre-restore state.
+  `warnings` may include `ROLLBACK_PARTIAL` notes when a rewind step
+  itself failed (rare; operator action required).
+- HTTP **409** when another admin operation (provider import or a
+  concurrent restore) holds the single-flight mutex.
+- HTTP **413** when the upload exceeds `BACKUP_MAX_BYTES`.
 
 ## Mutex with provider import
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -128,6 +128,13 @@ Restore returns:
 - HTTP **409** when another admin operation (provider import or a
   concurrent restore) holds the single-flight mutex.
 - HTTP **413** when the upload exceeds `BACKUP_MAX_BYTES`.
+- HTTP **503** with `code: DATA_LOCK_HELD` for *other* mutating
+  `/api/*` requests (jobs, runtime-config, profiles, classes,
+  `/api/word`, etc.) while an export stream or restore apply holds
+  the data lock. The `Retry-After` header is set to 5. Backup,
+  preview, and restore endpoints are exempt — they're the operations
+  the lock is protecting — so an operator can still preview an
+  archive even while one is being applied or exported.
 
 ## Mutex with provider import
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -70,7 +70,7 @@ apply UI flow never collides with itself.
 
 | Method | Path | Backup-rate-limited | Notes |
 | --- | --- | --- | --- |
-| `GET` | `/api/admin/backup` | Yes | Streams the archive. Query: `includeProviders=true|false`, `includeDictionaries=true|false`. |
+| `GET` | `/api/admin/backup` | Yes | Streams the archive. Query: `includeProviders=true\|false`, `includeDictionaries=true\|false`. |
 | `POST` | `/api/admin/backup/preview` | No | Validates an uploaded archive without applying. Returns `{ manifestVersion, appVersion, createdAt, nodeId, files, totalBytes }`. |
 | `POST` | `/api/admin/restore` | Yes | Applies atomically. Requires the header `x-admin-confirm: I-UNDERSTAND` plus a multipart `archive` field. |
 
@@ -202,9 +202,32 @@ The archive is plaintext. `data/leaderboard.json` and
 `data/classes.json` contain profile names and per-game timing. Treat
 backups as sensitive; encrypt at rest if you are sharing them off-host.
 
+## Configured data paths
+
+The backup/restore implementation reads and writes files at their
+canonical paths under `<projectRoot>/data/` (e.g.
+`<projectRoot>/data/leaderboard.json`). If a deployment redirects an
+individual store via env (`STATS_STORE_PATH`, `CLASSES_STORE_PATH`,
+`ADMIN_JOBS_STORE_PATH`, `APP_CONFIG_PATH`) the live store reads from
+the configured path but backup/restore still operates on the
+canonical location. Operators using non-default paths must either:
+
+- Symlink the configured paths into `<projectRoot>/data/` so backup
+  and the live store agree, or
+- Set `BACKUP_PROJECT_ROOT` to the directory whose `data/` subtree
+  contains the configured files (test-style isolation), or
+- Skip backup/restore entirely for that store and reconcile it
+  manually.
+
+A future revision can route backup through the same path-resolution
+logic the stores use; tracked separately.
+
 ## What's NOT in v1
 
 - Selective per-file restore (all-or-nothing only)
 - Cross-host migration (archives are local to a single node)
 - Encryption / password protection
 - Continuous backups, retention policies
+- Backup with non-default `STATS_STORE_PATH` /
+  `CLASSES_STORE_PATH` / `ADMIN_JOBS_STORE_PATH` /
+  `APP_CONFIG_PATH` (see *Configured data paths* above)

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -221,10 +221,13 @@ canonical paths under `<projectRoot>/data/` (e.g.
 individual store via env (`STATS_STORE_PATH`, `CLASSES_STORE_PATH`,
 `ADMIN_JOBS_STORE_PATH`, `APP_CONFIG_PATH`) the live store reads from
 the configured path but backup/restore still operates on the
-canonical location. Operators using non-default paths must either:
+canonical location. Symlinks are NOT a workaround — both the backup
+build and restore-time schema check call `assertRegularFile` on
+in-scope paths and reject symlinks/non-regular files with
+`PATH_UNSAFE`. Operators using non-default paths must either:
 
-- Symlink the configured paths into `<projectRoot>/data/` so backup
-  and the live store agree, or
+- Copy or hard-link the configured paths to `<projectRoot>/data/`
+  before each backup so both sides see the same regular file, or
 - Set `BACKUP_PROJECT_ROOT` to the directory whose `data/` subtree
   contains the configured files (test-style isolation), or
 - Skip backup/restore entirely for that store and reconcile it

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,192 @@
+# Backup & Restore
+
+Operator runbook for the admin Data tab.
+
+## What gets backed up
+
+The archive is a single `.zip` with a `manifest.json` at the root and
+the following files, all at their canonical paths under the project
+root:
+
+**Always included** (in-scope, restored on apply):
+
+- `data/leaderboard.json`
+- `data/languages.json`
+- `data/admin-jobs.json`
+- `data/app-config.json`
+- `data/classes.json`
+- `data/word.json`
+
+**Diagnostic-only** (read-only, included for cross-version diagnostics
+but never restored):
+
+- `data/leaderboard.schema.json`
+- `data/languages.schema.json`
+- `data/admin-jobs.schema.json`
+- `data/app-config.schema.json`
+- `data/classes.schema.json`
+- `data/backup-manifest.schema.json`
+- `data/providers/provider-import-manifest.schema.json`
+
+**Optional sets** (off by default; toggled in the export UI or via
+`includeProviders=true` / `includeDictionaries=true` query params):
+
+- `data/providers/**` — provider artifacts (per-language, per-commit).
+  Can be tens of MiB per language. See *Sizing* below.
+- `data/dictionaries/**` — raw dictionary files.
+
+**Explicitly excluded**:
+
+- `.env` and any other secrets directory
+- `data/.admin-key`
+- Anything not under `data/`
+
+## Manifest schema
+
+[`data/backup-manifest.schema.json`](../data/backup-manifest.schema.json) —
+JSON Schema 2020-12, validated by `npm run schema:check`.
+
+Required fields:
+
+- `manifestVersion` — currently locked at `1`. Mismatched manifest
+  versions are rejected with `MANIFEST_VERSION_UNSUPPORTED`.
+- `appVersion` — from the server's `package.json` at export time.
+- `createdAt` — ISO-8601 UTC.
+- `nodeId` — taken from `data/app-config.json` `nodeId` (defaults to
+  `"unknown-node"` if unset).
+- `files[]` — every entry has `path`, `bytes`, `sha256`. Files that
+  have a paired schema also carry a `schema: { schemaPath, sha256 }`
+  digest used for schema-drift detection on restore.
+- `optionalSets[]` — `"providers"` and/or `"dictionaries"` if those
+  sets were included.
+
+## Endpoints
+
+All under `/api/admin/*`, gated by `x-admin-key`, rate-limited per
+`BACKUP_RATE_LIMIT_*`.
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/api/admin/backup` | Streams the archive. Query: `includeProviders=true|false`, `includeDictionaries=true|false`. |
+| `POST` | `/api/admin/backup/preview` | Validates an uploaded archive without applying. Returns `{ manifestVersion, appVersion, createdAt, nodeId, files, totalBytes }`. |
+| `POST` | `/api/admin/restore` | Applies atomically. Requires the header `x-admin-confirm: I-UNDERSTAND` plus a multipart `archive` field. |
+
+## Restore algorithm
+
+1. Validate the uploaded archive against
+   `data/backup-manifest.schema.json`.
+2. Reject if `manifestVersion !== 1`, if any entry's recomputed sha256
+   differs from the manifest, or if any entry exceeds the per-entry
+   size cap (default 64 MiB) or pushes the total past
+   `BACKUP_MAX_BYTES`.
+3. Schema-drift guard: for each manifest entry that carries a
+   `schema:` digest, recompute the digest of the matching schema file
+   on disk. Reject with `SCHEMA_DRIFT` if they differ — the archive
+   was produced under an incompatible schema and needs offline
+   migration before restoring.
+4. Extract every restorable file (in-scope + included optional sets)
+   into `data/.restore-staging-<ts>-<rand>/`.
+5. Validate each staged in-scope file against its schema.
+6. For each file, snapshot the live copy into
+   `data/.restore-rollback-<ts>-<rand>/` and rename the staged file
+   into place.
+7. On any error in step 6, reverse the renames from the rollback dir;
+   the live `data/` is left byte-identical to its pre-restore state.
+8. On success, remove both the staging and rollback directories.
+9. Reload in-memory caches (`leaderboardStore`, `adminJobsStore`,
+   `classesStore`, `appConfigStore`, `languageRegistryStore`, language
+   runtime catalog). The response surfaces per-store reload status.
+
+## Atomicity
+
+Every in-scope file is byte-copied via the staging dir, validated
+against its schema, then atomically renamed into place. A failure
+mid-apply triggers a reverse rename from the rollback dir — operators
+see HTTP 200 with `partialFailure` info only when the leaderboard
+mutate succeeds but a non-fatal cleanup step fails. A genuine
+mid-write failure aborts with `rolledBackOnError: true` and leaves the
+live tree unchanged.
+
+## Mutex with provider import
+
+The restore handler shares a single-flight mutex with the provider
+import queue. While a restore is in flight, the queue and any
+follow-on syncs return HTTP 409. While an import is in flight, restore
+returns HTTP 409 (`code: RESTORE_BUSY`).
+
+## Sizing
+
+`BACKUP_MAX_BYTES` defaults to 256 MiB. Reference sizes from upstream
+LibreOffice/dictionaries (raw `.dic` files only — wordle-local
+processed artifacts are typically 2-5x larger):
+
+| Locale | Raw size | Notes |
+| --- | --- | --- |
+| `en_US.dic` | ~539 KiB | Comfortably under default cap. |
+| `de_DE_frami.dic` | ~4.4 MiB | The DE thesaurus is 31 MiB each — wordle doesn't use it. |
+| `tr_TR.dic` | ~1.7 MiB | Rich morphology — expanded forms can balloon. |
+
+A typical 1-3 language deployment with the latest commit per language
+fits well under 256 MiB. For multi-language deployments with several
+historical commits, raise `BACKUP_MAX_BYTES`.
+
+## Environment
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `BACKUP_MAX_BYTES` | `268435456` (256 MiB) | Per-archive byte cap (export streaming + import upload). Clamped to `[1 MiB, 4 GiB]`. |
+| `BACKUP_INCLUDE_PROVIDERS_DEFAULT` | `false` | Default for the export UI's "include providers" checkbox. |
+| `BACKUP_RATE_LIMIT_WINDOW_MS` | `30000` | Rolling window for the backup-route rate limit. |
+| `BACKUP_RATE_LIMIT_MAX` | `1` | Max backup/preview/restore calls per window per admin key. |
+| `BACKUP_PROJECT_ROOT` | (server's `__dirname`) | Override for tests; should not be set in production. |
+
+## Boot-time orphan check
+
+If the server starts and finds `data/.restore-staging-*` or
+`data/.restore-rollback-*` directories left over from a previous run,
+it logs a warning at boot but does not auto-delete. Inspect the
+contents before removing — they may contain partial state from a
+restore that was killed mid-apply, and rolling forward or back may
+need an operator decision.
+
+## Offline restore
+
+If the admin UI is unreachable (e.g. a config-driven boot loop after a
+failed apply), use the CLI fallback:
+
+```bash
+node scripts/restore-from-disk.js path/to/wordle-backup-XXXXX.zip
+```
+
+Stop the server before running. The script reuses
+`lib/backup-store.js` so the atomicity guarantees are identical.
+
+## Schema drift between archive and current server
+
+If the manifest carries schema digests that don't match the live
+schema files, restore aborts with `SCHEMA_DRIFT`. Migrating the
+archive offline:
+
+1. Stop the server.
+2. Extract the archive.
+3. Apply your project's schema-migration tool (or hand-edit) to bring
+   each `data/<store>.json` up to the current schema.
+4. Recompute the manifest's `files[].sha256` and the schema digests
+   (or rebuild the archive via the export endpoint after applying the
+   migrated state in a controlled environment).
+5. Re-zip with the updated `manifest.json` at the root.
+6. Run `node scripts/restore-from-disk.js <new-archive>` or upload it
+   via the admin Data tab.
+
+## PII boundary
+
+The archive is plaintext. `data/leaderboard.json` and
+`data/classes.json` contain profile names and per-game timing. Treat
+backups as sensitive; encrypt at rest if you are sharing them off-host.
+
+## What's NOT in v1
+
+- Selective per-file restore (all-or-nothing only)
+- Cross-host migration (archives are local to a single node)
+- Encryption / password protection
+- Continuous backups, retention policies

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -154,8 +154,8 @@ historical commits, raise `BACKUP_MAX_BYTES`.
 | --- | --- | --- |
 | `BACKUP_MAX_BYTES` | `268435456` (256 MiB) | Per-archive byte cap (export streaming + import upload). Clamped to `[1 MiB, 4 GiB]`. |
 | `BACKUP_INCLUDE_PROVIDERS_DEFAULT` | `false` | Default for the export UI's "include providers" checkbox. |
-| `BACKUP_RATE_LIMIT_WINDOW_MS` | `30000` | Rolling window for the backup-route rate limit. |
-| `BACKUP_RATE_LIMIT_MAX` | `1` | Max backup/preview/restore calls per window per admin key. |
+| `BACKUP_RATE_LIMIT_WINDOW_MS` | `30000` | Rolling window for the strict backup rate limiter. |
+| `BACKUP_RATE_LIMIT_MAX` | `1` | Max calls per window per admin key against the strict backup limiter. **Only `GET /api/admin/backup` and `POST /api/admin/restore` are gated by this limiter** — `POST /api/admin/backup/preview` is read-only and falls through to the standard admin-write limit. |
 | `BACKUP_PROJECT_ROOT` | (server's `__dirname`) | Override for tests; should not be set in production. |
 
 ## Boot-time orphan check

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -164,7 +164,7 @@ historical commits, raise `BACKUP_MAX_BYTES`.
 | Var | Default | Purpose |
 | --- | --- | --- |
 | `BACKUP_MAX_BYTES` | `268435456` (256 MiB) | Per-archive byte cap (export streaming + import upload). Clamped to `[1 MiB, 4 GiB]`. |
-| `BACKUP_INCLUDE_PROVIDERS_DEFAULT` | `false` | Default for the export UI's "include providers" checkbox. |
+| `BACKUP_INCLUDE_PROVIDERS_DEFAULT` | `false` | Server-side default applied when `GET /api/admin/backup` is called without an `includeProviders` query param. The admin UI starts with the checkbox unchecked and always sends an explicit value, so this only affects scripts/`curl` callers that omit the param. |
 | `BACKUP_RATE_LIMIT_WINDOW_MS` | `30000` | Rolling window for the strict backup rate limiter. |
 | `BACKUP_RATE_LIMIT_MAX` | `1` | Max calls per window per admin key against the strict backup limiter. **Only `GET /api/admin/backup` and `POST /api/admin/restore` are gated by this limiter** — `POST /api/admin/backup/preview` is read-only and falls through to the standard admin-write limit. |
 | `BACKUP_PROJECT_ROOT` | (server's `__dirname`) | Override for tests; should not be set in production. |

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -62,14 +62,17 @@ Required fields:
 
 ## Endpoints
 
-All under `/api/admin/*`, gated by `x-admin-key`, rate-limited per
-`BACKUP_RATE_LIMIT_*`.
+All under `/api/admin/*`, gated by `x-admin-key`. The strict
+`BACKUP_RATE_LIMIT_*` bucket guards the bandwidth-heavy export and
+destructive restore operations; preview is idempotent and gated only
+by the standard admin-write rate limit so the normal preview-then-
+apply UI flow never collides with itself.
 
-| Method | Path | Notes |
-| --- | --- | --- |
-| `GET` | `/api/admin/backup` | Streams the archive. Query: `includeProviders=true|false`, `includeDictionaries=true|false`. |
-| `POST` | `/api/admin/backup/preview` | Validates an uploaded archive without applying. Returns `{ manifestVersion, appVersion, createdAt, nodeId, files, totalBytes }`. |
-| `POST` | `/api/admin/restore` | Applies atomically. Requires the header `x-admin-confirm: I-UNDERSTAND` plus a multipart `archive` field. |
+| Method | Path | Backup-rate-limited | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/api/admin/backup` | Yes | Streams the archive. Query: `includeProviders=true|false`, `includeDictionaries=true|false`. |
+| `POST` | `/api/admin/backup/preview` | No | Validates an uploaded archive without applying. Returns `{ manifestVersion, appVersion, createdAt, nodeId, files, totalBytes }`. |
+| `POST` | `/api/admin/restore` | Yes | Applies atomically. Requires the header `x-admin-confirm: I-UNDERSTAND` plus a multipart `archive` field. |
 
 ## Restore algorithm
 

--- a/lib/admin-jobs-store.js
+++ b/lib/admin-jobs-store.js
@@ -181,8 +181,10 @@ class AdminJobsStore {
     // Drop the cached state so the next read pulls fresh content from disk.
     // Used by the backup-restore flow after files under data/ are swapped
     // — the in-memory cache must not outlive the on-disk swap.
-    this.state = null;
+    // Drain the write queue first so an in-flight #persist() doesn't try
+    // to mutate this.state.updatedAt after we've nulled the field.
     await this.writeQueue.catch(() => {});
+    this.state = null;
     return this.load();
   }
 

--- a/lib/admin-jobs-store.js
+++ b/lib/admin-jobs-store.js
@@ -173,6 +173,10 @@ class AdminJobsStore {
       : DEFAULT_MAX_JOBS;
     this.logger = options.logger || console;
     this.now = typeof options.now === "function" ? options.now : () => new Date();
+    // Optional barrier; see LeaderboardStore for the rationale.
+    this.waitForDataMutationLock = typeof options.waitForDataMutationLock === "function"
+      ? options.waitForDataMutationLock
+      : null;
     this.state = null;
     this.writeQueue = Promise.resolve();
   }
@@ -389,6 +393,12 @@ class AdminJobsStore {
 
   async #enqueueWrite(operation) {
     await this.load();
+    // Pause here if a backup/restore is holding the data-mutation lock.
+    // Without this, a handler that already passed the /api gate could
+    // queue a write that lands on top of the just-restored file.
+    if (this.waitForDataMutationLock) {
+      await this.waitForDataMutationLock();
+    }
     const run = async () => operation();
     const next = this.writeQueue.then(run, run);
     this.writeQueue = next.then(

--- a/lib/admin-jobs-store.js
+++ b/lib/admin-jobs-store.js
@@ -177,6 +177,15 @@ class AdminJobsStore {
     this.writeQueue = Promise.resolve();
   }
 
+  async reload() {
+    // Drop the cached state so the next read pulls fresh content from disk.
+    // Used by the backup-restore flow after files under data/ are swapped
+    // — the in-memory cache must not outlive the on-disk swap.
+    this.state = null;
+    await this.writeQueue.catch(() => {});
+    return this.load();
+  }
+
   async load() {
     if (this.state) {
       return clone(this.state);

--- a/lib/app-config-store.js
+++ b/lib/app-config-store.js
@@ -245,6 +245,14 @@ class AppConfigStore {
     this.state = null;
   }
 
+  reloadSync() {
+    // Drop the cached state so the next read pulls fresh content from disk.
+    // Used by the backup-restore flow after data/app-config.json is
+    // swapped — the in-memory cache must not outlive the on-disk swap.
+    this.state = null;
+    return this.loadSync();
+  }
+
   loadSync() {
     if (this.state) {
       return clone(this.state);

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -102,6 +102,22 @@ async function fileExists(filePath) {
   }
 }
 
+// Reject symlinks (and anything that isn't a regular file) before
+// reading the file into the backup. listFilesUnder() already skips
+// symlinks for optional roots, but the in-scope and diagnostic loops
+// use fixed paths and would otherwise follow a symlink to pull bytes
+// from outside projectRoot into the archive.
+async function assertRegularFile(filePath, archivePath) {
+  const st = await fsp.lstat(filePath);
+  if (!st.isFile()) {
+    throw new BackupError(
+      "PATH_UNSAFE",
+      `Backup entry must be a regular file (not a symlink/dir/special): ${archivePath}.`,
+      { path: archivePath }
+    );
+  }
+}
+
 async function statBytes(filePath) {
   const st = await fsp.stat(filePath);
   return st.size;
@@ -192,6 +208,7 @@ async function buildManifest({
         { path: archivePath }
       );
     }
+    await assertRegularFile(absPath, archivePath);
     const sha256 = await sha256OfFile(absPath);
     const bytes = await statBytes(absPath);
     const entry = { path: archivePath, bytes, sha256 };
@@ -199,6 +216,7 @@ async function buildManifest({
     if (schemaRel) {
       const schemaAbs = path.join(projectRoot, schemaRel);
       if (await fileExists(schemaAbs)) {
+        await assertRegularFile(schemaAbs, schemaRel);
         entry.schema = {
           schemaPath: schemaRel,
           sha256: await sha256OfFile(schemaAbs)
@@ -212,6 +230,7 @@ async function buildManifest({
   for (const schemaRel of DIAGNOSTIC_SCHEMAS) {
     const absPath = path.join(projectRoot, schemaRel);
     if (!(await fileExists(absPath))) continue;
+    await assertRegularFile(absPath, schemaRel);
     files.push({
       path: schemaRel,
       bytes: await statBytes(absPath),
@@ -300,7 +319,19 @@ function createArchive({
       now
     });
     // Manifest first so streaming consumers can validate before extracting.
-    archive.append(`${JSON.stringify(manifest, null, 2)}\n`, {
+    // Verify the serialized manifest fits the same cap readManifest will
+    // enforce on preview/restore — without this, we could ship an
+    // archive that this very server would later reject with
+    // MANIFEST_TOO_LARGE on its own preview.
+    const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
+    const manifestBytes = Buffer.byteLength(manifestJson);
+    if (manifestBytes > MANIFEST_MAX_UNCOMPRESSED_BYTES) {
+      throw new BackupError(
+        "MANIFEST_TOO_LARGE",
+        `Generated manifest.json is ${manifestBytes} bytes, exceeding the ${MANIFEST_MAX_UNCOMPRESSED_BYTES}-byte cap.`
+      );
+    }
+    archive.append(manifestJson, {
       name: MANIFEST_ENTRY_PATH,
       date: now()
     });

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -690,6 +690,14 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
     // inclusive backup actually replaces the live tree under
     // data/providers/** instead of leaving newer commits intact.
     // Deletions go through the same snapshot-then-rewind logic as swaps.
+    // Diagnostic schemas (e.g. data/providers/provider-import-manifest.schema.json)
+    // live under an optional-set prefix but are intentionally NOT in
+    // restorablePaths — they're bundled in the archive as read-only
+    // metadata. Excluding them from the removal queue keeps the live
+    // schema file in place across restores; without this, every
+    // provider-inclusive restore would delete the diagnostic schema and
+    // break later schema checks/backups.
+    const diagnosticSchemaSet = new Set(DIAGNOSTIC_SCHEMAS);
     const removalQueue = [];
     for (const optionalSet of manifest.optionalSets) {
       const prefix = OPTIONAL_SET_PREFIXES[optionalSet];
@@ -698,6 +706,7 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
       const liveFiles = await listFilesUnder(rootAbs, prefix.replace(/\/$/, ""));
       for (const file of liveFiles) {
         if (restorablePaths.has(file.archivePath)) continue;
+        if (diagnosticSchemaSet.has(file.archivePath)) continue;
         removalQueue.push({ archivePath: file.archivePath });
       }
     }

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -573,9 +573,22 @@ async function validateArchive(archivePath, options = {}) {
   // Enforce optional-set prefix at validation time so a crafted manifest
   // can't bypass scope by tagging an arbitrary path as "providers" or
   // "dictionaries". Each optional-set entry must live under the
-  // declared subtree.
+  // declared subtree, AND its set must be in manifest.optionalSets.
+  // Without the membership check, preview would succeed but
+  // applyRestore() silently skips entries whose set isn't declared
+  // (restorablePaths only adds entries from declared sets), so preview
+  // and apply would disagree on what gets restored.
+  const declaredOptionalSets = new Set(
+    Array.isArray(manifest.optionalSets) ? manifest.optionalSets : []
+  );
   for (const entry of manifest.files) {
     if (!entry.optionalSet) continue;
+    if (!declaredOptionalSets.has(entry.optionalSet)) {
+      throw new BackupError(
+        "MANIFEST_OPTIONAL_SET_UNDECLARED",
+        `Manifest entry ${entry.path} references optionalSet=${entry.optionalSet}, but that set is not declared in manifest.optionalSets.`
+      );
+    }
     const requiredPrefix = OPTIONAL_SET_PREFIXES[entry.optionalSet];
     if (!requiredPrefix || !entry.path.startsWith(requiredPrefix)) {
       throw new BackupError(
@@ -719,6 +732,13 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
         { schemaPath: entry.schema.schemaPath }
       );
     }
+    // Belt-and-suspenders: even though schemaPath is sanitized and
+    // fileExists confirmed something is there, an attacker (or
+    // accidental misconfiguration) could symlink it to a special
+    // file like /dev/zero. assertRegularFile lstats and rejects
+    // anything that isn't a regular file, so sha256OfFile won't
+    // hang reading bytes from a device while we hold the data lock.
+    await assertRegularFile(currentSchemaPath, entry.schema.schemaPath);
     const currentDigest = await sha256OfFile(currentSchemaPath);
     if (currentDigest !== entry.schema.sha256) {
       throw new BackupError(
@@ -788,6 +808,10 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
       if (!schemaRel) continue;
       const schemaAbs = path.join(projectRoot, schemaRel);
       if (!(await fileExists(schemaAbs))) continue;
+      // Same symlink/special-file defense as the drift loop above —
+      // assertRegularFile rejects anything that isn't a regular file
+      // before we read it, so a symlinked schema can't hang phase 2.
+      await assertRegularFile(schemaAbs, schemaRel);
       const schemaJson = await readJsonFile(schemaAbs);
       const validate = ajv.compile(schemaJson);
       const data = await readJsonFile(staged.stagedAbs);
@@ -796,6 +820,41 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
           "RESTORED_FILE_INVALID",
           `Staged ${staged.archivePath} fails validation against ${schemaRel}.`,
           { errors: validate.errors }
+        );
+      }
+    }
+    // Phase 2 doesn't have a schema for data/word.json (it's a
+    // simple shape, not in IN_SCOPE_SCHEMAS), so a malformed staged
+    // word.json would silently restore and reloadWordData would
+    // overwrite it with defaults — turning a bad archive into a
+    // false success. Inline a minimal shape check before phase 3
+    // so the restore fails fast on parse errors and obviously-wrong
+    // structures. We accept missing optional fields (older fixtures
+    // omit `lang`/`updatedAt`); we only reject non-objects, arrays,
+    // and fields with the wrong primitive type.
+    for (const staged of stagedFiles) {
+      if (staged.archivePath !== "data/word.json") continue;
+      let parsed;
+      try {
+        parsed = await readJsonFile(staged.stagedAbs);
+      } catch (err) {
+        throw new BackupError(
+          "RESTORED_FILE_INVALID",
+          `Staged data/word.json could not be parsed as JSON: ${err.message}`
+        );
+      }
+      const isPlainObject = parsed && typeof parsed === "object" && !Array.isArray(parsed);
+      const fieldOk = (val) => val === undefined || val === null || typeof val === "string";
+      const isValidWordEntry =
+        isPlainObject
+        && fieldOk(parsed.word)
+        && fieldOk(parsed.lang)
+        && fieldOk(parsed.date)
+        && fieldOk(parsed.updatedAt);
+      if (!isValidWordEntry) {
+        throw new BackupError(
+          "RESTORED_FILE_INVALID",
+          "Staged data/word.json must be an object whose word/lang/date/updatedAt fields, when present, are strings or null."
         );
       }
     }

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -878,9 +878,9 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
       // optional root. listProviderCommitDirectories() etc. scan
       // directories and would otherwise report empty commit dirs as
       // incomplete artifacts after restoring an older backup.
-      // Rollback semantics: ensureParentDir (in the rewind loop) will
-      // recreate any directory it needs when restoring files from
-      // the rollback dir, so removing empty dirs here is rollback-safe.
+      // Rollback semantics: the rewind loop calls ensureParentDir
+      // before each rename, so removing empty dirs here is
+      // rollback-safe even if a later step throws.
       for (const optionalSet of manifest.optionalSets) {
         const prefix = OPTIONAL_SET_PREFIXES[optionalSet];
         if (!prefix) continue;
@@ -890,12 +890,16 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
     } catch (err) {
       // Rewind: for each entry recorded, delete the (possibly partial)
       // live file and, if there was a prior copy, move it back from the
-      // rollback dir.
+      // rollback dir. ensureParentDir runs before the rename because an
+      // earlier optional-root prune (or a partial prune that errored
+      // mid-way) may have removed the parent directory, which would
+      // otherwise leave the prior copy stranded in the rollback dir.
       for (let i = swapped.length - 1; i >= 0; i -= 1) {
         const op = swapped[i];
         try {
           await fsp.rm(op.livePath, { force: true });
           if (op.hadPrior) {
+            await ensureParentDir(op.livePath);
             await fsp.rename(op.rolledPath, op.livePath);
           }
         } catch (rewindErr) {

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -102,6 +102,21 @@ async function fileExists(filePath) {
   }
 }
 
+// Like fileExists, but lstat-based so it returns true for dangling
+// symlinks (where the target is gone but the symlink itself is still
+// present on disk). Used by the optional-root prune so that stale
+// symlink-backed artifacts get removed even when their target is
+// already missing — fileExists() would follow the link, see ENOENT
+// on the target, and return false, leaving the symlink stranded.
+async function pathEntryExists(filePath) {
+  try {
+    await fsp.lstat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Reject symlinks (and anything that isn't a regular file) before
 // reading the file into the backup. listFilesUnder() already skips
 // symlinks for optional roots, but the in-scope and diagnostic loops
@@ -598,6 +613,27 @@ async function validateArchive(archivePath, options = {}) {
     }
   }
 
+  // Reject manifests that omit any IN_SCOPE_FILES entry. The runbook
+  // documents these as "always included / replace-all", and applyRestore
+  // relies on each one being staged before phase 3. A crafted (or
+  // accidentally-trimmed) archive that drops, say, data/app-config.json
+  // would otherwise produce a partial restore that violates the
+  // documented semantics — the dropped file would silently retain its
+  // pre-restore contents. Runs AFTER the optional-set checks so a
+  // crafted manifest that's both incomplete AND has bad optional-set
+  // paths still surfaces the security-relevant error first.
+  {
+    const declaredPaths = new Set(manifest.files.map((entry) => entry.path));
+    const missing = IN_SCOPE_FILES.filter((p) => !declaredPaths.has(p));
+    if (missing.length > 0) {
+      throw new BackupError(
+        "MANIFEST_INCOMPLETE",
+        `Manifest is missing required in-scope files: ${missing.join(", ")}.`,
+        { missing }
+      );
+    }
+  }
+
   // Re-open to walk entries (yauzl is single-pass).
   const zip = await openZip(archivePath);
   const fileChecks = [];
@@ -928,7 +964,12 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
       for (const removal of removalQueue) {
         const livePath = path.join(projectRoot, removal.archivePath);
         const rolledPath = path.join(rollbackDir, removal.archivePath);
-        if (!(await fileExists(livePath))) continue;
+        // Use the lstat-based check so dangling symlinks are treated
+        // as present and renamed into the rollback dir. fileExists()
+        // follows the link and would skip them, leaving the symlink
+        // on disk after restore — listProviderCommitDirectories()
+        // would then continue reporting the stale commit.
+        if (!(await pathEntryExists(livePath))) continue;
         await ensureParentDir(rolledPath);
         await fsp.rename(livePath, rolledPath);
         swapped.push({

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -39,6 +39,15 @@ const DIAGNOSTIC_SCHEMAS = Object.freeze([
   "data/providers/provider-import-manifest.schema.json"
 ]);
 
+// Optional-set names map to the path prefix their entries must live
+// under. A crafted manifest claiming `optionalSet: "providers"` for a
+// path like `server.js` is rejected — the prefix check enforces that
+// optional-set entries can only restore into their declared subtree.
+const OPTIONAL_SET_PREFIXES = Object.freeze({
+  providers: "data/providers/",
+  dictionaries: "data/dictionaries/"
+});
+
 const DEFAULT_TOTAL_UNCOMPRESSED_MAX_BYTES = 256 * 1024 * 1024;
 const DEFAULT_PER_ENTRY_MAX_BYTES = 64 * 1024 * 1024;
 const ARCHIVE_PATH_PATTERN = /^[A-Za-z0-9._/-]+$/;
@@ -407,6 +416,39 @@ async function validateArchive(archivePath, options = {}) {
     );
   }
 
+  // Reject duplicate paths in the manifest itself before touching the
+  // archive — two manifest entries pointing at the same path could
+  // otherwise interfere with each other during staging.
+  {
+    const manifestPathCounts = new Map();
+    for (const entry of manifest.files) {
+      manifestPathCounts.set(entry.path, (manifestPathCounts.get(entry.path) || 0) + 1);
+    }
+    for (const [archivePath, count] of manifestPathCounts) {
+      if (count > 1) {
+        throw new BackupError(
+          "MANIFEST_DUPLICATE_PATH",
+          `Manifest contains ${count} entries for ${archivePath}; paths must be unique.`
+        );
+      }
+    }
+  }
+
+  // Enforce optional-set prefix at validation time so a crafted manifest
+  // can't bypass scope by tagging an arbitrary path as "providers" or
+  // "dictionaries". Each optional-set entry must live under the
+  // declared subtree.
+  for (const entry of manifest.files) {
+    if (!entry.optionalSet) continue;
+    const requiredPrefix = OPTIONAL_SET_PREFIXES[entry.optionalSet];
+    if (!requiredPrefix || !entry.path.startsWith(requiredPrefix)) {
+      throw new BackupError(
+        "OPTIONAL_SET_PATH_INVALID",
+        `Manifest entry ${entry.path} is tagged optionalSet=${entry.optionalSet} but is not under ${requiredPrefix || "an allowed prefix"}.`
+      );
+    }
+  }
+
   // Re-open to walk entries (yauzl is single-pass).
   const zip = await openZip(archivePath);
   const fileChecks = [];
@@ -418,9 +460,20 @@ async function validateArchive(archivePath, options = {}) {
     const entries = await listArchiveEntries(zip);
     for (const entry of entries) {
       if (entry.fileName === MANIFEST_ENTRY_PATH) continue;
+      // Some zip writers include explicit directory entries (trailing
+      // slash, zero bytes). Skip them — there's nothing to validate or
+      // restore, and complaining about MANIFEST_MISMATCH for them is
+      // noise.
+      if (entry.fileName.endsWith("/")) continue;
       const safePath = entry.fileName;
       if (!isPathSafe(safePath)) {
         throw new BackupError("PATH_UNSAFE", `Archive entry rejected for unsafe path: ${safePath}`);
+      }
+      if (seenPaths.has(safePath)) {
+        throw new BackupError(
+          "ARCHIVE_DUPLICATE_PATH",
+          `Archive contains multiple entries for ${safePath}; paths must be unique.`
+        );
       }
       const expected = expectedByPath.get(safePath);
       if (!expected) {
@@ -548,12 +601,19 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
     const restorablePaths = new Set();
     for (const entry of manifest.files) {
       // Only restore in-scope files and explicitly-included optional sets.
-      if (
-        IN_SCOPE_FILES.includes(entry.path)
-        || (entry.optionalSet && manifest.optionalSets.includes(entry.optionalSet))
-      ) {
+      if (IN_SCOPE_FILES.includes(entry.path)) {
         restorablePaths.add(entry.path);
+        continue;
       }
+      if (!entry.optionalSet || !manifest.optionalSets.includes(entry.optionalSet)) {
+        continue;
+      }
+      // Defense in depth: validateArchive already enforces this prefix,
+      // but check again here so a future code path that skips the
+      // validator can't hand applyRestore an out-of-tree path.
+      const requiredPrefix = OPTIONAL_SET_PREFIXES[entry.optionalSet];
+      if (!requiredPrefix || !entry.path.startsWith(requiredPrefix)) continue;
+      restorablePaths.add(entry.path);
     }
     for (const entry of entries) {
       if (!restorablePaths.has(entry.fileName)) continue;
@@ -586,7 +646,13 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
     // Phase 3: snapshot existing files into the rollback dir, then swap
     // staged files into place. Each file is snapshot-then-swap individually
     // so rollback can rewind by reversing the renames.
-    const swapped = []; // { archivePath, livePath, rolledPath, hadPrior }
+    //
+    // We record the rewindable operation BEFORE the staged-into-live
+    // rename. If that rename throws (transient FS error etc.), the live
+    // file is missing but the original is in the rollback dir — the
+    // rewind logic still works because the entry is in `swapped` with
+    // `hadPrior` set correctly.
+    const swapped = [];
     try {
       for (const staged of stagedFiles) {
         const livePath = path.join(projectRoot, staged.archivePath);
@@ -596,15 +662,24 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
         if (hadPrior) {
           await fsp.rename(livePath, rolledPath);
         }
+        // Record the rewindable state immediately. Even if the next
+        // rename throws, the rewind loop will see this entry and
+        // restore from rollback if `hadPrior`.
+        const op = {
+          archivePath: staged.archivePath,
+          livePath,
+          rolledPath,
+          hadPrior
+        };
+        swapped.push(op);
         await ensureParentDir(livePath);
         await fsp.rename(staged.stagedAbs, livePath);
-        swapped.push({ archivePath: staged.archivePath, livePath, rolledPath, hadPrior });
         restoredFiles.push(staged.archivePath);
       }
     } catch (err) {
-      // Rewind: for each successfully-swapped file, put the live file back
-      // to where it came from (delete current → move rolled back into place
-      // if there was a prior).
+      // Rewind: for each entry recorded, delete the (possibly partial)
+      // live file and, if there was a prior copy, move it back from the
+      // rollback dir.
       for (let i = swapped.length - 1; i >= 0; i -= 1) {
         const op = swapped[i];
         try {

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -160,6 +160,34 @@ function compileManifestValidator(projectRoot) {
   return ajv.compile(schema);
 }
 
+// Recursively remove empty directories under rootDir, bottom-up.
+// Used by applyRestore after pruning files from optional-root
+// subtrees so empty <variant>/<commit>/ shells don't survive a
+// replace-all restore. The root itself is preserved (we only delete
+// its children if they're empty).
+async function pruneEmptyDirectoriesUnder(rootDir) {
+  let entries;
+  try {
+    entries = await fsp.readdir(rootDir, { withFileTypes: true });
+  } catch (err) {
+    if (err && err.code === "ENOENT") return;
+    throw err;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const child = path.join(rootDir, entry.name);
+    await pruneEmptyDirectoriesUnder(child);
+    try {
+      await fsp.rmdir(child);
+    } catch (err) {
+      // ENOTEMPTY = still has files (intentional); ENOENT = race; both fine.
+      if (err && err.code !== "ENOTEMPTY" && err.code !== "ENOENT") {
+        throw err;
+      }
+    }
+  }
+}
+
 async function listFilesUnder(rootDir, baseRel) {
   const out = [];
   let entries;
@@ -790,6 +818,19 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
           hadPrior: true
         });
         removedFiles.push(removal.archivePath);
+      }
+      // Prune empty directories left behind under each included
+      // optional root. listProviderCommitDirectories() etc. scan
+      // directories and would otherwise report empty commit dirs as
+      // incomplete artifacts after restoring an older backup.
+      // Rollback semantics: ensureParentDir (in the rewind loop) will
+      // recreate any directory it needs when restoring files from
+      // the rollback dir, so removing empty dirs here is rollback-safe.
+      for (const optionalSet of manifest.optionalSets) {
+        const prefix = OPTIONAL_SET_PREFIXES[optionalSet];
+        if (!prefix) continue;
+        const rootAbs = path.join(projectRoot, prefix);
+        await pruneEmptyDirectoriesUnder(rootAbs);
       }
     } catch (err) {
       // Rewind: for each entry recorded, delete the (possibly partial)

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -212,6 +212,44 @@ async function listFilesUnder(rootDir, baseRel) {
   return out;
 }
 
+// Variant of listFilesUnder used by the optional-root prune. Includes
+// symlinks (recorded as regular file entries) so they get queued for
+// deletion alongside real files. Without this, a stale symlink-backed
+// artifact under data/providers/<variant>/<commit>/ would survive a
+// restore even though the archive didn't contain it — and provider
+// discovery (which uses fs.existsSync) would still report the commit
+// as importable. We DON'T descend into directory symlinks (those
+// could escape projectRoot); we only treat symlink-as-file entries
+// the same as regular files for pruning purposes.
+async function listFilesForPruneUnder(rootDir, baseRel) {
+  const out = [];
+  let entries;
+  try {
+    entries = await fsp.readdir(rootDir, { withFileTypes: true });
+  } catch (err) {
+    if (err && err.code === "ENOENT") return out;
+    throw err;
+  }
+  for (const entry of entries) {
+    const abs = path.join(rootDir, entry.name);
+    const rel = path.posix.join(baseRel, entry.name);
+    if (entry.isSymbolicLink()) {
+      // Treat any symlink (regardless of target type) as a removable
+      // artifact for prune purposes.
+      out.push({ absPath: abs, archivePath: rel });
+      continue;
+    }
+    if (entry.isDirectory()) {
+      const nested = await listFilesForPruneUnder(abs, rel);
+      out.push(...nested);
+    } else if (entry.isFile()) {
+      out.push({ absPath: abs, archivePath: rel });
+    }
+  }
+  out.sort((a, b) => a.archivePath.localeCompare(b.archivePath));
+  return out;
+}
+
 async function buildManifest({
   projectRoot,
   includeProviders,
@@ -773,7 +811,13 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
       const prefix = OPTIONAL_SET_PREFIXES[optionalSet];
       if (!prefix) continue;
       const rootAbs = path.join(projectRoot, prefix);
-      const liveFiles = await listFilesUnder(rootAbs, prefix.replace(/\/$/, ""));
+      // Use the prune-specific walk that includes symlinks. Stale
+      // symlink-backed artifacts under <variant>/<commit>/ would
+      // otherwise survive the restore (the backup-side
+      // listFilesUnder skips symlinks intentionally so we never
+      // archive their targets, but the prune side needs to see them
+      // so they don't outlive the restore).
+      const liveFiles = await listFilesForPruneUnder(rootAbs, prefix.replace(/\/$/, ""));
       for (const file of liveFiles) {
         if (restorablePaths.has(file.archivePath)) continue;
         if (diagnosticSchemaSet.has(file.archivePath)) continue;

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -1,0 +1,684 @@
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const nodeCrypto = require("node:crypto");
+const { pipeline } = require("node:stream/promises");
+
+const archiver = require("archiver");
+const yauzl = require("yauzl");
+const Ajv2020 = require("ajv/dist/2020");
+const addFormats = require("ajv-formats");
+
+const MANIFEST_VERSION = 1;
+const MANIFEST_ENTRY_PATH = "manifest.json";
+
+const IN_SCOPE_FILES = Object.freeze([
+  "data/leaderboard.json",
+  "data/languages.json",
+  "data/admin-jobs.json",
+  "data/app-config.json",
+  "data/classes.json",
+  "data/word.json"
+]);
+
+const IN_SCOPE_SCHEMAS = Object.freeze({
+  "data/leaderboard.json": "data/leaderboard.schema.json",
+  "data/languages.json": "data/languages.schema.json",
+  "data/admin-jobs.json": "data/admin-jobs.schema.json",
+  "data/app-config.json": "data/app-config.schema.json",
+  "data/classes.json": "data/classes.schema.json"
+});
+
+const DIAGNOSTIC_SCHEMAS = Object.freeze([
+  "data/leaderboard.schema.json",
+  "data/languages.schema.json",
+  "data/admin-jobs.schema.json",
+  "data/app-config.schema.json",
+  "data/classes.schema.json",
+  "data/backup-manifest.schema.json",
+  "data/providers/provider-import-manifest.schema.json"
+]);
+
+const DEFAULT_TOTAL_UNCOMPRESSED_MAX_BYTES = 256 * 1024 * 1024;
+const DEFAULT_PER_ENTRY_MAX_BYTES = 64 * 1024 * 1024;
+const ARCHIVE_PATH_PATTERN = /^[A-Za-z0-9._/-]+$/;
+
+class BackupError extends Error {
+  constructor(code, message, details) {
+    super(message);
+    this.name = "BackupError";
+    this.code = code;
+    if (details) this.details = details;
+  }
+}
+
+function isPathSafe(entryPath) {
+  if (typeof entryPath !== "string" || entryPath.length === 0) return false;
+  if (!ARCHIVE_PATH_PATTERN.test(entryPath)) return false;
+  if (entryPath.startsWith("/")) return false;
+  if (entryPath.includes("\\")) return false;
+  const normalized = path.posix.normalize(entryPath);
+  if (normalized !== entryPath) return false;
+  if (normalized.startsWith("..") || normalized.includes("/../")) return false;
+  return true;
+}
+
+function sha256OfBuffer(buf) {
+  return nodeCrypto.createHash("sha256").update(buf).digest("hex");
+}
+
+async function sha256OfFile(filePath) {
+  const hash = nodeCrypto.createHash("sha256");
+  await pipeline(fs.createReadStream(filePath), async function* (source) {
+    for await (const chunk of source) {
+      hash.update(chunk);
+      yield chunk;
+    }
+  }, new (require("node:stream").Writable)({
+    write(_chunk, _enc, cb) { cb(); }
+  }));
+  return hash.digest("hex");
+}
+
+async function fileExists(filePath) {
+  try {
+    await fsp.access(filePath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function statBytes(filePath) {
+  const st = await fsp.stat(filePath);
+  return st.size;
+}
+
+async function readJsonFile(filePath) {
+  const raw = await fsp.readFile(filePath, "utf8");
+  return JSON.parse(raw);
+}
+
+async function readAppVersion(projectRoot) {
+  try {
+    const pkg = await readJsonFile(path.join(projectRoot, "package.json"));
+    if (typeof pkg.version === "string" && pkg.version.length > 0) {
+      return pkg.version;
+    }
+  } catch {
+    // fall through
+  }
+  return "0.0.0";
+}
+
+async function readNodeId(projectRoot) {
+  try {
+    const config = await readJsonFile(path.join(projectRoot, "data", "app-config.json"));
+    if (config && typeof config.nodeId === "string" && config.nodeId.length > 0) {
+      return config.nodeId;
+    }
+  } catch {
+    // fall through
+  }
+  return "unknown-node";
+}
+
+function compileManifestValidator(projectRoot) {
+  const schemaPath = path.join(projectRoot, "data", "backup-manifest.schema.json");
+  const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  addFormats(ajv);
+  return ajv.compile(schema);
+}
+
+async function listFilesUnder(rootDir, baseRel) {
+  const out = [];
+  let entries;
+  try {
+    entries = await fsp.readdir(rootDir, { withFileTypes: true });
+  } catch (err) {
+    if (err && err.code === "ENOENT") return out;
+    throw err;
+  }
+  for (const entry of entries) {
+    const abs = path.join(rootDir, entry.name);
+    const rel = path.posix.join(baseRel, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await listFilesUnder(abs, rel);
+      out.push(...nested);
+    } else if (entry.isFile()) {
+      out.push({ absPath: abs, archivePath: rel });
+    }
+    // Symlinks intentionally skipped — backups must not follow.
+  }
+  out.sort((a, b) => a.archivePath.localeCompare(b.archivePath));
+  return out;
+}
+
+async function buildManifest({
+  projectRoot,
+  includeProviders,
+  includeDictionaries,
+  now = () => new Date()
+}) {
+  const dataRoot = path.join(projectRoot, "data");
+  const files = [];
+  const optionalSets = [];
+
+  for (const archivePath of IN_SCOPE_FILES) {
+    const absPath = path.join(projectRoot, archivePath);
+    if (!(await fileExists(absPath))) continue;
+    const sha256 = await sha256OfFile(absPath);
+    const bytes = await statBytes(absPath);
+    const entry = { path: archivePath, bytes, sha256 };
+    const schemaRel = IN_SCOPE_SCHEMAS[archivePath];
+    if (schemaRel) {
+      const schemaAbs = path.join(projectRoot, schemaRel);
+      if (await fileExists(schemaAbs)) {
+        entry.schema = {
+          schemaPath: schemaRel,
+          sha256: await sha256OfFile(schemaAbs)
+        };
+      }
+    }
+    files.push(entry);
+  }
+
+  // Diagnostic schemas (read-only, never restored)
+  for (const schemaRel of DIAGNOSTIC_SCHEMAS) {
+    const absPath = path.join(projectRoot, schemaRel);
+    if (!(await fileExists(absPath))) continue;
+    files.push({
+      path: schemaRel,
+      bytes: await statBytes(absPath),
+      sha256: await sha256OfFile(absPath)
+    });
+  }
+
+  if (includeProviders) {
+    optionalSets.push("providers");
+    const providersRoot = path.join(dataRoot, "providers");
+    const providerFiles = await listFilesUnder(providersRoot, "data/providers");
+    for (const file of providerFiles) {
+      files.push({
+        path: file.archivePath,
+        bytes: await statBytes(file.absPath),
+        sha256: await sha256OfFile(file.absPath),
+        optionalSet: "providers"
+      });
+    }
+  }
+
+  if (includeDictionaries) {
+    optionalSets.push("dictionaries");
+    const dictionariesRoot = path.join(dataRoot, "dictionaries");
+    const dictFiles = await listFilesUnder(dictionariesRoot, "data/dictionaries");
+    for (const file of dictFiles) {
+      files.push({
+        path: file.archivePath,
+        bytes: await statBytes(file.absPath),
+        sha256: await sha256OfFile(file.absPath),
+        optionalSet: "dictionaries"
+      });
+    }
+  }
+
+  return {
+    manifestVersion: MANIFEST_VERSION,
+    appVersion: await readAppVersion(projectRoot),
+    createdAt: now().toISOString(),
+    nodeId: await readNodeId(projectRoot),
+    files,
+    optionalSets
+  };
+}
+
+function createArchive({
+  projectRoot,
+  includeProviders = false,
+  includeDictionaries = false,
+  now = () => new Date()
+}) {
+  if (!projectRoot) {
+    throw new BackupError("INVALID_REQUEST", "projectRoot is required.");
+  }
+  const archive = archiver("zip", {
+    zlib: { level: 6 },
+    forceLocalTime: false
+  });
+
+  archive.on("error", (err) => {
+    archive.emit("end");
+    archive.destroy(err);
+  });
+
+  const builder = (async () => {
+    const manifest = await buildManifest({
+      projectRoot,
+      includeProviders,
+      includeDictionaries,
+      now
+    });
+    // Manifest first so streaming consumers can validate before extracting.
+    archive.append(`${JSON.stringify(manifest, null, 2)}\n`, {
+      name: MANIFEST_ENTRY_PATH,
+      date: now()
+    });
+    for (const entry of manifest.files) {
+      const absPath = path.join(projectRoot, entry.path);
+      archive.file(absPath, { name: entry.path, date: now() });
+    }
+    await archive.finalize();
+    return manifest;
+  })();
+
+  builder.catch((err) => {
+    archive.destroy(err);
+  });
+
+  return { archive, manifestPromise: builder };
+}
+
+function openZip(archivePath) {
+  return new Promise((resolve, reject) => {
+    yauzl.open(archivePath, { lazyEntries: true, autoClose: false }, (err, zip) => {
+      if (err) {
+        // yauzl throws "end of central directory record signature not
+        // found" / "invalid local file header signature" etc. for malformed
+        // uploads. Surface them as a 400-mapped BackupError rather than a
+        // raw error that the route would 500.
+        return reject(new BackupError(
+          "ARCHIVE_MALFORMED",
+          `Archive could not be opened as a zip: ${err.message}`
+        ));
+      }
+      resolve(zip);
+    });
+  });
+}
+
+function readEntryToBuffer(zip, entry) {
+  return new Promise((resolve, reject) => {
+    zip.openReadStream(entry, (err, readStream) => {
+      if (err) return reject(err);
+      const chunks = [];
+      readStream.on("data", (chunk) => chunks.push(chunk));
+      readStream.on("end", () => resolve(Buffer.concat(chunks)));
+      readStream.on("error", reject);
+    });
+  });
+}
+
+function readEntryToFile(zip, entry, destPath) {
+  return new Promise((resolve, reject) => {
+    zip.openReadStream(entry, (err, readStream) => {
+      if (err) return reject(err);
+      const writeStream = fs.createWriteStream(destPath);
+      readStream.pipe(writeStream);
+      writeStream.on("finish", () => resolve());
+      writeStream.on("error", reject);
+      readStream.on("error", reject);
+    });
+  });
+}
+
+async function readManifest(zip) {
+  return new Promise((resolve, reject) => {
+    let manifestEntry = null;
+    zip.on("entry", (entry) => {
+      if (entry.fileName === MANIFEST_ENTRY_PATH && !manifestEntry) {
+        manifestEntry = entry;
+        readEntryToBuffer(zip, entry)
+          .then((buf) => {
+            try {
+              resolve(JSON.parse(buf.toString("utf8")));
+            } catch (err) {
+              reject(new BackupError("MANIFEST_PARSE_FAILED", `manifest.json is not valid JSON: ${err.message}`));
+            }
+          })
+          .catch(reject);
+      } else {
+        zip.readEntry();
+      }
+    });
+    zip.on("end", () => {
+      if (!manifestEntry) {
+        reject(new BackupError("MANIFEST_MISSING", "Archive does not contain a manifest.json entry."));
+      }
+    });
+    zip.on("error", reject);
+    zip.readEntry();
+  });
+}
+
+async function listArchiveEntries(zip) {
+  return new Promise((resolve, reject) => {
+    const entries = [];
+    zip.on("entry", (entry) => {
+      entries.push(entry);
+      zip.readEntry();
+    });
+    zip.on("end", () => resolve(entries));
+    zip.on("error", reject);
+    zip.readEntry();
+  });
+}
+
+async function validateArchive(archivePath, options = {}) {
+  const projectRoot = options.projectRoot || process.cwd();
+  const totalMaxBytes = Number.isInteger(options.totalMaxBytes) && options.totalMaxBytes > 0
+    ? options.totalMaxBytes
+    : DEFAULT_TOTAL_UNCOMPRESSED_MAX_BYTES;
+  const perEntryMaxBytes = Number.isInteger(options.perEntryMaxBytes) && options.perEntryMaxBytes > 0
+    ? options.perEntryMaxBytes
+    : DEFAULT_PER_ENTRY_MAX_BYTES;
+
+  const validateManifest = compileManifestValidator(projectRoot);
+
+  let zipForManifest;
+  let manifest;
+  try {
+    zipForManifest = await openZip(archivePath);
+    manifest = await readManifest(zipForManifest);
+  } finally {
+    if (zipForManifest) zipForManifest.close();
+  }
+
+  if (!validateManifest(manifest)) {
+    throw new BackupError("MANIFEST_INVALID", "manifest.json failed schema validation.", {
+      errors: validateManifest.errors
+    });
+  }
+
+  if (manifest.manifestVersion !== MANIFEST_VERSION) {
+    throw new BackupError(
+      "MANIFEST_VERSION_UNSUPPORTED",
+      `manifest version ${manifest.manifestVersion} is not supported by this server (expected ${MANIFEST_VERSION}).`,
+      { expected: MANIFEST_VERSION, got: manifest.manifestVersion }
+    );
+  }
+
+  // Re-open to walk entries (yauzl is single-pass).
+  const zip = await openZip(archivePath);
+  const fileChecks = [];
+  let totalUncompressed = 0;
+  const expectedByPath = new Map(manifest.files.map((entry) => [entry.path, entry]));
+  const seenPaths = new Set();
+
+  try {
+    const entries = await listArchiveEntries(zip);
+    for (const entry of entries) {
+      if (entry.fileName === MANIFEST_ENTRY_PATH) continue;
+      const safePath = entry.fileName;
+      if (!isPathSafe(safePath)) {
+        throw new BackupError("PATH_UNSAFE", `Archive entry rejected for unsafe path: ${safePath}`);
+      }
+      const expected = expectedByPath.get(safePath);
+      if (!expected) {
+        throw new BackupError("MANIFEST_MISMATCH", `Archive contains entry not declared in manifest: ${safePath}`);
+      }
+      if (entry.uncompressedSize > perEntryMaxBytes) {
+        throw new BackupError(
+          "ENTRY_TOO_LARGE",
+          `Archive entry ${safePath} exceeds the per-entry limit (${entry.uncompressedSize} > ${perEntryMaxBytes}).`
+        );
+      }
+      totalUncompressed += entry.uncompressedSize;
+      if (totalUncompressed > totalMaxBytes) {
+        throw new BackupError(
+          "ARCHIVE_TOO_LARGE",
+          `Archive uncompressed size exceeds the total limit (${totalUncompressed} > ${totalMaxBytes}).`
+        );
+      }
+      const buf = await readEntryToBuffer(zip, entry);
+      if (buf.length !== expected.bytes) {
+        throw new BackupError(
+          "BYTES_MISMATCH",
+          `Archive entry ${safePath} bytes ${buf.length} differ from manifest ${expected.bytes}.`
+        );
+      }
+      const sha256 = sha256OfBuffer(buf);
+      if (sha256 !== expected.sha256) {
+        throw new BackupError(
+          "SHA256_MISMATCH",
+          `Archive entry ${safePath} sha256 ${sha256} differs from manifest ${expected.sha256}.`
+        );
+      }
+      seenPaths.add(safePath);
+      fileChecks.push({ path: safePath, bytes: buf.length, sha256, ok: true });
+    }
+  } finally {
+    zip.close();
+  }
+
+  for (const expected of manifest.files) {
+    if (!seenPaths.has(expected.path)) {
+      throw new BackupError(
+        "ENTRY_MISSING",
+        `Manifest declares ${expected.path} but the archive does not contain it.`
+      );
+    }
+  }
+
+  return { manifest, fileChecks };
+}
+
+async function makeStagingDir(dataRoot, kind) {
+  const stamp = new Date().toISOString().replace(/[^0-9T-]/g, "");
+  const random = nodeCrypto.randomBytes(4).toString("hex");
+  const name = `.restore-${kind}-${stamp}-${random}`;
+  const dir = path.join(dataRoot, name);
+  await fsp.mkdir(dir, { recursive: false });
+  return dir;
+}
+
+async function rmDirRecursive(dirPath) {
+  try {
+    await fsp.rm(dirPath, { recursive: true, force: true });
+  } catch {
+    // best effort
+  }
+}
+
+async function ensureParentDir(filePath) {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function applyRestore({ archivePath, projectRoot, logger = console }, options = {}) {
+  if (!projectRoot) {
+    throw new BackupError("INVALID_REQUEST", "projectRoot is required.");
+  }
+  const dataRoot = path.join(projectRoot, "data");
+  const warnings = [];
+
+  const validation = await validateArchive(archivePath, {
+    projectRoot,
+    totalMaxBytes: options.totalMaxBytes,
+    perEntryMaxBytes: options.perEntryMaxBytes
+  });
+  const { manifest } = validation;
+
+  // Schema-drift guard: every manifest file with a `schema` block must have
+  // its declared schema digest match the schema currently on disk.
+  for (const entry of manifest.files) {
+    if (!entry.schema) continue;
+    const currentSchemaPath = path.join(projectRoot, entry.schema.schemaPath);
+    if (!(await fileExists(currentSchemaPath))) {
+      throw new BackupError(
+        "SCHEMA_DRIFT",
+        `Archive references schema ${entry.schema.schemaPath} which is missing on this server.`,
+        { schemaPath: entry.schema.schemaPath }
+      );
+    }
+    const currentDigest = await sha256OfFile(currentSchemaPath);
+    if (currentDigest !== entry.schema.sha256) {
+      throw new BackupError(
+        "SCHEMA_DRIFT",
+        `Archive's ${entry.path} was produced under a different ${entry.schema.schemaPath}. ` +
+          `Run the offline migration tool before restoring.`,
+        {
+          schemaPath: entry.schema.schemaPath,
+          archiveSha256: entry.schema.sha256,
+          currentSha256: currentDigest
+        }
+      );
+    }
+  }
+
+  const stagingDir = await makeStagingDir(dataRoot, "staging");
+  const rollbackDir = await makeStagingDir(dataRoot, "rollback");
+  const restoredFiles = [];
+  const stagedFiles = [];
+  let zip;
+  let succeeded = false;
+
+  try {
+    // Phase 1: extract every restorable file (in-scope + optional sets) into staging
+    zip = await openZip(archivePath);
+    const entries = await listArchiveEntries(zip);
+    const restorablePaths = new Set();
+    for (const entry of manifest.files) {
+      // Only restore in-scope files and explicitly-included optional sets.
+      if (
+        IN_SCOPE_FILES.includes(entry.path)
+        || (entry.optionalSet && manifest.optionalSets.includes(entry.optionalSet))
+      ) {
+        restorablePaths.add(entry.path);
+      }
+    }
+    for (const entry of entries) {
+      if (!restorablePaths.has(entry.fileName)) continue;
+      const stagedAbs = path.join(stagingDir, entry.fileName);
+      await ensureParentDir(stagedAbs);
+      await readEntryToFile(zip, entry, stagedAbs);
+      stagedFiles.push({ archivePath: entry.fileName, stagedAbs });
+    }
+
+    // Phase 2: validate every staged in-scope file against its current schema
+    const ajv = new Ajv2020({ allErrors: true, strict: true });
+    addFormats(ajv);
+    for (const staged of stagedFiles) {
+      const schemaRel = IN_SCOPE_SCHEMAS[staged.archivePath];
+      if (!schemaRel) continue;
+      const schemaAbs = path.join(projectRoot, schemaRel);
+      if (!(await fileExists(schemaAbs))) continue;
+      const schemaJson = await readJsonFile(schemaAbs);
+      const validate = ajv.compile(schemaJson);
+      const data = await readJsonFile(staged.stagedAbs);
+      if (!validate(data)) {
+        throw new BackupError(
+          "RESTORED_FILE_INVALID",
+          `Staged ${staged.archivePath} fails validation against ${schemaRel}.`,
+          { errors: validate.errors }
+        );
+      }
+    }
+
+    // Phase 3: snapshot existing files into the rollback dir, then swap
+    // staged files into place. Each file is snapshot-then-swap individually
+    // so rollback can rewind by reversing the renames.
+    const swapped = []; // { archivePath, livePath, rolledPath, hadPrior }
+    try {
+      for (const staged of stagedFiles) {
+        const livePath = path.join(projectRoot, staged.archivePath);
+        const rolledPath = path.join(rollbackDir, staged.archivePath);
+        await ensureParentDir(rolledPath);
+        const hadPrior = await fileExists(livePath);
+        if (hadPrior) {
+          await fsp.rename(livePath, rolledPath);
+        }
+        await ensureParentDir(livePath);
+        await fsp.rename(staged.stagedAbs, livePath);
+        swapped.push({ archivePath: staged.archivePath, livePath, rolledPath, hadPrior });
+        restoredFiles.push(staged.archivePath);
+      }
+    } catch (err) {
+      // Rewind: for each successfully-swapped file, put the live file back
+      // to where it came from (delete current → move rolled back into place
+      // if there was a prior).
+      for (let i = swapped.length - 1; i >= 0; i -= 1) {
+        const op = swapped[i];
+        try {
+          await fsp.rm(op.livePath, { force: true });
+          if (op.hadPrior) {
+            await fsp.rename(op.rolledPath, op.livePath);
+          }
+        } catch (rewindErr) {
+          warnings.push({
+            code: "ROLLBACK_PARTIAL",
+            message: `Could not fully rewind ${op.archivePath}: ${rewindErr.message}`
+          });
+        }
+      }
+      throw err;
+    }
+
+    succeeded = true;
+  } finally {
+    if (zip) zip.close();
+    if (succeeded) {
+      // Best-effort cleanup; both dirs should be safe to remove on success.
+      await rmDirRecursive(stagingDir);
+      await rmDirRecursive(rollbackDir);
+    } else {
+      // On failure leave both dirs in place so an operator can investigate.
+      // The boot-time orphan-dir warning will surface them.
+      logger?.warn?.(
+        `[backup-store] Restore failed — staging dir at ${stagingDir} and rollback dir at ${rollbackDir} were left in place for inspection.`
+      );
+    }
+  }
+
+  return {
+    restored: restoredFiles,
+    rolledBack: !succeeded,
+    warnings,
+    manifest
+  };
+}
+
+async function findOrphanedRestoreDirs(dataRoot) {
+  let entries;
+  try {
+    entries = await fsp.readdir(dataRoot, { withFileTypes: true });
+  } catch (err) {
+    if (err && err.code === "ENOENT") return [];
+    throw err;
+  }
+  const out = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!entry.name.startsWith(".restore-staging-") && !entry.name.startsWith(".restore-rollback-")) {
+      continue;
+    }
+    const abs = path.join(dataRoot, entry.name);
+    let mtime = null;
+    try {
+      const st = await fsp.stat(abs);
+      mtime = st.mtime;
+    } catch {
+      // ignore
+    }
+    out.push({ name: entry.name, path: abs, mtime });
+  }
+  return out;
+}
+
+module.exports = {
+  BackupError,
+  MANIFEST_VERSION,
+  MANIFEST_ENTRY_PATH,
+  IN_SCOPE_FILES,
+  IN_SCOPE_SCHEMAS,
+  DIAGNOSTIC_SCHEMAS,
+  DEFAULT_TOTAL_UNCOMPRESSED_MAX_BYTES,
+  DEFAULT_PER_ENTRY_MAX_BYTES,
+  buildManifest,
+  createArchive,
+  validateArchive,
+  applyRestore,
+  findOrphanedRestoreDirs,
+  isPathSafe,
+  sha256OfBuffer,
+  sha256OfFile
+};

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -50,6 +50,10 @@ const OPTIONAL_SET_PREFIXES = Object.freeze({
 
 const DEFAULT_TOTAL_UNCOMPRESSED_MAX_BYTES = 256 * 1024 * 1024;
 const DEFAULT_PER_ENTRY_MAX_BYTES = 64 * 1024 * 1024;
+// Manifest is the metadata index; in practice a few KB even with hundreds
+// of provider files. Capping it at 4 MiB before buffering defends against
+// a zip-bomb that hides a huge manifest under a small compressed payload.
+const MANIFEST_MAX_UNCOMPRESSED_BYTES = 4 * 1024 * 1024;
 const ARCHIVE_PATH_PATTERN = /^[A-Za-z0-9._/-]+$/;
 
 class BackupError extends Error {
@@ -266,7 +270,9 @@ function createArchive({
   });
 
   archive.on("error", (err) => {
-    archive.emit("end");
+    // Don't emit a synthetic "end" here — consumers (e.g. the route)
+    // treat the real "end" event as success. Just destroy with the
+    // error and let the consumer's "error" listener handle the failure.
     archive.destroy(err);
   });
 
@@ -346,8 +352,25 @@ async function readManifest(zip) {
     zip.on("entry", (entry) => {
       if (entry.fileName === MANIFEST_ENTRY_PATH && !manifestEntry) {
         manifestEntry = entry;
+        // Cap before buffering. A malicious zip whose manifest claims a
+        // 500 MB uncompressed size would otherwise fully expand into
+        // memory before any later validation can return 413.
+        if (entry.uncompressedSize > MANIFEST_MAX_UNCOMPRESSED_BYTES) {
+          reject(new BackupError(
+            "MANIFEST_TOO_LARGE",
+            `manifest.json uncompressed size ${entry.uncompressedSize} exceeds the ${MANIFEST_MAX_UNCOMPRESSED_BYTES}-byte cap.`
+          ));
+          return;
+        }
         readEntryToBuffer(zip, entry)
           .then((buf) => {
+            if (buf.length > MANIFEST_MAX_UNCOMPRESSED_BYTES) {
+              reject(new BackupError(
+                "MANIFEST_TOO_LARGE",
+                `manifest.json read ${buf.length} bytes, exceeding the ${MANIFEST_MAX_UNCOMPRESSED_BYTES}-byte cap.`
+              ));
+              return;
+            }
             try {
               resolve(JSON.parse(buf.toString("utf8")));
             } catch (err) {
@@ -590,6 +613,7 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
   const stagingDir = await makeStagingDir(dataRoot, "staging");
   const rollbackDir = await makeStagingDir(dataRoot, "rollback");
   const restoredFiles = [];
+  const removedFiles = [];
   const stagedFiles = [];
   let zip;
   let succeeded = false;
@@ -643,9 +667,29 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
       }
     }
 
+    // Phase 2.5: replace-all semantics for INCLUDED optional roots. Walk
+    // each included optional-set root on disk; any file that's NOT in the
+    // archive (and therefore not in restorablePaths) gets queued for
+    // deletion alongside the swap, so restoring an older provider-
+    // inclusive backup actually replaces the live tree under
+    // data/providers/** instead of leaving newer commits intact.
+    // Deletions go through the same snapshot-then-rewind logic as swaps.
+    const removalQueue = [];
+    for (const optionalSet of manifest.optionalSets) {
+      const prefix = OPTIONAL_SET_PREFIXES[optionalSet];
+      if (!prefix) continue;
+      const rootAbs = path.join(projectRoot, prefix);
+      const liveFiles = await listFilesUnder(rootAbs, prefix.replace(/\/$/, ""));
+      for (const file of liveFiles) {
+        if (restorablePaths.has(file.archivePath)) continue;
+        removalQueue.push({ archivePath: file.archivePath });
+      }
+    }
+
     // Phase 3: snapshot existing files into the rollback dir, then swap
     // staged files into place. Each file is snapshot-then-swap individually
-    // so rollback can rewind by reversing the renames.
+    // so rollback can rewind by reversing the renames. removalQueue items
+    // share the same shape but skip the staged-into-live rename.
     //
     // We record the rewindable operation BEFORE the staged-into-live
     // rename. If that rename throws (transient FS error etc.), the live
@@ -676,6 +720,21 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
         await fsp.rename(staged.stagedAbs, livePath);
         restoredFiles.push(staged.archivePath);
       }
+      // Apply removals from optional roots (replace-all semantics).
+      for (const removal of removalQueue) {
+        const livePath = path.join(projectRoot, removal.archivePath);
+        const rolledPath = path.join(rollbackDir, removal.archivePath);
+        if (!(await fileExists(livePath))) continue;
+        await ensureParentDir(rolledPath);
+        await fsp.rename(livePath, rolledPath);
+        swapped.push({
+          archivePath: removal.archivePath,
+          livePath,
+          rolledPath,
+          hadPrior: true
+        });
+        removedFiles.push(removal.archivePath);
+      }
     } catch (err) {
       // Rewind: for each entry recorded, delete the (possibly partial)
       // live file and, if there was a prior copy, move it back from the
@@ -695,9 +754,14 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
         }
       }
       // Tag the error so callers can distinguish "validation failed
-      // before any on-disk mutation" from "we mutated, then rewound".
+      // before any on-disk mutation" from "we mutated, then rewound",
+      // and surface any partial-rewind warnings so the UI can prompt
+      // the operator for manual intervention.
       if (err && typeof err === "object") {
         err.rolledBackChanges = swapped.length > 0;
+        if (warnings.length > 0) {
+          err.warnings = warnings.slice();
+        }
       }
       throw err;
     }
@@ -720,6 +784,7 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
 
   return {
     restored: restoredFiles,
+    removed: removedFiles,
     rolledBack: !succeeded,
     warnings,
     manifest

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -195,17 +195,24 @@ async function buildManifest({
     });
   }
 
+  // Skip files that were already added above (in-scope or diagnostic
+  // schemas) so the provider/dictionary walks don't produce duplicate
+  // manifest entries — duplicates would conflict during restore staging.
+  const alreadyIncluded = new Set(files.map((entry) => entry.path));
+
   if (includeProviders) {
     optionalSets.push("providers");
     const providersRoot = path.join(dataRoot, "providers");
     const providerFiles = await listFilesUnder(providersRoot, "data/providers");
     for (const file of providerFiles) {
+      if (alreadyIncluded.has(file.archivePath)) continue;
       files.push({
         path: file.archivePath,
         bytes: await statBytes(file.absPath),
         sha256: await sha256OfFile(file.absPath),
         optionalSet: "providers"
       });
+      alreadyIncluded.add(file.archivePath);
     }
   }
 
@@ -214,12 +221,14 @@ async function buildManifest({
     const dictionariesRoot = path.join(dataRoot, "dictionaries");
     const dictFiles = await listFilesUnder(dictionariesRoot, "data/dictionaries");
     for (const file of dictFiles) {
+      if (alreadyIncluded.has(file.archivePath)) continue;
       files.push({
         path: file.archivePath,
         bytes: await statBytes(file.absPath),
         sha256: await sha256OfFile(file.absPath),
         optionalSet: "dictionaries"
       });
+      alreadyIncluded.add(file.archivePath);
     }
   }
 

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -747,6 +747,7 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
     zip = await openZip(archivePath);
     const entries = await listArchiveEntries(zip);
     const restorablePaths = new Set();
+    const diagnosticSchemaSet = new Set(DIAGNOSTIC_SCHEMAS);
     for (const entry of manifest.files) {
       // Only restore in-scope files and explicitly-included optional sets.
       if (IN_SCOPE_FILES.includes(entry.path)) {
@@ -761,6 +762,14 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
       // validator can't hand applyRestore an out-of-tree path.
       const requiredPrefix = OPTIONAL_SET_PREFIXES[entry.optionalSet];
       if (!requiredPrefix || !entry.path.startsWith(requiredPrefix)) continue;
+      // Diagnostic schemas live under the optional prefixes (e.g.
+      // data/providers/provider-import-manifest.schema.json under
+      // data/providers/) but are bundled as read-only artifacts —
+      // never restored. A crafted manifest tagging one with
+      // optionalSet="providers" must not be allowed to swap the
+      // live schema with archive contents and break future schema
+      // checks.
+      if (diagnosticSchemaSet.has(entry.path)) continue;
       restorablePaths.add(entry.path);
     }
     for (const entry of entries) {
@@ -798,14 +807,11 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
     // inclusive backup actually replaces the live tree under
     // data/providers/** instead of leaving newer commits intact.
     // Deletions go through the same snapshot-then-rewind logic as swaps.
-    // Diagnostic schemas (e.g. data/providers/provider-import-manifest.schema.json)
-    // live under an optional-set prefix but are intentionally NOT in
-    // restorablePaths — they're bundled in the archive as read-only
-    // metadata. Excluding them from the removal queue keeps the live
-    // schema file in place across restores; without this, every
-    // provider-inclusive restore would delete the diagnostic schema and
-    // break later schema checks/backups.
-    const diagnosticSchemaSet = new Set(DIAGNOSTIC_SCHEMAS);
+    // diagnosticSchemaSet is declared earlier (in the restorable-paths
+    // loop) so the same exclusion applies to both restore staging and
+    // optional-root prune. Diagnostic schemas live under an optional-set
+    // prefix but are bundled in the archive as read-only metadata; they
+    // never get restored and must survive a provider-inclusive restore.
     const removalQueue = [];
     for (const optionalSet of manifest.optionalSets) {
       const prefix = OPTIONAL_SET_PREFIXES[optionalSet];

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -180,7 +180,18 @@ async function buildManifest({
 
   for (const archivePath of IN_SCOPE_FILES) {
     const absPath = path.join(projectRoot, archivePath);
-    if (!(await fileExists(absPath))) continue;
+    if (!(await fileExists(absPath))) {
+      // In-scope files are documented as "always included". On a fresh
+      // node where the matching store hasn't loaded yet, the file may
+      // not exist. The route is responsible for warming each store
+      // before calling buildManifest, but we error here as a safety
+      // net so a partial manifest never silently ships.
+      throw new BackupError(
+        "INSCOPE_FILE_MISSING",
+        `Required in-scope file is missing: ${archivePath}. Ensure the matching store has loaded before requesting a backup.`,
+        { path: archivePath }
+      );
+    }
     const sha256 = await sha256OfFile(absPath);
     const bytes = await statBytes(absPath);
     const entry = { path: archivePath, bytes, sha256 };
@@ -259,7 +270,8 @@ function createArchive({
   projectRoot,
   includeProviders = false,
   includeDictionaries = false,
-  now = () => new Date()
+  now = () => new Date(),
+  manifest: precomputedManifest = null
 }) {
   if (!projectRoot) {
     throw new BackupError("INVALID_REQUEST", "projectRoot is required.");
@@ -277,7 +289,11 @@ function createArchive({
   });
 
   const builder = (async () => {
-    const manifest = await buildManifest({
+    // The route can pass in a manifest it already built (e.g. for the
+    // pre-stream byte-cap check) so we don't re-walk + re-hash every
+    // file. Without this, the export path doubles the FS IO + sha256
+    // work and the data lock is held twice as long.
+    const manifest = precomputedManifest || await buildManifest({
       projectRoot,
       includeProviders,
       includeDictionaries,

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -619,6 +619,11 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
           });
         }
       }
+      // Tag the error so callers can distinguish "validation failed
+      // before any on-disk mutation" from "we mutated, then rewound".
+      if (err && typeof err === "object") {
+        err.rolledBackChanges = swapped.length > 0;
+      }
       throw err;
     }
 

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -660,8 +660,19 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
 
   // Schema-drift guard: every manifest file with a `schema` block must have
   // its declared schema digest match the schema currently on disk.
+  // Reject unsafe schemaPaths BEFORE joining + reading. Without this,
+  // a malicious manifest could set schemaPath to '../../../../dev/zero'
+  // and trick sha256OfFile into hashing a special file outside
+  // projectRoot — hanging the restore while it holds the data lock.
   for (const entry of manifest.files) {
     if (!entry.schema) continue;
+    if (!isPathSafe(entry.schema.schemaPath)) {
+      throw new BackupError(
+        "PATH_UNSAFE",
+        `Archive schema reference rejected for unsafe path: ${entry.schema.schemaPath}`,
+        { schemaPath: entry.schema.schemaPath }
+      );
+    }
     const currentSchemaPath = path.join(projectRoot, entry.schema.schemaPath);
     if (!(await fileExists(currentSchemaPath))) {
       throw new BackupError(

--- a/lib/classes-store.js
+++ b/lib/classes-store.js
@@ -261,6 +261,12 @@ class ClassesStore {
     // Used by the backup-restore flow after data/classes.json is swapped —
     // the in-memory cache must not outlive the on-disk swap.
     await this.writeQueue.catch(() => {});
+    // Drain any in-flight load too — see LeaderboardStore.reload for the
+    // race that this guards against (pre-restore load finishing late and
+    // clobbering this.state with stale content).
+    if (this.loadPromise) {
+      await this.loadPromise.catch(() => {});
+    }
     this.state = null;
     this.loadPromise = null;
     return this.load();

--- a/lib/classes-store.js
+++ b/lib/classes-store.js
@@ -229,6 +229,10 @@ class ClassesStore {
         : DEFAULT_MAX_MEMBERS_PER_CLASS;
     this.logger = options.logger || console;
     this.now = typeof options.now === "function" ? options.now : () => new Date();
+    // Optional barrier; see LeaderboardStore for the rationale.
+    this.waitForDataMutationLock = typeof options.waitForDataMutationLock === "function"
+      ? options.waitForDataMutationLock
+      : null;
 
     this.state = null;
     this.loadPromise = null;
@@ -603,6 +607,12 @@ class ClassesStore {
 
   async #enqueueWrite(operation) {
     await this.load();
+    // Pause here if a backup/restore is holding the data-mutation lock.
+    // Without this, a handler that already passed the /api gate could
+    // queue a write that lands on top of the just-restored file.
+    if (this.waitForDataMutationLock) {
+      await this.waitForDataMutationLock();
+    }
     const run = async () => {
       // Snapshot live state so we can restore on persist failure. Without
       // this, a writeFile/rename failure leaves dirty in-memory state that

--- a/lib/classes-store.js
+++ b/lib/classes-store.js
@@ -252,6 +252,16 @@ class ClassesStore {
     return clone(this.state);
   }
 
+  async reload() {
+    // Drop the cached state so the next read pulls fresh content from disk.
+    // Used by the backup-restore flow after data/classes.json is swapped —
+    // the in-memory cache must not outlive the on-disk swap.
+    await this.writeQueue.catch(() => {});
+    this.state = null;
+    this.loadPromise = null;
+    return this.load();
+  }
+
   // Reads await the active write queue before snapshotting state. Without
   // this, a queued write that has run its mutator but is still inside
   // #persist() would expose its uncommitted in-memory mutations to a

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -424,7 +424,13 @@ class LeaderboardStore {
       return clone(this.state);
     }
     if (!this.loadPromise) {
-      this.loadPromise = this.#loadInternal();
+      // Clear the cached promise on rejection so a transient disk-read
+      // failure (e.g. immediately after a restore swap) doesn't wedge
+      // every future load() call. Same pattern ClassesStore uses.
+      this.loadPromise = this.#loadInternal().catch((err) => {
+        this.loadPromise = null;
+        throw err;
+      });
     }
     await this.loadPromise;
     return clone(this.state);

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -405,6 +405,14 @@ class LeaderboardStore {
       : DEFAULT_MAX_RESULTS_PER_PROFILE;
     this.logger = options.logger || console;
     this.now = typeof options.now === "function" ? options.now : () => new Date();
+    // Optional barrier: when set, every mutate call awaits this fn
+    // before queuing. Used by the backup/restore flow to pause
+    // in-flight handlers that already passed the /api gate but haven't
+    // started their write yet — without this they could persist
+    // pre-restore state over the just-swapped restored file.
+    this.waitForDataMutationLock = typeof options.waitForDataMutationLock === "function"
+      ? options.waitForDataMutationLock
+      : null;
 
     this.state = null;
     this.loadPromise = null;
@@ -438,6 +446,9 @@ class LeaderboardStore {
   }
 
   async replace(nextState) {
+    if (this.waitForDataMutationLock) {
+      await this.waitForDataMutationLock();
+    }
     return this.#enqueueWrite(async () => {
       const { state } = normalizeLeaderboardState(nextState, {
         maxProfiles: this.maxProfiles,
@@ -453,6 +464,9 @@ class LeaderboardStore {
   async mutate(mutator) {
     if (typeof mutator !== "function") {
       throw new Error("mutator must be a function.");
+    }
+    if (this.waitForDataMutationLock) {
+      await this.waitForDataMutationLock();
     }
 
     return this.#enqueueWrite(async () => {

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -422,6 +422,16 @@ class LeaderboardStore {
     return clone(this.state);
   }
 
+  async reload() {
+    // Drop the cached state so the next read pulls fresh content from disk.
+    // Used by the backup-restore flow after data/leaderboard.json is
+    // swapped — the in-memory cache must not outlive the on-disk swap.
+    await this.writeQueue.catch(() => {});
+    this.state = null;
+    this.loadPromise = null;
+    return this.load();
+  }
+
   async getSnapshot() {
     await this.load();
     return clone(this.state);

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -441,6 +441,15 @@ class LeaderboardStore {
     // Used by the backup-restore flow after data/leaderboard.json is
     // swapped — the in-memory cache must not outlive the on-disk swap.
     await this.writeQueue.catch(() => {});
+    // Drain any in-flight load too. Without this, a load that started
+    // before reload (still reading the pre-restore file) could finish
+    // AFTER reload's fresh load and clobber this.state with stale
+    // content. Whoever is awaiting that pre-load (e.g. an in-flight
+    // mutate) would then operate on stale state and persist over the
+    // freshly restored leaderboard.
+    if (this.loadPromise) {
+      await this.loadPromise.catch(() => {});
+    }
     this.state = null;
     this.loadPromise = null;
     return this.load();

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -452,9 +452,6 @@ class LeaderboardStore {
   }
 
   async replace(nextState) {
-    if (this.waitForDataMutationLock) {
-      await this.waitForDataMutationLock();
-    }
     return this.#enqueueWrite(async () => {
       const { state } = normalizeLeaderboardState(nextState, {
         maxProfiles: this.maxProfiles,
@@ -471,9 +468,8 @@ class LeaderboardStore {
     if (typeof mutator !== "function") {
       throw new Error("mutator must be a function.");
     }
-    if (this.waitForDataMutationLock) {
-      await this.waitForDataMutationLock();
-    }
+    // Barrier check now lives inside #enqueueWrite, after the load
+    // yield — see #enqueueWrite for the rationale.
 
     return this.#enqueueWrite(async () => {
       const draft = clone(this.state);
@@ -653,6 +649,17 @@ class LeaderboardStore {
 
   async #enqueueWrite(operation) {
     await this.load();
+    // Pause here if a backup/restore is holding the data-mutation lock.
+    // The mutate() public method also checks the barrier, but the gap
+    // between that check and #enqueueWrite's `await this.load()` lets
+    // an in-flight mutation that started with no cached state become
+    // invisible to drainStoreWriteQueues — the load yield gives the
+    // restore handler a chance to acquire the lock before this op
+    // chains onto writeQueue. Re-checking after load (matching
+    // ClassesStore/AdminJobsStore) closes that gap.
+    if (this.waitForDataMutationLock) {
+      await this.waitForDataMutationLock();
+    }
 
     const run = async () => operation();
     const next = this.writeQueue.then(run, run);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "CC0-1.0",
       "dependencies": {
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "archiver": "^7.0.1",
         "busboy": "^1.6.0",
         "compression": "^1.7.4",
@@ -22,8 +24,6 @@
         "@axe-core/playwright": "^4.11.1",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.49.1",
-        "ajv": "^8.18.0",
-        "ajv-formats": "^3.0.1",
         "esbuild": "^0.27.3",
         "eslint": "^10.0.0",
         "globals": "^17.3.0",
@@ -2012,7 +2012,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2029,7 +2028,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3762,7 +3760,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -3796,7 +3793,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5268,7 +5264,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6180,7 +6175,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,14 @@
       "version": "1.0.0",
       "license": "CC0-1.0",
       "dependencies": {
+        "archiver": "^7.0.1",
+        "busboy": "^1.6.0",
         "compression": "^1.7.4",
         "express": "^4.19.2",
         "express-rate-limit": "^8.2.1",
         "helmet": "^8.1.0",
-        "nspell": "^2.1.5"
+        "nspell": "^2.1.5",
+        "yauzl": "^3.3.0"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
@@ -78,7 +81,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1280,6 +1282,102 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1672,6 +1770,16 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -1852,6 +1960,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1871,7 +1991,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1944,7 +2063,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1954,7 +2072,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1980,6 +2097,87 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2003,6 +2201,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2018,6 +2222,20 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -2140,7 +2358,117 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2221,7 +2549,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2246,12 +2573,56 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2419,7 +2790,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2432,7 +2802,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2456,6 +2825,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/compressible": {
@@ -2554,6 +2939,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -2580,7 +2996,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2706,6 +3121,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2736,7 +3157,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2878,7 +3298,6 @@
       "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3198,6 +3617,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3253,7 +3699,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3318,6 +3763,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3446,6 +3897,34 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.5",
@@ -3673,7 +4152,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -3799,6 +4277,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3936,7 +4434,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3979,7 +4476,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3988,11 +4484,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4102,6 +4603,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest": {
@@ -4795,6 +5311,48 @@
         "node": ">=6"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4838,6 +5396,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5001,6 +5565,15 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5041,7 +5614,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5201,6 +5773,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5253,7 +5831,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5266,10 +5843,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -5340,7 +5945,6 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -5400,6 +6004,21 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -5500,6 +6119,52 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5666,7 +6331,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5679,7 +6343,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5831,6 +6494,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -5849,7 +6540,21 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5864,7 +6569,19 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6021,6 +6738,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -6034,6 +6772,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tmpl": {
@@ -6171,6 +6918,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -6218,7 +6971,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6255,6 +7007,24 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6335,6 +7105,28 @@
         "node": ">=12"
       }
     },
+    "node_modules/yauzl": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -6346,6 +7138,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "archiver": "^7.0.1",
     "busboy": "^1.6.0",
     "compression": "^1.7.4",
@@ -39,8 +41,6 @@
     "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.49.1",
-    "ajv": "^8.18.0",
-    "ajv-formats": "^3.0.1",
     "esbuild": "^0.27.3",
     "eslint": "^10.0.0",
     "globals": "^17.3.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,14 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "archiver": "^7.0.1",
+    "busboy": "^1.6.0",
     "compression": "^1.7.4",
     "express": "^4.19.2",
     "express-rate-limit": "^8.2.1",
     "helmet": "^8.1.0",
-    "nspell": "^2.1.5"
+    "nspell": "^2.1.5",
+    "yauzl": "^3.3.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -73,6 +73,21 @@ const runtimeLockedBodyEl = document.getElementById("runtimeLockedBody");
 const tabButtons = Array.from(document.querySelectorAll(".admin-tab"));
 const tabPanels = Array.from(document.querySelectorAll(".admin-slot"));
 
+const backupExportFormEl = document.getElementById("backupExportForm");
+const backupIncludeProvidersEl = document.getElementById("backupIncludeProviders");
+const backupIncludeDictionariesEl = document.getElementById("backupIncludeDictionaries");
+const backupExportBtnEl = document.getElementById("backupExportBtn");
+const backupExportStatusEl = document.getElementById("backupExportStatus");
+const backupRestoreFormEl = document.getElementById("backupRestoreForm");
+const backupRestoreFileEl = document.getElementById("backupRestoreFile");
+const backupRestorePreviewBtnEl = document.getElementById("backupRestorePreviewBtn");
+const backupRestoreStatusEl = document.getElementById("backupRestoreStatus");
+const backupRestoreDialogEl = document.getElementById("backupRestoreDialog");
+const backupRestorePreviewSummaryEl = document.getElementById("backupRestorePreviewSummary");
+const backupRestoreConfirmInputEl = document.getElementById("backupRestoreConfirmInput");
+const backupRestoreCancelBtnEl = document.getElementById("backupRestoreCancelBtn");
+const backupRestoreApplyBtnEl = document.getElementById("backupRestoreApplyBtn");
+
 const PROVIDER_IMPORT_SOURCE_TYPES = Object.freeze({
   REMOTE_FETCH: "remote-fetch",
   MANUAL_UPLOAD: "manual-upload"
@@ -1972,6 +1987,201 @@ if (refreshJobsBtnEl) {
   });
 }
 
+const RESTORE_CONFIRM_PHRASE = "RESTORE";
+const RESTORE_CONFIRM_HEADER = "x-admin-confirm";
+const RESTORE_CONFIRM_VALUE = "I-UNDERSTAND";
+let pendingRestoreFile = null;
+
+function formatBytes(bytes) {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes)) return "?";
+  const units = ["B", "KiB", "MiB", "GiB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function parseAttachmentFilename(disposition) {
+  if (typeof disposition !== "string") return null;
+  const match = disposition.match(/filename\*?=(?:UTF-8''|")?([^";]+)"?/i);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+async function fetchAdminBlob(path, init = {}) {
+  const headers = Object.assign({}, init.headers || {});
+  if (state.adminKey) headers["x-admin-key"] = state.adminKey;
+  const response = await fetch(path, Object.assign({}, init, { headers }));
+  if (!response.ok) {
+    let message = `${response.status} ${response.statusText}`;
+    try {
+      const text = await response.text();
+      message = text || message;
+    } catch {
+      // ignore
+    }
+    const err = new Error(message);
+    err.status = response.status;
+    throw err;
+  }
+  return response;
+}
+
+if (backupExportFormEl) {
+  backupExportFormEl.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!state.unlocked) {
+      setStatus(backupExportStatusEl, "Unlock the admin session first.", "admin-status-off");
+      return;
+    }
+    backupExportBtnEl.disabled = true;
+    setStatus(backupExportStatusEl, "Building backup archive…", "");
+    try {
+      const includeProviders = backupIncludeProvidersEl?.checked ? "true" : "false";
+      const includeDictionaries = backupIncludeDictionariesEl?.checked ? "true" : "false";
+      const url = `/api/admin/backup?includeProviders=${includeProviders}&includeDictionaries=${includeDictionaries}`;
+      const response = await fetchAdminBlob(url);
+      const blob = await response.blob();
+      const filename =
+        parseAttachmentFilename(response.headers.get("content-disposition"))
+        || `wordle-backup-${new Date().toISOString().replace(/[:.]/g, "-")}.zip`;
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(objectUrl);
+      setStatus(
+        backupExportStatusEl,
+        `Downloaded ${filename} (${formatBytes(blob.size)}).`,
+        "admin-status-ok"
+      );
+    } catch (err) {
+      setStatus(backupExportStatusEl, `Export failed: ${err.message}`, "admin-status-missing");
+    } finally {
+      backupExportBtnEl.disabled = false;
+    }
+  });
+}
+
+function renderBackupPreviewSummary(payload) {
+  if (!backupRestorePreviewSummaryEl) return;
+  const fileCount = Array.isArray(payload.files) ? payload.files.length : 0;
+  const total = formatBytes(payload.totalBytes);
+  const lines = [
+    `Manifest version: ${payload.manifestVersion}`,
+    `App version: ${payload.appVersion}`,
+    `Created: ${payload.createdAt}`,
+    `Node id: ${payload.nodeId}`,
+    `Files: ${fileCount} (${total} total)`
+  ];
+  backupRestorePreviewSummaryEl.textContent = lines.join("\n");
+}
+
+function resetRestoreDialog() {
+  if (backupRestoreConfirmInputEl) backupRestoreConfirmInputEl.value = "";
+  if (backupRestoreApplyBtnEl) backupRestoreApplyBtnEl.disabled = true;
+  if (backupRestorePreviewSummaryEl) backupRestorePreviewSummaryEl.textContent = "";
+  pendingRestoreFile = null;
+}
+
+if (backupRestoreFormEl) {
+  backupRestoreFormEl.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!state.unlocked) {
+      setStatus(backupRestoreStatusEl, "Unlock the admin session first.", "admin-status-off");
+      return;
+    }
+    const file = backupRestoreFileEl?.files?.[0];
+    if (!file) {
+      setStatus(backupRestoreStatusEl, "Select an archive file first.", "admin-status-missing");
+      return;
+    }
+    backupRestorePreviewBtnEl.disabled = true;
+    setStatus(backupRestoreStatusEl, "Validating archive…", "");
+    try {
+      const formData = new FormData();
+      formData.append("archive", file, file.name);
+      const response = await fetchAdminBlob("/api/admin/backup/preview", {
+        method: "POST",
+        body: formData
+      });
+      const payload = await response.json();
+      renderBackupPreviewSummary(payload);
+      pendingRestoreFile = file;
+      if (backupRestoreApplyBtnEl) backupRestoreApplyBtnEl.disabled = true;
+      if (backupRestoreConfirmInputEl) {
+        backupRestoreConfirmInputEl.value = "";
+        setTimeout(() => backupRestoreConfirmInputEl.focus(), 0);
+      }
+      if (backupRestoreDialogEl?.showModal) {
+        backupRestoreDialogEl.showModal();
+      } else if (backupRestoreDialogEl) {
+        backupRestoreDialogEl.setAttribute("open", "");
+      }
+      setStatus(backupRestoreStatusEl, "Preview ready.", "admin-status-ok");
+    } catch (err) {
+      setStatus(backupRestoreStatusEl, `Preview failed: ${err.message}`, "admin-status-missing");
+    } finally {
+      backupRestorePreviewBtnEl.disabled = false;
+    }
+  });
+}
+
+if (backupRestoreConfirmInputEl) {
+  backupRestoreConfirmInputEl.addEventListener("input", () => {
+    if (!backupRestoreApplyBtnEl) return;
+    backupRestoreApplyBtnEl.disabled =
+      backupRestoreConfirmInputEl.value.trim() !== RESTORE_CONFIRM_PHRASE;
+  });
+}
+
+if (backupRestoreCancelBtnEl) {
+  backupRestoreCancelBtnEl.addEventListener("click", () => {
+    resetRestoreDialog();
+    if (backupRestoreDialogEl?.close) backupRestoreDialogEl.close();
+    else backupRestoreDialogEl?.removeAttribute("open");
+  });
+}
+
+if (backupRestoreApplyBtnEl) {
+  backupRestoreApplyBtnEl.addEventListener("click", async () => {
+    if (backupRestoreConfirmInputEl?.value.trim() !== RESTORE_CONFIRM_PHRASE) return;
+    if (!pendingRestoreFile) return;
+    backupRestoreApplyBtnEl.disabled = true;
+    setStatus(backupRestoreStatusEl, "Applying restore…", "");
+    try {
+      const formData = new FormData();
+      formData.append("archive", pendingRestoreFile, pendingRestoreFile.name);
+      const response = await fetchAdminBlob("/api/admin/restore", {
+        method: "POST",
+        headers: { [RESTORE_CONFIRM_HEADER]: RESTORE_CONFIRM_VALUE },
+        body: formData
+      });
+      const payload = await response.json();
+      const failedReloads = (payload.reloads || []).filter((entry) => !entry.ok);
+      const filesRestored = payload.filesRestored ?? payload.restored?.length ?? 0;
+      let message = `Restore complete — ${filesRestored} file(s) restored.`;
+      let tone = "admin-status-ok";
+      if (failedReloads.length > 0) {
+        message += ` Caches partially reloaded; ${failedReloads.length} store(s) failed.`;
+        tone = "admin-status-missing";
+      }
+      setStatus(backupRestoreStatusEl, message, tone);
+    } catch (err) {
+      setStatus(backupRestoreStatusEl, `Restore failed: ${err.message}`, "admin-status-missing");
+    } finally {
+      resetRestoreDialog();
+      if (backupRestoreDialogEl?.close) backupRestoreDialogEl.close();
+      else backupRestoreDialogEl?.removeAttribute("open");
+    }
+  });
+}
+
 lockSessionBtnEl.addEventListener("click", () => {
   if (jobsRefreshTimer) {
     clearTimeout(jobsRefreshTimer);
@@ -2011,11 +2221,18 @@ lockSessionBtnEl.addEventListener("click", () => {
   if (classReportToEl) classReportToEl.value = "";
   if (classReportLangEl) classReportLangEl.value = "";
   if (classReportBomEl) classReportBomEl.checked = false;
+  if (backupRestoreFileEl) backupRestoreFileEl.value = "";
+  if (backupIncludeProvidersEl) backupIncludeProvidersEl.checked = false;
+  if (backupIncludeDictionariesEl) backupIncludeDictionariesEl.checked = false;
+  resetRestoreDialog();
+  if (backupRestoreDialogEl?.close && backupRestoreDialogEl.open) backupRestoreDialogEl.close();
   setStatus(profilesStatusEl, "");
   setStatus(profilesLimitsStatusEl, "");
   setStatus(classesStatusEl, "");
   setStatus(classDetailStatusEl, "");
   setStatus(classReportStatusEl, "");
+  setStatus(backupExportStatusEl, "");
+  setStatus(backupRestoreStatusEl, "");
   setStatus(workspaceStatusEl, "Session locked. Re-enter admin key to continue.", "admin-status-off");
   setStatus(unlockStatusEl, "");
   setStatus(jobsStatusEl, "", "");

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -83,6 +83,16 @@ const backupRestoreFileEl = document.getElementById("backupRestoreFile");
 const backupRestorePreviewBtnEl = document.getElementById("backupRestorePreviewBtn");
 const backupRestoreStatusEl = document.getElementById("backupRestoreStatus");
 const backupRestoreDialogEl = document.getElementById("backupRestoreDialog");
+const backupRestoreDialogFormEl = document.getElementById("backupRestoreDialogForm");
+if (backupRestoreDialogFormEl) {
+  // Helmet's CSP (script-src-attr 'none') blocks inline event handlers,
+  // so we wire the submit preventDefault here. Pressing Enter in the
+  // confirmation field would otherwise close the dialog and bypass the
+  // typed-confirmation gate.
+  backupRestoreDialogFormEl.addEventListener("submit", (event) => {
+    event.preventDefault();
+  });
+}
 const backupRestorePreviewSummaryEl = document.getElementById("backupRestorePreviewSummary");
 const backupRestoreConfirmInputEl = document.getElementById("backupRestoreConfirmInput");
 const backupRestoreCancelBtnEl = document.getElementById("backupRestoreCancelBtn");
@@ -2088,20 +2098,35 @@ function renderBackupPreviewSummary(payload) {
   if (!backupRestorePreviewSummaryEl) return;
   const fileCount = Array.isArray(payload.files) ? payload.files.length : 0;
   const total = formatBytes(payload.totalBytes);
-  const lines = [
-    `Manifest version: ${payload.manifestVersion}`,
-    `App version: ${payload.appVersion}`,
-    `Created: ${payload.createdAt}`,
-    `Node id: ${payload.nodeId}`,
-    `Files: ${fileCount} (${total} total)`
+  const rows = [
+    ["Manifest version", payload.manifestVersion],
+    ["App version", payload.appVersion],
+    ["Created", payload.createdAt],
+    ["Node id", payload.nodeId],
+    ["Files", `${fileCount} (${total} total)`]
   ];
-  backupRestorePreviewSummaryEl.textContent = lines.join("\n");
+  // Render as a definition list so the entries lay out one-per-row
+  // without depending on whitespace CSS for the line breaks. Plain
+  // textContent collapses newlines because the .message class
+  // doesn't set white-space: pre-wrap.
+  backupRestorePreviewSummaryEl.innerHTML = "";
+  const list = document.createElement("dl");
+  list.className = "backup-preview-summary";
+  for (const [label, value] of rows) {
+    const dt = document.createElement("dt");
+    dt.textContent = label;
+    const dd = document.createElement("dd");
+    dd.textContent = String(value);
+    list.appendChild(dt);
+    list.appendChild(dd);
+  }
+  backupRestorePreviewSummaryEl.appendChild(list);
 }
 
 function resetRestoreDialog() {
   if (backupRestoreConfirmInputEl) backupRestoreConfirmInputEl.value = "";
   if (backupRestoreApplyBtnEl) backupRestoreApplyBtnEl.disabled = true;
-  if (backupRestorePreviewSummaryEl) backupRestorePreviewSummaryEl.textContent = "";
+  if (backupRestorePreviewSummaryEl) backupRestorePreviewSummaryEl.innerHTML = "";
   pendingRestoreFile = null;
 }
 

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -2180,6 +2180,18 @@ if (backupRestoreApplyBtnEl) {
         tone = "admin-status-missing";
       }
       setStatus(backupRestoreStatusEl, message, tone);
+
+      // Refresh every loaded admin section so the in-memory client view
+      // matches the just-restored state. Run in parallel; failures here
+      // are logged via setStatus on the relevant section but don't block
+      // the restore success message.
+      await Promise.allSettled([
+        typeof loadProviders === "function" ? loadProviders({ announce: false }) : null,
+        typeof loadJobs === "function" ? loadJobs({ announce: false }) : null,
+        typeof loadRuntimeConfig === "function" ? loadRuntimeConfig({ announce: false }) : null,
+        typeof loadProfiles === "function" ? loadProfiles({ announce: false }) : null,
+        typeof loadClasses === "function" ? loadClasses({ announce: false }) : null
+      ].filter(Boolean));
     } catch (err) {
       setStatus(backupRestoreStatusEl, `Restore failed: ${err.message}`, "admin-status-missing");
     } finally {

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -2016,15 +2016,22 @@ function formatBytes(bytes) {
 
 function parseAttachmentFilename(disposition) {
   if (typeof disposition !== "string") return null;
-  const match = disposition.match(/filename\*?=(?:UTF-8''|")?([^";]+)"?/i);
-  if (!match) return null;
+  // Per RFC 6266, when both `filename` and `filename*` are present
+  // recipients SHOULD prefer `filename*` and ignore `filename`. The
+  // earlier regex matched whichever came first textually — which
+  // could pick a US-ASCII filename and ignore the UTF-8 form. Try
+  // filename* first; fall through to filename if it isn't there.
+  const starMatch = disposition.match(/filename\*=(?:UTF-8'')?"?([^";]+)"?/i);
+  const plainMatch = disposition.match(/filename=(?:UTF-8''|")?([^";]+)"?/i);
+  const captured = starMatch ? starMatch[1] : (plainMatch ? plainMatch[1] : null);
+  if (!captured) return null;
   // Headers from older servers may contain a literal % that isn't valid
   // percent-encoding. decodeURIComponent throws on those; fall back to
   // the raw matched value rather than breaking the whole download flow.
   try {
-    return decodeURIComponent(match[1]);
+    return decodeURIComponent(captured);
   } catch (_err) {
-    return match[1];
+    return captured;
   }
 }
 

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -2047,9 +2047,19 @@ if (backupExportFormEl) {
     backupExportBtnEl.disabled = true;
     setStatus(backupExportStatusEl, "Building backup archive…", "");
     try {
-      const includeProviders = backupIncludeProvidersEl?.checked ? "true" : "false";
-      const includeDictionaries = backupIncludeDictionariesEl?.checked ? "true" : "false";
-      const url = `/api/admin/backup?includeProviders=${includeProviders}&includeDictionaries=${includeDictionaries}`;
+      // Only set explicit `true` flags. Sending `false` would override
+      // server-side defaults like BACKUP_INCLUDE_PROVIDERS_DEFAULT and
+      // silently produce a narrower archive than the operator
+      // configured.
+      const params = new URLSearchParams();
+      if (backupIncludeProvidersEl?.checked) {
+        params.set("includeProviders", "true");
+      }
+      if (backupIncludeDictionariesEl?.checked) {
+        params.set("includeDictionaries", "true");
+      }
+      const query = params.toString();
+      const url = `/api/admin/backup${query ? `?${query}` : ""}`;
       const response = await fetchAdminBlob(url);
       const blob = await response.blob();
       const filename =

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -2047,19 +2047,17 @@ if (backupExportFormEl) {
     backupExportBtnEl.disabled = true;
     setStatus(backupExportStatusEl, "Building backup archive…", "");
     try {
-      // Only set explicit `true` flags. Sending `false` would override
-      // server-side defaults like BACKUP_INCLUDE_PROVIDERS_DEFAULT and
-      // silently produce a narrower archive than the operator
-      // configured.
-      const params = new URLSearchParams();
-      if (backupIncludeProvidersEl?.checked) {
-        params.set("includeProviders", "true");
-      }
-      if (backupIncludeDictionariesEl?.checked) {
-        params.set("includeDictionaries", "true");
-      }
-      const query = params.toString();
-      const url = `/api/admin/backup${query ? `?${query}` : ""}`;
+      // Send the explicit checkbox state every time. The UI is the
+      // operator's intent at the moment of export — they should be
+      // able to uncheck a box and see providers excluded even when the
+      // env sets BACKUP_INCLUDE_PROVIDERS_DEFAULT=true. Non-UI
+      // callers (curl/scripts) that omit the query param still get
+      // the env default.
+      const params = new URLSearchParams({
+        includeProviders: backupIncludeProvidersEl?.checked ? "true" : "false",
+        includeDictionaries: backupIncludeDictionariesEl?.checked ? "true" : "false"
+      });
+      const url = `/api/admin/backup?${params.toString()}`;
       const response = await fetchAdminBlob(url);
       const blob = await response.blob();
       const filename =

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -2035,10 +2035,18 @@ async function fetchAdminBlob(path, init = {}) {
   if (!response.ok) {
     let message = `${response.status} ${response.statusText}`;
     try {
-      const text = await response.text();
-      message = text || message;
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        const payload = await response.json();
+        if (payload && typeof payload.error === "string" && payload.error.trim()) {
+          message = payload.error.trim();
+        }
+      } else {
+        const text = await response.text();
+        if (text) message = text;
+      }
     } catch {
-      // ignore
+      // Body unreadable or not the shape we expected — fall back to status line.
     }
     const err = new Error(message);
     err.status = response.status;

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -2007,7 +2007,15 @@ function formatBytes(bytes) {
 function parseAttachmentFilename(disposition) {
   if (typeof disposition !== "string") return null;
   const match = disposition.match(/filename\*?=(?:UTF-8''|")?([^";]+)"?/i);
-  return match ? decodeURIComponent(match[1]) : null;
+  if (!match) return null;
+  // Headers from older servers may contain a literal % that isn't valid
+  // percent-encoding. decodeURIComponent throws on those; fall back to
+  // the raw matched value rather than breaking the whole download flow.
+  try {
+    return decodeURIComponent(match[1]);
+  } catch (_err) {
+    return match[1];
+  }
 }
 
 async function fetchAdminBlob(path, init = {}) {

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -565,10 +565,11 @@
             role="tabpanel"
             data-panel="data"
             aria-labelledby="admin-tab-data"
+            tabindex="0"
             hidden
           >
             <header class="admin-panel-header">
-              <h2>Data backup &amp; restore</h2>
+              <h3>Data backup &amp; restore</h3>
               <p class="muted">
                 Export the full state of this node as a versioned archive, or restore from a previous archive.
                 Restores are atomic: a failed apply leaves the node in its pre-restore state.
@@ -617,7 +618,11 @@
             </section>
 
             <dialog id="backupRestoreDialog" aria-labelledby="backupRestoreDialogTitle">
-              <form method="dialog" id="backupRestoreDialogForm">
+              <!-- No method="dialog": pressing Enter in the confirmation
+                   field would otherwise submit the form, close the dialog,
+                   and bypass the typed-confirmation gate. The apply button
+                   handler runs explicitly on click. -->
+              <form id="backupRestoreDialogForm" onsubmit="return false;">
                 <h3 id="backupRestoreDialogTitle">Confirm restore</h3>
                 <div id="backupRestorePreviewSummary" class="message"></div>
                 <p>

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -573,7 +573,7 @@
               <p class="muted">
                 Export the full state of this node as a versioned archive, or restore from a previous archive.
                 Restores are atomic: a failed apply leaves the node in its pre-restore state.
-                See <a href="/docs/backup-restore.md">docs/backup-restore.md</a> for the operator runbook.
+                See <code>docs/backup-restore.md</code> in the repo for the operator runbook.
               </p>
             </header>
 

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -597,8 +597,8 @@
               <p class="muted">
                 Upload an archive to preview its contents, then type
                 <code>RESTORE</code> in the confirmation dialog to apply it. The
-                running process reloads its caches automatically; restart-required
-                changes will be flagged in the response.
+                running process reloads its caches automatically; per-store
+                reload outcomes appear in the response.
               </p>
               <form id="backupRestoreForm" class="form-inline" enctype="multipart/form-data">
                 <label class="file-row">

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -621,8 +621,10 @@
               <!-- No method="dialog": pressing Enter in the confirmation
                    field would otherwise submit the form, close the dialog,
                    and bypass the typed-confirmation gate. The apply button
-                   handler runs explicitly on click. -->
-              <form id="backupRestoreDialogForm" onsubmit="return false;">
+                   handler runs explicitly on click. The submit
+                   preventDefault is wired via app.js (Helmet's
+                   script-src-attr 'none' blocks inline handlers). -->
+              <form id="backupRestoreDialogForm">
                 <h3 id="backupRestoreDialogTitle">Confirm restore</h3>
                 <div id="backupRestorePreviewSummary" class="message"></div>
                 <p>

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -132,6 +132,18 @@
             >
               Classes
             </button>
+            <button
+              id="admin-tab-data"
+              type="button"
+              class="ghost admin-tab"
+              data-tab="data"
+              role="tab"
+              aria-controls="admin-panel-data"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              Data
+            </button>
           </nav>
 
           <section
@@ -545,6 +557,102 @@
               <div id="classReportStatus" class="message" role="status" aria-live="polite"></div>
               <div id="classReportRendered" class="admin-table-wrap"></div>
             </section>
+          </section>
+
+          <section
+            id="admin-panel-data"
+            class="admin-slot hidden"
+            role="tabpanel"
+            data-panel="data"
+            aria-labelledby="admin-tab-data"
+            hidden
+          >
+            <header class="admin-panel-header">
+              <h2>Data backup &amp; restore</h2>
+              <p class="muted">
+                Export the full state of this node as a versioned archive, or restore from a previous archive.
+                Restores are atomic: a failed apply leaves the node in its pre-restore state.
+                See <a href="/docs/backup-restore.md">docs/backup-restore.md</a> for the operator runbook.
+              </p>
+            </header>
+
+            <section class="admin-subpanel">
+              <h3>Export</h3>
+              <form id="backupExportForm" class="form-inline">
+                <label class="checkbox-row">
+                  <input type="checkbox" id="backupIncludeProviders" />
+                  Include provider artifacts (data/providers/**)
+                </label>
+                <label class="checkbox-row">
+                  <input type="checkbox" id="backupIncludeDictionaries" />
+                  Include dictionaries (data/dictionaries/**)
+                </label>
+                <button type="submit" id="backupExportBtn">Download backup archive</button>
+              </form>
+              <div id="backupExportStatus" class="message" role="status" aria-live="polite"></div>
+            </section>
+
+            <section class="admin-subpanel">
+              <h3>Restore</h3>
+              <p class="muted">
+                Upload an archive to preview its contents, then type
+                <code>RESTORE</code> in the confirmation dialog to apply it. The
+                running process reloads its caches automatically; restart-required
+                changes will be flagged in the response.
+              </p>
+              <form id="backupRestoreForm" class="form-inline" enctype="multipart/form-data">
+                <label class="file-row">
+                  <span>Archive (.zip)</span>
+                  <input
+                    type="file"
+                    id="backupRestoreFile"
+                    name="archive"
+                    accept=".zip,application/zip"
+                    required
+                  />
+                </label>
+                <button type="submit" id="backupRestorePreviewBtn">Preview restore</button>
+              </form>
+              <div id="backupRestoreStatus" class="message" role="status" aria-live="polite"></div>
+            </section>
+
+            <dialog id="backupRestoreDialog" aria-labelledby="backupRestoreDialogTitle">
+              <form method="dialog" id="backupRestoreDialogForm">
+                <h3 id="backupRestoreDialogTitle">Confirm restore</h3>
+                <div id="backupRestorePreviewSummary" class="message"></div>
+                <p>
+                  Type <code>RESTORE</code> below to enable the apply button. This
+                  will replace every in-scope file under <code>data/</code> on this
+                  node and cannot be undone without re-uploading a prior backup.
+                </p>
+                <label class="form-inline">
+                  <span>Confirmation</span>
+                  <input
+                    type="text"
+                    id="backupRestoreConfirmInput"
+                    autocomplete="off"
+                    autocapitalize="characters"
+                  />
+                </label>
+                <menu>
+                  <button
+                    type="button"
+                    value="cancel"
+                    id="backupRestoreCancelBtn"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    value="apply"
+                    id="backupRestoreApplyBtn"
+                    disabled
+                  >
+                    Apply restore
+                  </button>
+                </menu>
+              </form>
+            </dialog>
           </section>
 
           <div id="workspaceStatus" class="message" role="status" aria-live="polite"></div>

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -86,6 +86,7 @@ function createAdminRouter(deps) {
     appConfigStore,
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
+    providerImportEnqueueActiveRef,
     dataMutationLockRef,
     restoreInProgressRef,
     waitForDataMutationLock,
@@ -609,7 +610,14 @@ function createAdminRouter(deps) {
       }
     }
 
-    // Async path: enqueue job
+    // Async path: enqueue job. Claim the enqueue slot synchronously
+    // so a restore that fires during the staging+enqueue window can't
+    // race past us — the restore busy check observes
+    // providerImportEnqueueActiveRef and will 409. The flag clears in
+    // the finally below regardless of success/failure.
+    if (providerImportEnqueueActiveRef) {
+      providerImportEnqueueActiveRef.value = true;
+    }
     let queuedJob = null;
     let stagedManualUpload = null;
     try {
@@ -638,7 +646,16 @@ function createAdminRouter(deps) {
         await adminJobsStore.markFailed(queuedJob.id, formatProviderJobError(err)).catch(() => {});
       }
       await cleanupManualUploadStaging(stagedManualUpload).catch(() => {});
+      if (providerImportEnqueueActiveRef) {
+        providerImportEnqueueActiveRef.value = false;
+      }
       return providerAdminError(res, err instanceof StatsApiError ? err : mapProviderPipelineError(err));
+    }
+    // Job is durably enqueued; release the enqueue guard. The queue
+    // starter below claims providerImportQueueActiveRef before
+    // processing the job.
+    if (providerImportEnqueueActiveRef) {
+      providerImportEnqueueActiveRef.value = false;
     }
 
     startProviderImportQueueIfNeeded().catch((err) => {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -87,6 +87,7 @@ function createAdminRouter(deps) {
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     dataMutationLockRef,
+    restoreInProgressRef,
     waitForDataMutationLock,
     buildRuntimeConfigResponse,
     applyRuntimeConfig,
@@ -559,6 +560,7 @@ function createAdminRouter(deps) {
         providerImportQueueActiveRef.value
         || providerImportSyncActiveRef.value
         || dataMutationLockRef?.value
+        || restoreInProgressRef?.value
       ) {
         return providerAdminError(
           res,

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -555,18 +555,32 @@ function createAdminRouter(deps) {
       return providerAdminError(res, err);
     }
 
+    // Refuse to start (or enqueue) any import while a restore is in
+    // flight. The async path below would otherwise persist a job into
+    // data/admin-jobs.json during the restore upload window; the
+    // restore would then overwrite that file with the archive's
+    // contents and the just-enqueued job (plus any staged manual
+    // upload) would vanish.
+    if (dataMutationLockRef?.value || restoreInProgressRef?.value) {
+      return providerAdminError(
+        res,
+        new StatsApiError(
+          409,
+          "A backup or restore is currently running; provider imports are paused. Retry once it completes."
+        )
+      );
+    }
+
     if (!importAsync) {
       if (
         providerImportQueueActiveRef.value
         || providerImportSyncActiveRef.value
-        || dataMutationLockRef?.value
-        || restoreInProgressRef?.value
       ) {
         return providerAdminError(
           res,
           new StatsApiError(
             409,
-            "Another admin operation (import or restore) is currently running. Retry with async=true or wait for completion."
+            "Another import is currently running. Retry with async=true or wait for completion."
           )
         );
       }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -86,7 +86,7 @@ function createAdminRouter(deps) {
     appConfigStore,
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
-    restoreActiveRef,
+    dataMutationLockRef,
     buildRuntimeConfigResponse,
     applyRuntimeConfig,
     buildImportQueueSummary,
@@ -548,7 +548,7 @@ function createAdminRouter(deps) {
       if (
         providerImportQueueActiveRef.value
         || providerImportSyncActiveRef.value
-        || restoreActiveRef?.value
+        || dataMutationLockRef?.value
       ) {
         return providerAdminError(
           res,

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -89,7 +89,7 @@ function createAdminRouter(deps) {
     providerImportEnqueueActiveRef,
     dataMutationLockRef,
     restoreInProgressRef,
-    waitForDataMutationLock,
+    claimDirectDataWriteSlot,
     buildRuntimeConfigResponse,
     applyRuntimeConfig,
     buildImportQueueSummary,
@@ -362,16 +362,16 @@ function createAdminRouter(deps) {
   });
 
   router.put("/api/admin/runtime-config", async (req, res) => {
+    // Atomic claim: wait for the data-mutation lock, then bump the
+    // direct-write counter under one synchronous tick so a restore
+    // can't race in between our lock-wait and the cap validation +
+    // persist. Restore observes the counter and 409s while we hold
+    // the slot. The slot is released in the finally below regardless
+    // of success/failure.
+    const releaseSlot = typeof claimDirectDataWriteSlot === "function"
+      ? await claimDirectDataWriteSlot()
+      : (() => {});
     try {
-      // Honor the data-mutation lock at the very start so the cap
-      // validations below see the same leaderboard the handler will
-      // eventually persist against. Without this, a PUT that arrived
-      // during a restore could validate against the pre-restore
-      // snapshot, wait at the barrier, then persist a cap that's
-      // smaller than the just-restored profile count.
-      if (typeof waitForDataMutationLock === "function") {
-        await waitForDataMutationLock();
-      }
       const requestedManualUploadMaxBytes = req.body?.overrides?.limits?.providerManualMaxFileBytes;
       if (requestedManualUploadMaxBytes !== undefined) {
         const parsedRequestedMaxBytes = Number(requestedManualUploadMaxBytes);
@@ -458,6 +458,8 @@ function createAdminRouter(deps) {
       }
       console.error("Runtime config update failed.", err);
       return res.status(503).json({ error: "Runtime config update failed right now. Try again soon." });
+    } finally {
+      releaseSlot();
     }
   });
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -735,7 +735,7 @@ function createAdminRouter(deps) {
     }
   });
 
-  router.post("/api/admin/providers/:variant/enable", (req, res) => {
+  router.post("/api/admin/providers/:variant/enable", async (req, res) => {
     let variant;
     try {
       variant = parseProviderVariant(req.params.variant);
@@ -750,6 +750,14 @@ function createAdminRouter(deps) {
       return providerAdminError(res, err);
     }
 
+    // Claim the direct-write slot before persisting the toggle. The
+    // upsert writes data/languages.json, which a restore will swap
+    // out from underneath any unbarrier-ed write. Without this, an
+    // enable that lands during a restore upload window would 200,
+    // then be silently overwritten by the archive's languages.json.
+    const releaseSlot = typeof claimDirectDataWriteSlot === "function"
+      ? await claimDirectDataWriteSlot()
+      : (() => {});
     try {
       const paths = buildProviderArtifactPaths(variant, commit);
       const minLength = PROVIDER_MIN_LENGTH;
@@ -785,10 +793,12 @@ function createAdminRouter(deps) {
       });
     } catch (err) {
       return providerAdminError(res, mapRegistryErrorToStats(err));
+    } finally {
+      releaseSlot();
     }
   });
 
-  router.post("/api/admin/providers/:variant/disable", (req, res) => {
+  router.post("/api/admin/providers/:variant/disable", async (req, res) => {
     let variant;
     try {
       variant = parseProviderVariant(req.params.variant);
@@ -796,6 +806,12 @@ function createAdminRouter(deps) {
       return providerAdminError(res, err);
     }
 
+    // Same direct-write-slot rationale as /enable above: the
+    // setLanguageEnabledSync call writes data/languages.json and must
+    // be serialised against a concurrent restore.
+    const releaseSlot = typeof claimDirectDataWriteSlot === "function"
+      ? await claimDirectDataWriteSlot()
+      : (() => {});
     try {
       const snapshot = languageRegistryStore.setLanguageEnabledSync(variant, false);
       rebuildLanguageRuntimeCatalog();
@@ -810,6 +826,8 @@ function createAdminRouter(deps) {
       });
     } catch (err) {
       return providerAdminError(res, mapRegistryErrorToStats(err));
+    } finally {
+      releaseSlot();
     }
   });
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -361,6 +361,15 @@ function createAdminRouter(deps) {
 
   router.put("/api/admin/runtime-config", async (req, res) => {
     try {
+      // Honor the data-mutation lock at the very start so the cap
+      // validations below see the same leaderboard the handler will
+      // eventually persist against. Without this, a PUT that arrived
+      // during a restore could validate against the pre-restore
+      // snapshot, wait at the barrier, then persist a cap that's
+      // smaller than the just-restored profile count.
+      if (typeof waitForDataMutationLock === "function") {
+        await waitForDataMutationLock();
+      }
       const requestedManualUploadMaxBytes = req.body?.overrides?.limits?.providerManualMaxFileBytes;
       if (requestedManualUploadMaxBytes !== undefined) {
         const parsedRequestedMaxBytes = Number(requestedManualUploadMaxBytes);
@@ -416,11 +425,6 @@ function createAdminRouter(deps) {
       // Snapshot the current overrides so a failed normalize can roll back
       // both disk and in-memory state, keeping GET /api/admin/runtime-config
       // honest about what the store is actually enforcing.
-      // Honor the data-mutation lock: a handler past the gate could
-      // otherwise write data/app-config.json on top of just-restored bytes.
-      if (typeof waitForDataMutationLock === "function") {
-        await waitForDataMutationLock();
-      }
       const previousOverrides = appConfigStore.getOverridesSync();
       const nextState = appConfigStore.replaceOverridesSync(req.body?.overrides || {});
       try {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -86,6 +86,7 @@ function createAdminRouter(deps) {
     appConfigStore,
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
+    restoreActiveRef,
     buildRuntimeConfigResponse,
     applyRuntimeConfig,
     buildImportQueueSummary,
@@ -544,12 +545,16 @@ function createAdminRouter(deps) {
     }
 
     if (!importAsync) {
-      if (providerImportQueueActiveRef.value || providerImportSyncActiveRef.value) {
+      if (
+        providerImportQueueActiveRef.value
+        || providerImportSyncActiveRef.value
+        || restoreActiveRef?.value
+      ) {
         return providerAdminError(
           res,
           new StatsApiError(
             409,
-            "Another queued import is currently running. Retry with async=true or wait for completion."
+            "Another admin operation (import or restore) is currently running. Retry with async=true or wait for completion."
           )
         );
       }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -87,6 +87,7 @@ function createAdminRouter(deps) {
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     dataMutationLockRef,
+    waitForDataMutationLock,
     buildRuntimeConfigResponse,
     applyRuntimeConfig,
     buildImportQueueSummary,
@@ -415,6 +416,11 @@ function createAdminRouter(deps) {
       // Snapshot the current overrides so a failed normalize can roll back
       // both disk and in-memory state, keeping GET /api/admin/runtime-config
       // honest about what the store is actually enforcing.
+      // Honor the data-mutation lock: a handler past the gate could
+      // otherwise write data/app-config.json on top of just-restored bytes.
+      if (typeof waitForDataMutationLock === "function") {
+        await waitForDataMutationLock();
+      }
       const previousOverrides = appConfigStore.getOverridesSync();
       const nextState = appConfigStore.replaceOverridesSync(req.body?.overrides || {});
       try {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -127,6 +127,16 @@ function createAdminRouter(deps) {
     getLocalDateString
   } = deps;
 
+  // Required dep — the toggle and runtime-config handlers depend on
+  // it to close the restore/direct-write TOCTOU. The earlier defensive
+  // `typeof === "function"` fallbacks would have degraded silently to
+  // a no-op release fn if a stale server.js failed to inject this,
+  // re-introducing the very race we documented. Fail loudly at wiring
+  // time so the bug surfaces in tests, not in production under load.
+  if (typeof claimDirectDataWriteSlot !== "function") {
+    throw new TypeError("createAdminRouter: claimDirectDataWriteSlot dep is required.");
+  }
+
   const router = express.Router();
 
   router.get("/admin", (req, res) => {
@@ -368,9 +378,7 @@ function createAdminRouter(deps) {
     // persist. Restore observes the counter and 409s while we hold
     // the slot. The slot is released in the finally below regardless
     // of success/failure.
-    const releaseSlot = typeof claimDirectDataWriteSlot === "function"
-      ? await claimDirectDataWriteSlot()
-      : (() => {});
+    const releaseSlot = await claimDirectDataWriteSlot();
     try {
       const requestedManualUploadMaxBytes = req.body?.overrides?.limits?.providerManualMaxFileBytes;
       if (requestedManualUploadMaxBytes !== undefined) {
@@ -755,9 +763,7 @@ function createAdminRouter(deps) {
     // out from underneath any unbarrier-ed write. Without this, an
     // enable that lands during a restore upload window would 200,
     // then be silently overwritten by the archive's languages.json.
-    const releaseSlot = typeof claimDirectDataWriteSlot === "function"
-      ? await claimDirectDataWriteSlot()
-      : (() => {});
+    const releaseSlot = await claimDirectDataWriteSlot();
     try {
       const paths = buildProviderArtifactPaths(variant, commit);
       const minLength = PROVIDER_MIN_LENGTH;
@@ -809,9 +815,7 @@ function createAdminRouter(deps) {
     // Same direct-write-slot rationale as /enable above: the
     // setLanguageEnabledSync call writes data/languages.json and must
     // be serialised against a concurrent restore.
-    const releaseSlot = typeof claimDirectDataWriteSlot === "function"
-      ? await claimDirectDataWriteSlot()
-      : (() => {});
+    const releaseSlot = await claimDirectDataWriteSlot();
     try {
       const snapshot = languageRegistryStore.setLanguageEnabledSync(variant, false);
       rebuildLanguageRuntimeCatalog();

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -513,6 +513,21 @@ function createBackupRouter(deps) {
 
     logEvent(req, "backup.restore.start", { bytes: upload.bytes, originalName: upload.originalName });
 
+    // Warm every in-scope store before phase 3 starts. If a store
+    // hasn't loaded yet (cold cache on a fresh process), a GET-side
+    // read fired during the brief rename gap (livePath momentarily
+    // absent between snapshot-rename and staged-rename) would
+    // otherwise see ENOENT and persist default state on top of the
+    // restore. Each load is idempotent. Failure is non-fatal — the
+    // restore can still proceed; warm is just a defense.
+    try {
+      await warmInScopeStores();
+    } catch (warmErr) {
+      console.warn(
+        `[admin] Pre-restore warm of in-scope stores failed: ${warmErr?.message || String(warmErr)}`
+      );
+    }
+
     // Recheck the provider-import refs after the upload window. Even
     // though restoreInProgressRef has been claimed since the busy
     // check, a provider import that started AFTER restoreInProgressRef

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -364,7 +364,11 @@ function createBackupRouter(deps) {
       logEvent(req, "backup.restore.rollback", { code: err?.code, error: err?.message });
       const status = backupErrorStatus(err);
       const body = backupErrorBody(err);
-      body.rolledBackOnError = true;
+      // True only when the failure happened after we'd started swapping
+      // files into place; pre-apply validation failures (malformed zip,
+      // schema drift, etc.) didn't mutate anything, so the flag stays
+      // false to avoid misleading operators.
+      body.rolledBackOnError = err?.rolledBackChanges === true;
       return res.status(status).json(body);
     } finally {
       restoreActiveRef.value = false;

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -7,6 +7,7 @@ const Busboy = require("busboy");
 
 const {
   BackupError,
+  buildManifest,
   createArchive,
   validateArchive,
   applyRestore
@@ -212,6 +213,32 @@ function createBackupRouter(deps) {
     const includeProviders = parseBoolFlag(req.query.includeProviders, backupIncludeProvidersDefault);
     const includeDictionaries = parseBoolFlag(req.query.includeDictionaries, false);
     logEvent(req, "backup.create", { includeProviders, includeDictionaries });
+
+    // Pre-check uncompressed total size before piping. Without this, an
+    // export of an over-cap data tree would stream past the operator's
+    // configured limit; for the import path, busboy guards uploads.
+    let manifest;
+    try {
+      manifest = await buildManifest({
+        projectRoot,
+        includeProviders,
+        includeDictionaries
+      });
+    } catch (err) {
+      logEvent(req, "backup.create.error", { error: err?.message || String(err) });
+      return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
+    }
+    const totalBytes = manifest.files.reduce((sum, entry) => sum + entry.bytes, 0);
+    if (totalBytes > backupMaxBytes) {
+      logEvent(req, "backup.create.too-large", { totalBytes, cap: backupMaxBytes });
+      return res.status(413).json({
+        error: `Archive uncompressed size ${totalBytes} bytes exceeds the cap of ${backupMaxBytes} bytes. ` +
+          "Disable optional sets, raise BACKUP_MAX_BYTES, or split the export.",
+        code: "ARCHIVE_TOO_LARGE",
+        totalBytes,
+        cap: backupMaxBytes
+      });
+    }
 
     const stamp = safeFilenameTimestamp();
     const nodeId = await readNodeIdSafe(projectRoot);

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -250,7 +250,10 @@ function createBackupRouter(deps) {
   });
 
   // POST /api/admin/backup/preview
-  router.post("/api/admin/backup/preview", limit, async (req, res) => {
+  // Not gated by the strict backup rate limiter: preview is idempotent
+  // and read-only, and the normal UI flow is preview-then-apply within
+  // a few seconds. The admin write rate limiter still applies.
+  router.post("/api/admin/backup/preview", async (req, res) => {
     let upload;
     try {
       upload = await receiveUpload(req, {

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -198,10 +198,25 @@ function createBackupRouter(deps) {
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     dataMutationLockRef,
+    restoreInProgressRef,
     backupMaxBytes,
     backupIncludeProvidersDefault,
     backupRateLimiter
   } = deps;
+
+  // Touch every in-scope store so its file exists on disk before
+  // buildManifest runs. On a fresh node where a store hasn't been read
+  // yet, its data file doesn't exist; without this, buildManifest
+  // would throw INSCOPE_FILE_MISSING. Each store's load() / loadSync()
+  // is idempotent and creates the file with its default state on first
+  // call.
+  async function warmInScopeStores() {
+    if (leaderboardStore?.load) await leaderboardStore.load();
+    if (adminJobsStore?.load) await adminJobsStore.load();
+    if (classesStore?.load) await classesStore.load();
+    if (appConfigStore?.loadSync) appConfigStore.loadSync();
+    if (languageRegistryStore?.loadSync) languageRegistryStore.loadSync();
+  }
 
   // Wait for every async store's write queue to drain. Called AFTER
   // dataMutationLockRef is set (so the /api gate has already started
@@ -245,6 +260,7 @@ function createBackupRouter(deps) {
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
       || dataMutationLockRef?.value
+      || restoreInProgressRef?.value
     ) {
       return res.status(409).json({
         error: "Another admin operation is in flight; retry shortly.",
@@ -258,6 +274,11 @@ function createBackupRouter(deps) {
     };
 
     try {
+      // Make sure every in-scope store's file exists on disk before
+      // hashing. On a fresh node, an unread store's data file may not
+      // exist yet — buildManifest would otherwise throw.
+      await warmInScopeStores();
+
       // Drain in-flight writers that already passed the gate before we
       // took the lock. Without this, an in-progress leaderboard mutation
       // could complete its rename mid-build and produce an archive
@@ -300,10 +321,14 @@ function createBackupRouter(deps) {
 
       let archive;
       try {
+        // Reuse the manifest we just built for the size check so
+        // createArchive doesn't re-walk and re-hash every file under
+        // the lock.
         const result = createArchive({
           projectRoot,
           includeProviders,
-          includeDictionaries
+          includeDictionaries,
+          manifest
         });
         archive = result.archive;
       } catch (err) {
@@ -398,20 +423,25 @@ function createBackupRouter(deps) {
         code: "RESTORE_CONFIRM_MISSING"
       });
     }
-    // Atomic check-and-set: must be synchronous (no await between the
-    // check and the assignment) so two simultaneous requests can't both
-    // pass the check before either one sets the flag.
+    // Atomic check-and-set for single-flight: claims the restore slot
+    // synchronously so two simultaneous requests can't both proceed.
+    // restoreInProgressRef is separate from dataMutationLockRef — we
+    // don't take the data-mutation lock yet because that would hold the
+    // /api gate closed for the full upload duration (potentially many
+    // seconds for large archives over slow connections). The data lock
+    // is acquired later, right before the actual swap.
     if (
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
       || dataMutationLockRef?.value
+      || restoreInProgressRef?.value
     ) {
       return res.status(409).json({
         error: "Another admin operation is in flight; retry shortly.",
         code: "RESTORE_BUSY"
       });
     }
-    dataMutationLockRef.value = true;
+    restoreInProgressRef.value = true;
 
     let upload;
     try {
@@ -420,11 +450,16 @@ function createBackupRouter(deps) {
         tempDir: uploadsTempDir
       });
     } catch (err) {
-      dataMutationLockRef.value = false;
+      restoreInProgressRef.value = false;
       return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
     }
 
     logEvent(req, "backup.restore.start", { bytes: upload.bytes, originalName: upload.originalName });
+
+    // NOW take the data-mutation lock — upload is done, we're about to
+    // start touching live data/. Other /api mutations are 503'd from
+    // here until the apply + reload completes.
+    dataMutationLockRef.value = true;
 
     try {
       // Drain in-flight writers that already passed the gate before we
@@ -480,6 +515,7 @@ function createBackupRouter(deps) {
       return res.status(status).json(body);
     } finally {
       dataMutationLockRef.value = false;
+      restoreInProgressRef.value = false;
       try {
         await fsp.rm(upload.tempPath, { force: true });
       } catch {

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -70,12 +70,18 @@ function backupErrorBody(err) {
   return body;
 }
 
-function parseBoolFlag(value, defaultValue) {
+function parseBoolFlag(value, defaultValue, fieldName) {
   if (value === undefined) return defaultValue;
-  const normalized = String(value).toLowerCase();
+  const normalized = String(value).trim().toLowerCase();
   if (normalized === "true") return true;
   if (normalized === "false") return false;
-  return defaultValue;
+  // Reject anything that isn't an explicit boolean — silently
+  // defaulting on a typo would silently exclude providers/dictionaries
+  // from the backup with no signal to the operator.
+  throw new BackupError(
+    "INVALID_REQUEST",
+    `${fieldName || "boolean flag"} must be 'true' or 'false'.`
+  );
 }
 
 function safeFilenameTimestamp(d = new Date()) {
@@ -131,8 +137,20 @@ async function receiveUpload(req, { maxBytes, tempDir }) {
     let bytesWritten = 0;
     let writeStream = null;
     let truncated = false;
+    // Once the promise resolves (caller has the tempPath and is using
+    // it), late events from busboy/writeStream must not delete the
+    // file. Track whether we've settled so cleanupAndReject becomes a
+    // no-op after success.
+    let settled = false;
 
+    const settleResolve = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
     const cleanupAndReject = async (err) => {
+      if (settled) return;
+      settled = true;
       try {
         if (writeStream && !writeStream.destroyed) writeStream.destroy();
         await fsp.rm(tempPath, { force: true });
@@ -170,7 +188,7 @@ async function receiveUpload(req, { maxBytes, tempDir }) {
           ));
           return;
         }
-        resolve({ tempPath, bytes: bytesWritten, originalName });
+        settleResolve({ tempPath, bytes: bytesWritten, originalName });
       });
     });
 
@@ -200,6 +218,7 @@ function createBackupRouter(deps) {
     providerImportEnqueueActiveRef,
     dataMutationLockRef,
     restoreInProgressRef,
+    directDataWriteActiveRef,
     backupMaxBytes,
     backupIncludeProvidersDefault,
     backupRateLimiter
@@ -248,8 +267,22 @@ function createBackupRouter(deps) {
 
   // GET /api/admin/backup
   router.get("/api/admin/backup", limit, async (req, res) => {
-    const includeProviders = parseBoolFlag(req.query.includeProviders, backupIncludeProvidersDefault);
-    const includeDictionaries = parseBoolFlag(req.query.includeDictionaries, false);
+    let includeProviders;
+    let includeDictionaries;
+    try {
+      includeProviders = parseBoolFlag(
+        req.query.includeProviders,
+        backupIncludeProvidersDefault,
+        "includeProviders"
+      );
+      includeDictionaries = parseBoolFlag(
+        req.query.includeDictionaries,
+        false,
+        "includeDictionaries"
+      );
+    } catch (err) {
+      return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
+    }
     logEvent(req, "backup.create", { includeProviders, includeDictionaries });
 
     // Take the data-mutation lock for the entire export. Without it,
@@ -263,6 +296,7 @@ function createBackupRouter(deps) {
       || providerImportEnqueueActiveRef?.value
       || dataMutationLockRef?.value
       || restoreInProgressRef?.value
+      || (directDataWriteActiveRef && directDataWriteActiveRef.value > 0)
     ) {
       return res.status(409).json({
         error: "Another admin operation is in flight; retry shortly.",
@@ -457,6 +491,7 @@ function createBackupRouter(deps) {
       || providerImportEnqueueActiveRef?.value
       || dataMutationLockRef?.value
       || restoreInProgressRef?.value
+      || (directDataWriteActiveRef && directDataWriteActiveRef.value > 0)
     ) {
       return res.status(409).json({
         error: "Another admin operation is in flight; retry shortly.",

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -197,6 +197,7 @@ function createBackupRouter(deps) {
     reloadWordData,
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
+    providerImportEnqueueActiveRef,
     dataMutationLockRef,
     restoreInProgressRef,
     backupMaxBytes,
@@ -259,6 +260,7 @@ function createBackupRouter(deps) {
     if (
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
+      || providerImportEnqueueActiveRef?.value
       || dataMutationLockRef?.value
       || restoreInProgressRef?.value
     ) {
@@ -452,6 +454,7 @@ function createBackupRouter(deps) {
     if (
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
+      || providerImportEnqueueActiveRef?.value
       || dataMutationLockRef?.value
       || restoreInProgressRef?.value
     ) {
@@ -479,12 +482,13 @@ function createBackupRouter(deps) {
     // though restoreInProgressRef has been claimed since the busy
     // check, a provider import that started AFTER restoreInProgressRef
     // was set but BEFORE we updated the import-side guards (older
-    // build) could be in flight. If either ref is now true, abort and
+    // build) could be in flight. If any ref is now true, abort and
     // tell the operator to retry — we don't want to take the data
     // lock and race a running import.
     if (
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
+      || providerImportEnqueueActiveRef?.value
     ) {
       restoreInProgressRef.value = false;
       try {

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -38,6 +38,8 @@ function backupErrorStatus(err) {
     case "MANIFEST_MISMATCH":
     case "MANIFEST_MISSING":
     case "MANIFEST_DUPLICATE_PATH":
+    case "MANIFEST_INCOMPLETE":
+    case "MANIFEST_OPTIONAL_SET_UNDECLARED":
     case "ARCHIVE_DUPLICATE_PATH":
     case "OPTIONAL_SET_PATH_INVALID":
     case "ENTRY_MISSING":
@@ -513,19 +515,28 @@ function createBackupRouter(deps) {
 
     logEvent(req, "backup.restore.start", { bytes: upload.bytes, originalName: upload.originalName });
 
-    // Warm every in-scope store before phase 3 starts. If a store
-    // hasn't loaded yet (cold cache on a fresh process), a GET-side
-    // read fired during the brief rename gap (livePath momentarily
-    // absent between snapshot-rename and staged-rename) would
-    // otherwise see ENOENT and persist default state on top of the
-    // restore. Each load is idempotent. Failure is non-fatal — the
-    // restore can still proceed; warm is just a defense.
+    // Pre-validate the archive BEFORE any side-effecting work
+    // (warm-up, lock acquisition, drain). Without this, a malformed
+    // archive that fails validation inside applyRestore would still
+    // have triggered warmInScopeStores() — which on a cold or
+    // corrupted node persists default/normalized state to disk for
+    // any missing or unparseable in-scope file. That violates the
+    // "failed restore leaves the node untouched" guarantee, even
+    // though we then return a 4xx. Validating first keeps the rest
+    // of the flow side-effect-free until we're sure the archive is
+    // good. applyRestore re-runs validateArchive — that's a small
+    // duplication (hash checks only) but the safety win is worth it.
     try {
-      await warmInScopeStores();
-    } catch (warmErr) {
-      console.warn(
-        `[admin] Pre-restore warm of in-scope stores failed: ${warmErr?.message || String(warmErr)}`
-      );
+      await validateArchive(upload.tempPath, { projectRoot });
+    } catch (err) {
+      logEvent(req, "backup.restore.validate.error", { code: err?.code, error: err?.message });
+      restoreInProgressRef.value = false;
+      try {
+        await fsp.rm(upload.tempPath, { force: true });
+      } catch {
+        // best effort
+      }
+      return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
     }
 
     // Recheck the provider-import refs after the upload window. Even
@@ -552,12 +563,29 @@ function createBackupRouter(deps) {
       });
     }
 
-    // NOW take the data-mutation lock — upload is done, we're about to
-    // start touching live data/. Other /api mutations are 503'd from
-    // here until the apply + reload completes.
+    // NOW take the data-mutation lock — upload is done, archive is
+    // validated, we're about to start touching live data/. Other
+    // /api mutations are 503'd from here until the apply + reload
+    // completes.
     dataMutationLockRef.value = true;
 
     try {
+      // Warm every in-scope store now that we know the archive is
+      // valid. If a store hasn't loaded yet (cold cache on a fresh
+      // process), a GET-side read fired during the brief rename
+      // gap (livePath momentarily absent between snapshot-rename
+      // and staged-rename) would otherwise see ENOENT and persist
+      // default state on top of the restore. Each load is
+      // idempotent. Failure is non-fatal — the restore can still
+      // proceed; warm is just a defense.
+      try {
+        await warmInScopeStores();
+      } catch (warmErr) {
+        console.warn(
+          `[admin] Pre-restore warm of in-scope stores failed: ${warmErr?.message || String(warmErr)}`
+        );
+      }
+
       // Drain in-flight writers that already passed the gate before we
       // took the lock. Without this, an in-progress mutation could
       // rename its stale JSON over the just-swapped restored file

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -527,7 +527,16 @@ function createBackupRouter(deps) {
     // good. applyRestore re-runs validateArchive — that's a small
     // duplication (hash checks only) but the safety win is worth it.
     try {
-      await validateArchive(upload.tempPath, { projectRoot });
+      // Match preview's options so pre-validation rejects the same
+      // archives preview would. Without this, an archive that the
+      // operator's BACKUP_MAX_BYTES would reject in preview could
+      // still slip past the apply path's pre-validation (which
+      // would then defer the rejection to applyRestore's internal
+      // validate — same effect, but inconsistent code paths).
+      await validateArchive(upload.tempPath, {
+        projectRoot,
+        totalMaxBytes: backupMaxBytes
+      });
     } catch (err) {
       logEvent(req, "backup.restore.validate.error", { code: err?.code, error: err?.message });
       restoreInProgressRef.value = false;
@@ -592,7 +601,10 @@ function createBackupRouter(deps) {
       // after applyRestore returns success.
       await drainStoreWriteQueues();
 
-      const result = await applyRestore({ archivePath: upload.tempPath, projectRoot });
+      const result = await applyRestore(
+        { archivePath: upload.tempPath, projectRoot },
+        { totalMaxBytes: backupMaxBytes }
+      );
 
       // Reload in-memory caches so consumers see the restored state.
       const reloadResults = [];

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -190,6 +190,7 @@ function createBackupRouter(deps) {
     appConfigStore,
     classesStore,
     rebuildLanguageRuntimeCatalog,
+    reloadWordData,
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     restoreActiveRef,
@@ -214,66 +215,109 @@ function createBackupRouter(deps) {
     const includeDictionaries = parseBoolFlag(req.query.includeDictionaries, false);
     logEvent(req, "backup.create", { includeProviders, includeDictionaries });
 
-    // Pre-check uncompressed total size before piping. Without this, an
-    // export of an over-cap data tree would stream past the operator's
-    // configured limit; for the import path, busboy guards uploads.
-    let manifest;
+    // Take the data-mutation lock for the entire export. Without it,
+    // a write between hash-time (in buildManifest) and archive-time
+    // (the streaming archive.file reads) would produce an archive whose
+    // bytes don't match its own manifest sha256. Same flag the restore
+    // uses, so both ops are mutually exclusive and writers see 503s.
+    if (
+      providerImportQueueActiveRef?.value
+      || providerImportSyncActiveRef?.value
+      || restoreActiveRef?.value
+    ) {
+      return res.status(409).json({
+        error: "Another admin operation is in flight; retry shortly.",
+        code: "BACKUP_BUSY"
+      });
+    }
+    restoreActiveRef.value = true;
+
+    let releaseLock = () => {
+      restoreActiveRef.value = false;
+    };
+
     try {
-      manifest = await buildManifest({
-        projectRoot,
-        includeProviders,
-        includeDictionaries
-      });
-    } catch (err) {
-      logEvent(req, "backup.create.error", { error: err?.message || String(err) });
-      return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
-    }
-    const totalBytes = manifest.files.reduce((sum, entry) => sum + entry.bytes, 0);
-    if (totalBytes > backupMaxBytes) {
-      logEvent(req, "backup.create.too-large", { totalBytes, cap: backupMaxBytes });
-      return res.status(413).json({
-        error: `Archive uncompressed size ${totalBytes} bytes exceeds the cap of ${backupMaxBytes} bytes. ` +
-          "Disable optional sets, raise BACKUP_MAX_BYTES, or split the export.",
-        code: "ARCHIVE_TOO_LARGE",
-        totalBytes,
-        cap: backupMaxBytes
-      });
-    }
-
-    const stamp = safeFilenameTimestamp();
-    const nodeId = await readNodeIdSafe(projectRoot);
-    const filename = `wordle-backup-${stamp}-${nodeId}.zip`;
-
-    res.setHeader("Content-Type", "application/zip");
-    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
-    res.setHeader("Cache-Control", "no-store");
-
-    let archive;
-    try {
-      const result = createArchive({
-        projectRoot,
-        includeProviders,
-        includeDictionaries
-      });
-      archive = result.archive;
-    } catch (err) {
-      logEvent(req, "backup.create.error", { error: err?.message || String(err) });
-      return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
-    }
-
-    archive.on("error", (err) => {
-      logEvent(req, "backup.create.error", { error: err?.message || String(err) });
-      if (!res.headersSent) {
-        res.status(500).json({ error: "Failed to build archive.", code: "ARCHIVE_BUILD_FAILED" });
-      } else {
-        res.destroy(err);
+      // Pre-check uncompressed total size before piping. Without this, an
+      // export of an over-cap data tree would stream past the operator's
+      // configured limit; for the import path, busboy guards uploads.
+      let manifest;
+      try {
+        manifest = await buildManifest({
+          projectRoot,
+          includeProviders,
+          includeDictionaries
+        });
+      } catch (err) {
+        logEvent(req, "backup.create.error", { error: err?.message || String(err) });
+        return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
       }
-    });
-    archive.on("end", () => {
-      logEvent(req, "backup.create.complete");
-    });
+      const totalBytes = manifest.files.reduce((sum, entry) => sum + entry.bytes, 0);
+      if (totalBytes > backupMaxBytes) {
+        logEvent(req, "backup.create.too-large", { totalBytes, cap: backupMaxBytes });
+        return res.status(413).json({
+          error: `Archive uncompressed size ${totalBytes} bytes exceeds the cap of ${backupMaxBytes} bytes. ` +
+            "Disable optional sets, raise BACKUP_MAX_BYTES, or split the export.",
+          code: "ARCHIVE_TOO_LARGE",
+          totalBytes,
+          cap: backupMaxBytes
+        });
+      }
 
-    archive.pipe(res);
+      const stamp = safeFilenameTimestamp();
+      const nodeId = await readNodeIdSafe(projectRoot);
+      const filename = `wordle-backup-${stamp}-${nodeId}.zip`;
+
+      res.setHeader("Content-Type", "application/zip");
+      res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+      res.setHeader("Cache-Control", "no-store");
+
+      let archive;
+      try {
+        const result = createArchive({
+          projectRoot,
+          includeProviders,
+          includeDictionaries
+        });
+        archive = result.archive;
+      } catch (err) {
+        logEvent(req, "backup.create.error", { error: err?.message || String(err) });
+        return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
+      }
+
+      // Release the lock when the archive finishes streaming or errors.
+      const lockFn = releaseLock;
+      releaseLock = () => {}; // prevent finally-block double-release
+      let released = false;
+      const release = () => {
+        if (released) return;
+        released = true;
+        lockFn();
+      };
+      archive.on("error", (err) => {
+        logEvent(req, "backup.create.error", { error: err?.message || String(err) });
+        release();
+        if (!res.headersSent) {
+          res.status(500).json({ error: "Failed to build archive.", code: "ARCHIVE_BUILD_FAILED" });
+        } else {
+          res.destroy(err);
+        }
+      });
+      archive.on("end", () => {
+        logEvent(req, "backup.create.complete");
+        release();
+      });
+      res.on("close", () => {
+        // Client disconnected mid-stream; ensure we don't hold the lock.
+        release();
+      });
+
+      archive.pipe(res);
+    } finally {
+      // If we exited the synchronous path without piping (early return),
+      // releaseLock is still the original lock-clearer. Otherwise it's
+      // a no-op and the archive event handlers own the release.
+      releaseLock();
+    }
   });
 
   // POST /api/admin/backup/preview
@@ -366,7 +410,8 @@ function createBackupRouter(deps) {
         ["classesStore", () => classesStore?.reload?.()],
         ["appConfigStore", () => appConfigStore?.reloadSync?.()],
         ["languageRegistryStore", () => languageRegistryStore?.reloadSync?.()],
-        ["languageRuntimeCatalog", () => rebuildLanguageRuntimeCatalog?.()]
+        ["languageRuntimeCatalog", () => rebuildLanguageRuntimeCatalog?.()],
+        ["wordDataCache", () => reloadWordData?.()]
       ]) {
         try {
           await action();

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -276,14 +276,33 @@ function createBackupRouter(deps) {
     try {
       // Make sure every in-scope store's file exists on disk before
       // hashing. On a fresh node, an unread store's data file may not
-      // exist yet — buildManifest would otherwise throw.
-      await warmInScopeStores();
+      // exist yet — buildManifest would otherwise throw. Wrap with the
+      // same error-mapping as the rest of the route so a store-load
+      // disk failure surfaces as a structured JSON 500 instead of an
+      // unhandled rejection / generic Express HTML error.
+      try {
+        await warmInScopeStores();
+      } catch (err) {
+        logEvent(req, "backup.create.error", { phase: "warm", error: err?.message || String(err) });
+        return res.status(500).json({
+          error: `Could not warm in-scope stores before backup: ${err?.message || String(err)}`,
+          code: "STORE_WARM_FAILED"
+        });
+      }
 
       // Drain in-flight writers that already passed the gate before we
       // took the lock. Without this, an in-progress leaderboard mutation
       // could complete its rename mid-build and produce an archive
       // whose hashed bytes don't match its streamed bytes.
-      await drainStoreWriteQueues();
+      try {
+        await drainStoreWriteQueues();
+      } catch (err) {
+        logEvent(req, "backup.create.error", { phase: "drain", error: err?.message || String(err) });
+        return res.status(500).json({
+          error: `Could not drain in-flight writers before backup: ${err?.message || String(err)}`,
+          code: "STORE_DRAIN_FAILED"
+        });
+      }
 
       // Pre-check uncompressed total size before piping. Without this, an
       // export of an over-cap data tree would stream past the operator's

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -456,6 +456,29 @@ function createBackupRouter(deps) {
 
     logEvent(req, "backup.restore.start", { bytes: upload.bytes, originalName: upload.originalName });
 
+    // Recheck the provider-import refs after the upload window. Even
+    // though restoreInProgressRef has been claimed since the busy
+    // check, a provider import that started AFTER restoreInProgressRef
+    // was set but BEFORE we updated the import-side guards (older
+    // build) could be in flight. If either ref is now true, abort and
+    // tell the operator to retry — we don't want to take the data
+    // lock and race a running import.
+    if (
+      providerImportQueueActiveRef?.value
+      || providerImportSyncActiveRef?.value
+    ) {
+      restoreInProgressRef.value = false;
+      try {
+        await fsp.rm(upload.tempPath, { force: true });
+      } catch {
+        // best effort
+      }
+      return res.status(409).json({
+        error: "A provider import started while the restore archive was uploading; retry once the import completes.",
+        code: "RESTORE_BUSY"
+      });
+    }
+
     // NOW take the data-mutation lock — upload is done, we're about to
     // start touching live data/. Other /api mutations are 503'd from
     // here until the apply + reload completes.

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -52,6 +52,7 @@ function backupErrorStatus(err) {
       return 400;
     case "ENTRY_TOO_LARGE":
     case "ARCHIVE_TOO_LARGE":
+    case "MANIFEST_TOO_LARGE":
       return 413;
     case "RESTORE_BUSY":
       return 409;
@@ -473,6 +474,9 @@ function createBackupRouter(deps) {
       // schema drift, etc.) didn't mutate anything, so the flag stays
       // false to avoid misleading operators.
       body.rolledBackOnError = err?.rolledBackChanges === true;
+      if (Array.isArray(err?.warnings) && err.warnings.length > 0) {
+        body.warnings = err.warnings;
+      }
       return res.status(status).json(body);
     } finally {
       dataMutationLockRef.value = false;

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -1,0 +1,381 @@
+const express = require("express");
+const path = require("node:path");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const nodeCrypto = require("node:crypto");
+const Busboy = require("busboy");
+
+const {
+  BackupError,
+  createArchive,
+  validateArchive,
+  applyRestore
+} = require("../lib/backup-store.js");
+
+const RESTORE_CONFIRM_HEADER = "x-admin-confirm";
+const RESTORE_CONFIRM_VALUE = "I-UNDERSTAND";
+
+function logEvent(req, event, fields = {}) {
+  try {
+    const payload = {
+      event,
+      ts: new Date().toISOString(),
+      ...fields
+    };
+    console.log(JSON.stringify(payload));
+  } catch {
+    // best effort
+  }
+}
+
+function backupErrorStatus(err) {
+  if (!(err instanceof BackupError)) return 500;
+  switch (err.code) {
+    case "INVALID_REQUEST":
+    case "MANIFEST_INVALID":
+    case "MANIFEST_PARSE_FAILED":
+    case "MANIFEST_MISMATCH":
+    case "MANIFEST_MISSING":
+    case "ENTRY_MISSING":
+    case "BYTES_MISMATCH":
+    case "SHA256_MISMATCH":
+    case "RESTORED_FILE_INVALID":
+    case "PATH_UNSAFE":
+    case "ARCHIVE_MALFORMED":
+      return 400;
+    case "MANIFEST_VERSION_UNSUPPORTED":
+    case "SCHEMA_DRIFT":
+      return 400;
+    case "ENTRY_TOO_LARGE":
+    case "ARCHIVE_TOO_LARGE":
+      return 413;
+    case "RESTORE_BUSY":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+function backupErrorBody(err) {
+  if (!(err instanceof BackupError)) {
+    return { error: "Backup operation failed.", code: "INTERNAL_ERROR" };
+  }
+  const body = { error: err.message, code: err.code };
+  if (err.details) body.details = err.details;
+  return body;
+}
+
+function parseBoolFlag(value, defaultValue) {
+  if (value === undefined) return defaultValue;
+  const normalized = String(value).toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  return defaultValue;
+}
+
+function safeFilenameTimestamp(d = new Date()) {
+  return d.toISOString().replace(/[:.]/g, "-");
+}
+
+async function readNodeIdSafe(projectRoot) {
+  try {
+    const config = JSON.parse(
+      await fsp.readFile(path.join(projectRoot, "data", "app-config.json"), "utf8")
+    );
+    if (config && typeof config.nodeId === "string" && config.nodeId.length > 0) {
+      return config.nodeId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 32) || "node";
+    }
+  } catch {
+    // fall through
+  }
+  return "node";
+}
+
+// Streaming multipart receiver. Writes the uploaded file to a temp path on
+// disk, enforcing the configured byte cap. Returns { tempPath, bytes,
+// originalName }. Rejects with a 413-friendly BackupError if the cap is
+// exceeded; the partial temp file is removed before rejecting.
+async function receiveUpload(req, { maxBytes, tempDir }) {
+  const contentType = req.headers["content-type"] || "";
+  if (!contentType.toLowerCase().startsWith("multipart/form-data")) {
+    throw new BackupError("INVALID_REQUEST", "Expected multipart/form-data upload.");
+  }
+  await fsp.mkdir(tempDir, { recursive: true });
+  const stamp = safeFilenameTimestamp();
+  const random = nodeCrypto.randomBytes(4).toString("hex");
+  const tempPath = path.join(tempDir, `upload-${stamp}-${random}.zip`);
+
+  return new Promise((resolve, reject) => {
+    let busboy;
+    try {
+      busboy = Busboy({
+        headers: req.headers,
+        limits: {
+          fileSize: maxBytes + 1,
+          files: 1,
+          fields: 10
+        }
+      });
+    } catch (err) {
+      reject(new BackupError("INVALID_REQUEST", `Multipart parser init failed: ${err.message}`));
+      return;
+    }
+
+    let received = false;
+    let originalName = "upload.zip";
+    let bytesWritten = 0;
+    let writeStream = null;
+    let truncated = false;
+
+    const cleanupAndReject = async (err) => {
+      try {
+        if (writeStream && !writeStream.destroyed) writeStream.destroy();
+        await fsp.rm(tempPath, { force: true });
+      } catch {
+        // best effort
+      }
+      reject(err);
+    };
+
+    busboy.on("file", (_fieldname, file, info) => {
+      if (received) {
+        file.resume();
+        return;
+      }
+      received = true;
+      originalName = (info && info.filename) || originalName;
+      writeStream = fs.createWriteStream(tempPath);
+
+      file.on("limit", () => {
+        truncated = true;
+        file.resume();
+      });
+      file.on("data", (chunk) => {
+        bytesWritten += chunk.length;
+      });
+      file.on("error", (err) => cleanupAndReject(err));
+
+      writeStream.on("error", (err) => cleanupAndReject(err));
+      file.pipe(writeStream);
+      writeStream.on("finish", () => {
+        if (truncated || bytesWritten > maxBytes) {
+          cleanupAndReject(new BackupError(
+            "ARCHIVE_TOO_LARGE",
+            `Uploaded archive exceeds the per-request limit of ${maxBytes} bytes.`
+          ));
+          return;
+        }
+        resolve({ tempPath, bytes: bytesWritten, originalName });
+      });
+    });
+
+    busboy.on("error", (err) => cleanupAndReject(err));
+    busboy.on("finish", () => {
+      if (!received) {
+        cleanupAndReject(new BackupError("INVALID_REQUEST", "Upload did not include a file."));
+      }
+    });
+
+    req.pipe(busboy);
+  });
+}
+
+function createBackupRouter(deps) {
+  const {
+    projectRoot,
+    leaderboardStore,
+    languageRegistryStore,
+    adminJobsStore,
+    appConfigStore,
+    classesStore,
+    rebuildLanguageRuntimeCatalog,
+    providerImportQueueActiveRef,
+    providerImportSyncActiveRef,
+    restoreActiveRef,
+    backupMaxBytes,
+    backupIncludeProvidersDefault,
+    backupRateLimiter
+  } = deps;
+
+  if (!projectRoot) {
+    throw new Error("createBackupRouter requires projectRoot.");
+  }
+
+  const router = express.Router();
+  const dataRoot = path.join(projectRoot, "data");
+  const uploadsTempDir = path.join(dataRoot, ".restore-uploads");
+  const passthrough = (req, res, next) => next();
+  const limit = typeof backupRateLimiter === "function" ? backupRateLimiter : passthrough;
+
+  // GET /api/admin/backup
+  router.get("/api/admin/backup", limit, async (req, res) => {
+    const includeProviders = parseBoolFlag(req.query.includeProviders, backupIncludeProvidersDefault);
+    const includeDictionaries = parseBoolFlag(req.query.includeDictionaries, false);
+    logEvent(req, "backup.create", { includeProviders, includeDictionaries });
+
+    const stamp = safeFilenameTimestamp();
+    const nodeId = await readNodeIdSafe(projectRoot);
+    const filename = `wordle-backup-${stamp}-${nodeId}.zip`;
+
+    res.setHeader("Content-Type", "application/zip");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+    res.setHeader("Cache-Control", "no-store");
+
+    let archive;
+    try {
+      const result = createArchive({
+        projectRoot,
+        includeProviders,
+        includeDictionaries
+      });
+      archive = result.archive;
+    } catch (err) {
+      logEvent(req, "backup.create.error", { error: err?.message || String(err) });
+      return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
+    }
+
+    archive.on("error", (err) => {
+      logEvent(req, "backup.create.error", { error: err?.message || String(err) });
+      if (!res.headersSent) {
+        res.status(500).json({ error: "Failed to build archive.", code: "ARCHIVE_BUILD_FAILED" });
+      } else {
+        res.destroy(err);
+      }
+    });
+    archive.on("end", () => {
+      logEvent(req, "backup.create.complete");
+    });
+
+    archive.pipe(res);
+  });
+
+  // POST /api/admin/backup/preview
+  router.post("/api/admin/backup/preview", limit, async (req, res) => {
+    let upload;
+    try {
+      upload = await receiveUpload(req, {
+        maxBytes: backupMaxBytes,
+        tempDir: uploadsTempDir
+      });
+    } catch (err) {
+      return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
+    }
+    logEvent(req, "backup.preview", { bytes: upload.bytes, originalName: upload.originalName });
+    try {
+      const { manifest, fileChecks } = await validateArchive(upload.tempPath, {
+        projectRoot,
+        totalMaxBytes: backupMaxBytes
+      });
+      const totalBytes = fileChecks.reduce((sum, entry) => sum + entry.bytes, 0);
+      return res.json({
+        ok: true,
+        manifestVersion: manifest.manifestVersion,
+        appVersion: manifest.appVersion,
+        createdAt: manifest.createdAt,
+        nodeId: manifest.nodeId,
+        files: fileChecks,
+        totalBytes,
+        warnings: []
+      });
+    } catch (err) {
+      logEvent(req, "backup.preview.error", { code: err?.code, error: err?.message });
+      return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
+    } finally {
+      try {
+        await fsp.rm(upload.tempPath, { force: true });
+      } catch {
+        // best effort
+      }
+    }
+  });
+
+  // POST /api/admin/restore
+  router.post("/api/admin/restore", limit, async (req, res) => {
+    if (req.headers[RESTORE_CONFIRM_HEADER] !== RESTORE_CONFIRM_VALUE) {
+      return res.status(400).json({
+        error: `Restore requires header ${RESTORE_CONFIRM_HEADER}: ${RESTORE_CONFIRM_VALUE}.`,
+        code: "RESTORE_CONFIRM_MISSING"
+      });
+    }
+    // Atomic check-and-set: must be synchronous (no await between the
+    // check and the assignment) so two simultaneous requests can't both
+    // pass the check before either one sets the flag.
+    if (
+      providerImportQueueActiveRef?.value
+      || providerImportSyncActiveRef?.value
+      || restoreActiveRef?.value
+    ) {
+      return res.status(409).json({
+        error: "Another admin operation is in flight; retry shortly.",
+        code: "RESTORE_BUSY"
+      });
+    }
+    restoreActiveRef.value = true;
+
+    let upload;
+    try {
+      upload = await receiveUpload(req, {
+        maxBytes: backupMaxBytes,
+        tempDir: uploadsTempDir
+      });
+    } catch (err) {
+      restoreActiveRef.value = false;
+      return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
+    }
+
+    logEvent(req, "backup.restore.start", { bytes: upload.bytes, originalName: upload.originalName });
+
+    try {
+      const result = await applyRestore({ archivePath: upload.tempPath, projectRoot });
+
+      // Reload in-memory caches so consumers see the restored state.
+      const reloadResults = [];
+      for (const [name, action] of [
+        ["leaderboardStore", () => leaderboardStore?.reload?.()],
+        ["adminJobsStore", () => adminJobsStore?.reload?.()],
+        ["classesStore", () => classesStore?.reload?.()],
+        ["appConfigStore", () => appConfigStore?.reloadSync?.()],
+        ["languageRegistryStore", () => languageRegistryStore?.reloadSync?.()],
+        ["languageRuntimeCatalog", () => rebuildLanguageRuntimeCatalog?.()]
+      ]) {
+        try {
+          await action();
+          reloadResults.push({ name, ok: true });
+        } catch (reloadErr) {
+          reloadResults.push({ name, ok: false, error: reloadErr?.message || String(reloadErr) });
+        }
+      }
+      logEvent(req, "backup.restore.complete", {
+        filesRestored: result.restored.length,
+        warnings: result.warnings.length
+      });
+      return res.json({
+        ok: true,
+        restored: result.restored,
+        filesRestored: result.restored.length,
+        rolledBackOnError: false,
+        warnings: result.warnings,
+        reloads: reloadResults
+      });
+    } catch (err) {
+      logEvent(req, "backup.restore.rollback", { code: err?.code, error: err?.message });
+      const status = backupErrorStatus(err);
+      const body = backupErrorBody(err);
+      body.rolledBackOnError = true;
+      return res.status(status).json(body);
+    } finally {
+      restoreActiveRef.value = false;
+      try {
+        await fsp.rm(upload.tempPath, { force: true });
+      } catch {
+        // best effort
+      }
+    }
+  });
+
+  return router;
+}
+
+module.exports = createBackupRouter;
+module.exports.RESTORE_CONFIRM_HEADER = RESTORE_CONFIRM_HEADER;
+module.exports.RESTORE_CONFIRM_VALUE = RESTORE_CONFIRM_VALUE;

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -196,14 +196,14 @@ function createBackupRouter(deps) {
     reloadWordData,
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
-    restoreActiveRef,
+    dataMutationLockRef,
     backupMaxBytes,
     backupIncludeProvidersDefault,
     backupRateLimiter
   } = deps;
 
   // Wait for every async store's write queue to drain. Called AFTER
-  // restoreActiveRef is set (so the /api gate has already started
+  // dataMutationLockRef is set (so the /api gate has already started
   // refusing new mutations) and BEFORE buildManifest/applyRestore reads
   // or swaps any files. Without this, a mutation that passed the gate
   // moments before the lock was taken could complete its atomic-rename
@@ -243,17 +243,17 @@ function createBackupRouter(deps) {
     if (
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
-      || restoreActiveRef?.value
+      || dataMutationLockRef?.value
     ) {
       return res.status(409).json({
         error: "Another admin operation is in flight; retry shortly.",
         code: "BACKUP_BUSY"
       });
     }
-    restoreActiveRef.value = true;
+    dataMutationLockRef.value = true;
 
     let releaseLock = () => {
-      restoreActiveRef.value = false;
+      dataMutationLockRef.value = false;
     };
 
     try {
@@ -403,14 +403,14 @@ function createBackupRouter(deps) {
     if (
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
-      || restoreActiveRef?.value
+      || dataMutationLockRef?.value
     ) {
       return res.status(409).json({
         error: "Another admin operation is in flight; retry shortly.",
         code: "RESTORE_BUSY"
       });
     }
-    restoreActiveRef.value = true;
+    dataMutationLockRef.value = true;
 
     let upload;
     try {
@@ -419,7 +419,7 @@ function createBackupRouter(deps) {
         tempDir: uploadsTempDir
       });
     } catch (err) {
-      restoreActiveRef.value = false;
+      dataMutationLockRef.value = false;
       return res.status(backupErrorStatus(err)).json(backupErrorBody(err));
     }
 
@@ -475,7 +475,7 @@ function createBackupRouter(deps) {
       body.rolledBackOnError = err?.rolledBackChanges === true;
       return res.status(status).json(body);
     } finally {
-      restoreActiveRef.value = false;
+      dataMutationLockRef.value = false;
       try {
         await fsp.rm(upload.tempPath, { force: true });
       } catch {

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -37,6 +37,9 @@ function backupErrorStatus(err) {
     case "MANIFEST_PARSE_FAILED":
     case "MANIFEST_MISMATCH":
     case "MANIFEST_MISSING":
+    case "MANIFEST_DUPLICATE_PATH":
+    case "ARCHIVE_DUPLICATE_PATH":
+    case "OPTIONAL_SET_PATH_INVALID":
     case "ENTRY_MISSING":
     case "BYTES_MISMATCH":
     case "SHA256_MISMATCH":
@@ -199,6 +202,23 @@ function createBackupRouter(deps) {
     backupRateLimiter
   } = deps;
 
+  // Wait for every async store's write queue to drain. Called AFTER
+  // restoreActiveRef is set (so the /api gate has already started
+  // refusing new mutations) and BEFORE buildManifest/applyRestore reads
+  // or swaps any files. Without this, a mutation that passed the gate
+  // moments before the lock was taken could complete its atomic-rename
+  // step after we've hashed/swapped, overwriting the just-restored
+  // file with stale bytes.
+  async function drainStoreWriteQueues() {
+    const queues = [
+      leaderboardStore?.writeQueue,
+      adminJobsStore?.writeQueue,
+      classesStore?.writeQueue
+    ].filter(Boolean);
+    if (queues.length === 0) return;
+    await Promise.allSettled(queues);
+  }
+
   if (!projectRoot) {
     throw new Error("createBackupRouter requires projectRoot.");
   }
@@ -237,6 +257,12 @@ function createBackupRouter(deps) {
     };
 
     try {
+      // Drain in-flight writers that already passed the gate before we
+      // took the lock. Without this, an in-progress leaderboard mutation
+      // could complete its rename mid-build and produce an archive
+      // whose hashed bytes don't match its streamed bytes.
+      await drainStoreWriteQueues();
+
       // Pre-check uncompressed total size before piping. Without this, an
       // export of an over-cap data tree would stream past the operator's
       // configured limit; for the import path, busboy guards uploads.
@@ -400,6 +426,12 @@ function createBackupRouter(deps) {
     logEvent(req, "backup.restore.start", { bytes: upload.bytes, originalName: upload.originalName });
 
     try {
+      // Drain in-flight writers that already passed the gate before we
+      // took the lock. Without this, an in-progress mutation could
+      // rename its stale JSON over the just-swapped restored file
+      // after applyRestore returns success.
+      await drainStoreWriteQueues();
+
       const result = await applyRestore({ archivePath: upload.tempPath, projectRoot });
 
       // Reload in-memory caches so consumers see the restored state.

--- a/scripts/restore-from-disk.js
+++ b/scripts/restore-from-disk.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+// CLI fallback for applying a backup archive when the admin UI is
+// unreachable (e.g. post-corruption boot loop). Reads an archive from
+// disk and writes the restored data/ tree atomically.
+//
+// Usage:
+//   node scripts/restore-from-disk.js <archive.zip> [--project-root <dir>]
+//
+// The script does NOT take the in-process admin mutex — it's intended to
+// run when the server is offline. Make sure the server is stopped before
+// running, or operators may observe inconsistent reads from a half-swapped
+// data/ during the restore window.
+
+const path = require("node:path");
+const { existsSync } = require("node:fs");
+const { applyRestore } = require("../lib/backup-store.js");
+
+function parseArgs(argv) {
+  const args = { archivePath: null, projectRoot: path.resolve(__dirname, "..") };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--project-root" || arg === "-p") {
+      args.projectRoot = path.resolve(argv[++i] || "");
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else if (!arg.startsWith("-") && !args.archivePath) {
+      args.archivePath = path.resolve(arg);
+    } else {
+      throw new Error(`Unrecognized argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write([
+    "Usage: node scripts/restore-from-disk.js <archive.zip> [--project-root <dir>]",
+    "",
+    "Restores a wordle-local node from a backup archive. The server should",
+    "be stopped before running. The atomic-apply algorithm in",
+    "lib/backup-store.js writes to <project-root>/data/ via a staging dir",
+    "and rewinds from a rollback dir on any failure.",
+    "",
+    "Options:",
+    "  --project-root, -p   Path to the wordle-local project root.",
+    "                       Default: the script's parent directory.",
+    "  --help, -h           Print this help and exit.",
+    ""
+  ].join("\n"));
+}
+
+(async () => {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`${err.message}\n\n`);
+    printHelp();
+    process.exit(64);
+    return;
+  }
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+    return;
+  }
+  if (!args.archivePath) {
+    process.stderr.write("error: archive path is required\n\n");
+    printHelp();
+    process.exit(64);
+    return;
+  }
+  if (!existsSync(args.archivePath)) {
+    process.stderr.write(`error: archive not found at ${args.archivePath}\n`);
+    process.exit(66);
+    return;
+  }
+  if (!existsSync(path.join(args.projectRoot, "data"))) {
+    process.stderr.write(`error: project root has no data/ directory: ${args.projectRoot}\n`);
+    process.exit(66);
+    return;
+  }
+
+  process.stdout.write(`[restore] applying ${args.archivePath} -> ${args.projectRoot}/data/\n`);
+  try {
+    const result = await applyRestore({
+      archivePath: args.archivePath,
+      projectRoot: args.projectRoot
+    });
+    process.stdout.write(
+      `[restore] OK — ${result.restored.length} file(s) restored. ` +
+      `Warnings: ${result.warnings.length}\n`
+    );
+    for (const file of result.restored) {
+      process.stdout.write(`  ${file}\n`);
+    }
+    for (const warning of result.warnings) {
+      process.stdout.write(`  warning: ${warning.code} ${warning.message}\n`);
+    }
+    process.exit(0);
+  } catch (err) {
+    const code = err && err.code ? err.code : "UNKNOWN";
+    process.stderr.write(`[restore] FAILED — ${code}: ${err.message}\n`);
+    if (err && err.details) {
+      process.stderr.write(`  details: ${JSON.stringify(err.details)}\n`);
+    }
+    process.stderr.write(
+      "[restore] data/ should be unchanged (rollback ran). Inspect any " +
+      ".restore-staging-* and .restore-rollback-* directories under data/ " +
+      "before deleting; see docs/backup-restore.md.\n"
+    );
+    process.exit(1);
+  }
+})();

--- a/scripts/restore-from-disk.js
+++ b/scripts/restore-from-disk.js
@@ -21,7 +21,12 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--project-root" || arg === "-p") {
-      args.projectRoot = path.resolve(argv[++i] || "");
+      const next = argv[i + 1];
+      if (typeof next !== "string" || next.length === 0 || next.startsWith("-")) {
+        throw new Error(`${arg} requires a path argument`);
+      }
+      args.projectRoot = path.resolve(next);
+      i += 1;
     } else if (arg === "--help" || arg === "-h") {
       args.help = true;
     } else if (!arg.startsWith("-") && !args.archivePath) {

--- a/scripts/validate-schemas.js
+++ b/scripts/validate-schemas.js
@@ -29,6 +29,8 @@ const appConfigSchemaPath = path.join(projectRoot, "data", "app-config.schema.js
 const appConfigExamplePath = path.join(projectRoot, "data", "app-config.example.json");
 const classesSchemaPath = path.join(projectRoot, "data", "classes.schema.json");
 const classesExamplePath = path.join(projectRoot, "data", "classes.example.json");
+const backupManifestSchemaPath = path.join(projectRoot, "data", "backup-manifest.schema.json");
+const backupManifestExamplePath = path.join(projectRoot, "data", "backup-manifest.example.json");
 
 function readJson(filePath, kind) {
   let raw;
@@ -96,6 +98,11 @@ function runSchemaChecks() {
       schemaPath: classesSchemaPath,
       dataPath: classesExamplePath,
       schemaLabel: "classes schema"
+    },
+    {
+      schemaPath: backupManifestSchemaPath,
+      dataPath: backupManifestExamplePath,
+      schemaLabel: "backup manifest schema"
     }
   ];
 

--- a/server.js
+++ b/server.js
@@ -259,6 +259,29 @@ const dataMutationLockRef = {
 };
 const waitForDataMutationLock = () => dataMutationLockRef.waitForRelease();
 
+// Atomic claim helper for direct data writers. Loops: wait for the
+// lock, then synchronously verify no restore is in flight and bump
+// the counter. Returns a release fn to call in finally. Without this,
+// a writer that simply awaits waitForDataMutationLock() can race a
+// new restore that claims the lock during the next event-loop tick.
+async function claimDirectDataWriteSlot() {
+  while (true) {
+    await waitForDataMutationLock();
+    // Synchronous check + increment — no awaits in between, so no
+    // other handler can run.
+    if (
+      dataMutationLockRef.value
+      || restoreInProgressRef.value
+    ) {
+      continue;
+    }
+    directDataWriteActiveRef.value += 1;
+    return () => {
+      directDataWriteActiveRef.value -= 1;
+    };
+  }
+}
+
 const leaderboardStore = new LeaderboardStore({
   filePath: LEADERBOARD_DATA_PATH,
   maxProfiles: ENV_LEADERBOARD_MAX_PROFILES,
@@ -1089,6 +1112,17 @@ const providerImportSyncActiveRef = { value: false };
 // staged upload + queued job orphaned. The restore busy check
 // observes this ref and 409s the restore in that window.
 const providerImportEnqueueActiveRef = { value: false };
+// Counter incremented by direct (non-store-mutate) data writers —
+// PUT /api/admin/runtime-config and POST /api/word — for the duration
+// of their validation+persist sequence. The restore busy check
+// observes this counter so a new restore can't slip in between a
+// direct writer's lock-wait return and its actual write, which would
+// validate against pre-restore state and persist over the swap.
+// The writer claims the slot atomically: loop awaiting
+// waitForDataMutationLock() then synchronously check restore flags
+// and increment the counter (no awaits between the check and
+// increment).
+const directDataWriteActiveRef = { value: 0 };
 // Marks the restore route as "claiming" the restore slot — set
 // synchronously after the busy-check, before the multipart upload
 // starts. Separate from dataMutationLockRef so we don't hold the
@@ -2508,6 +2542,7 @@ app.use(
     providerImportEnqueueActiveRef,
     dataMutationLockRef,
     restoreInProgressRef,
+    directDataWriteActiveRef,
     backupMaxBytes: ENV_BACKUP_MAX_BYTES,
     backupIncludeProvidersDefault: ENV_BACKUP_INCLUDE_PROVIDERS_DEFAULT,
     backupRateLimiter
@@ -2558,7 +2593,7 @@ app.use(
     providerImportEnqueueActiveRef,
     dataMutationLockRef,
     restoreInProgressRef,
-    waitForDataMutationLock,
+    claimDirectDataWriteSlot,
     getEditableProviderManualMaxFileBytes,
     PROVIDER_MANUAL_MAX_FILE_BYTES_MIN,
     PROVIDER_COMMIT_PATTERN,
@@ -2726,14 +2761,19 @@ app.post("/api/word", requireAdminAccess, async (req, res) => {
     updatedAt: new Date().toISOString()
   };
 
-  // Honor the data-mutation lock: a handler that already passed the gate
-  // could otherwise write data/word.json on top of a just-restored value.
-  await waitForDataMutationLock();
+  // Atomic claim: wait for the data-mutation lock, then increment the
+  // direct-write counter under one synchronous tick so a restore that
+  // claims the lock immediately after our wait can't race past us
+  // before saveWordDataAtomic runs. Restore busy check observes the
+  // counter and 409s while it's > 0.
+  const releaseSlot = await claimDirectDataWriteSlot();
   try {
     await saveWordDataAtomic(data);
   } catch (err) {
     console.error("Failed to persist daily word data.", err);
     return res.status(500).json({ error: "Could not save daily word right now." });
+  } finally {
+    releaseSlot();
   }
   wordDataCache = data;
   res.json({ ok: true, data });

--- a/server.js
+++ b/server.js
@@ -1578,10 +1578,14 @@ rebuildLanguageRuntimeCatalog();
 // Boot-time orphan check: a previous restore that crashed mid-apply leaves
 // .restore-staging-* / .restore-rollback-* dirs in data/. Log them loudly
 // rather than auto-deleting — operators may need to inspect or rewind.
+// Honor BACKUP_PROJECT_ROOT so the scan path matches the restore handler's.
 (async () => {
   try {
     const { findOrphanedRestoreDirs } = require("./lib/backup-store.js");
-    const orphans = await findOrphanedRestoreDirs(path.join(__dirname, "data"));
+    const backupRoot = process.env.BACKUP_PROJECT_ROOT
+      ? path.resolve(process.env.BACKUP_PROJECT_ROOT)
+      : __dirname;
+    const orphans = await findOrphanedRestoreDirs(path.join(backupRoot, "data"));
     if (orphans.length > 0) {
       const list = orphans.map((entry) => entry.name).join(", ");
       console.warn(
@@ -2445,13 +2449,15 @@ const backupRateLimiter = rateLimit({
   // rate-limit store dumps, logs, or metrics. Falls back to
   // express-rate-limit's IPv6-aware ipKeyGenerator when no admin key is
   // set.
-  keyGenerator: (req, res) => {
+  keyGenerator: (req) => {
     const key = req.headers["x-admin-key"];
     if (typeof key === "string" && key.length > 0) {
       const digest = nodeCrypto.createHash("sha256").update(key).digest("hex").slice(0, 16);
       return `admin:${digest}`;
     }
-    return rateLimitIpKeyGenerator(req, res);
+    // ipKeyGenerator expects an IP string, not the request object. Pass
+    // req.ip and let the helper apply IPv6 subnet masking.
+    return rateLimitIpKeyGenerator(req.ip);
   },
   message: { error: "Too many backup or restore requests. Try again later." }
 });
@@ -2530,6 +2536,7 @@ app.use(
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     dataMutationLockRef,
+    waitForDataMutationLock,
     getEditableProviderManualMaxFileBytes,
     PROVIDER_MANUAL_MAX_FILE_BYTES_MIN,
     PROVIDER_COMMIT_PATTERN,
@@ -2697,6 +2704,9 @@ app.post("/api/word", requireAdminAccess, async (req, res) => {
     updatedAt: new Date().toISOString()
   };
 
+  // Honor the data-mutation lock: a handler that already passed the gate
+  // could otherwise write data/word.json on top of a just-restored value.
+  await waitForDataMutationLock();
   try {
     await saveWordDataAtomic(data);
   } catch (err) {

--- a/server.js
+++ b/server.js
@@ -1082,6 +1082,13 @@ let registeredLanguageCatalog = new Map();
 let availableLanguages = new Map();
 const providerImportQueueActiveRef = { value: false };
 const providerImportSyncActiveRef = { value: false };
+// Set by the async provider-import endpoint while it's staging the
+// upload and enqueuing the job into data/admin-jobs.json. Without
+// this, a restore could squeeze between the import's busy check and
+// its enqueue, write the archive over admin-jobs.json, and leave the
+// staged upload + queued job orphaned. The restore busy check
+// observes this ref and 409s the restore in that window.
+const providerImportEnqueueActiveRef = { value: false };
 // Marks the restore route as "claiming" the restore slot — set
 // synchronously after the busy-check, before the multipart upload
 // starts. Separate from dataMutationLockRef so we don't hold the
@@ -2190,6 +2197,7 @@ async function startProviderImportQueueIfNeeded() {
   if (
     providerImportQueueActiveRef.value
     || providerImportSyncActiveRef.value
+    || providerImportEnqueueActiveRef.value
     || dataMutationLockRef.value
     || restoreInProgressRef.value
   ) {
@@ -2497,6 +2505,7 @@ app.use(
     },
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
+    providerImportEnqueueActiveRef,
     dataMutationLockRef,
     restoreInProgressRef,
     backupMaxBytes: ENV_BACKUP_MAX_BYTES,
@@ -2546,6 +2555,7 @@ app.use(
     getProviderManualMaxFileBytes,
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
+    providerImportEnqueueActiveRef,
     dataMutationLockRef,
     restoreInProgressRef,
     waitForDataMutationLock,

--- a/server.js
+++ b/server.js
@@ -2129,7 +2129,15 @@ function toAdminJobResponse(job) {
 }
 
 async function startProviderImportQueueIfNeeded() {
-  if (providerImportQueueActiveRef.value || providerImportSyncActiveRef.value) {
+  // Bidirectional mutex with the restore router: don't start dequeueing
+  // jobs while a restore is mutating data/. Without this, a pending
+  // import could begin between the restore's pre-check and the leaderboard
+  // mutate and write data/providers/** concurrently with the swap.
+  if (
+    providerImportQueueActiveRef.value
+    || providerImportSyncActiveRef.value
+    || restoreActiveRef.value
+  ) {
     return;
   }
   providerImportQueueActiveRef.value = true;
@@ -2421,6 +2429,7 @@ app.use(
     getProviderManualMaxFileBytes,
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
+    restoreActiveRef,
     getEditableProviderManualMaxFileBytes,
     PROVIDER_MANUAL_MAX_FILE_BYTES_MIN,
     PROVIDER_COMMIT_PATTERN,

--- a/server.js
+++ b/server.js
@@ -2466,7 +2466,24 @@ function limitAdminWrites(req, res, next) {
 // during export would tear the archive. The window is short (seconds)
 // and admin-initiated. The backup endpoints themselves are exempt
 // because they are the operations holding the lock.
-const DATA_LOCK_EXEMPT_PATHS = ["/api/admin/backup", "/api/admin/restore"];
+// Paths that should NOT be 503'd while the data lock is held. Two
+// categories:
+//   1. The backup/restore endpoints themselves (they own the lock).
+//   2. Stateless gameplay POSTs that compute responses without
+//      writing to data/. Without these exemptions, players see
+//      failed guesses during long provider-inclusive exports — even
+//      though the gameplay calls don't touch the files restore is
+//      swapping. /api/stats/result IS NOT exempt: it persists the
+//      day's result via leaderboardStore.mutate which honors the
+//      mutate barrier already.
+const DATA_LOCK_EXEMPT_PATHS = [
+  "/api/admin/backup",
+  "/api/admin/restore",
+  "/api/encode",
+  "/api/random",
+  "/api/puzzle",
+  "/api/guess"
+];
 function isDataLockExemptPath(reqUrl) {
   if (typeof reqUrl !== "string") return false;
   // Strip query string if present.

--- a/server.js
+++ b/server.js
@@ -223,10 +223,47 @@ const INDEX_LOOKUP_UNAVAILABLE = Symbol("index-lookup-unavailable");
 let fullEnglishDefinitions = null;
 let englishDefinitionIndexManifest = null;
 let hasWarnedAboutDefinitionIndex = false;
+
+// Data-mutation lock used by backup export and restore. Acts as both a
+// boolean flag (the /api gate reads `.value` to 503 mutating requests)
+// AND a Promise barrier (stores call `.waitForRelease()` at the start
+// of every mutate so any in-flight handler that already passed the
+// gate is paused until the lock clears). Without the barrier, a
+// handler that passed the gate, hit an `await` (e.g. getSnapshot),
+// then resumed during a restore could call mutate() and overwrite the
+// just-restored file with cached pre-restore state.
+const dataMutationLockRef = {
+  _value: false,
+  _releaseResolve: null,
+  _releasePromise: Promise.resolve(),
+  get value() {
+    return this._value;
+  },
+  set value(next) {
+    if (next && !this._value) {
+      this._value = true;
+      this._releasePromise = new Promise((resolve) => {
+        this._releaseResolve = resolve;
+      });
+    } else if (!next && this._value) {
+      this._value = false;
+      const resolve = this._releaseResolve;
+      this._releaseResolve = null;
+      if (resolve) resolve();
+    }
+  },
+  async waitForRelease() {
+    if (!this._value) return;
+    await this._releasePromise;
+  }
+};
+const waitForDataMutationLock = () => dataMutationLockRef.waitForRelease();
+
 const leaderboardStore = new LeaderboardStore({
   filePath: LEADERBOARD_DATA_PATH,
   maxProfiles: ENV_LEADERBOARD_MAX_PROFILES,
-  maxResultsPerProfile: ENV_LEADERBOARD_MAX_RESULTS_PER_PROFILE
+  maxResultsPerProfile: ENV_LEADERBOARD_MAX_RESULTS_PER_PROFILE,
+  waitForDataMutationLock
 });
 
 function parsePositiveInteger(value, fallback) {
@@ -1032,18 +1069,21 @@ const appConfigStore = new AppConfigStore({
 });
 const adminJobsStore = new AdminJobsStore({
   filePath: ADMIN_JOBS_DATA_PATH,
-  logger: console
+  logger: console,
+  waitForDataMutationLock
 });
 const classesStore = new ClassesStore({
   filePath: CLASSES_DATA_PATH,
   maxMembersPerClass: ENV_CLASSES_MAX_MEMBERS_PER_CLASS,
-  logger: console
+  logger: console,
+  waitForDataMutationLock
 });
 let registeredLanguageCatalog = new Map();
 let availableLanguages = new Map();
 const providerImportQueueActiveRef = { value: false };
 const providerImportSyncActiveRef = { value: false };
-const dataMutationLockRef = { value: false };
+// dataMutationLockRef and waitForDataMutationLock are defined earlier
+// next to leaderboardStore so the constructor can wire the barrier.
 
 function initializeRuntimeConfig() {
   let normalizePromise;

--- a/server.js
+++ b/server.js
@@ -1082,6 +1082,13 @@ let registeredLanguageCatalog = new Map();
 let availableLanguages = new Map();
 const providerImportQueueActiveRef = { value: false };
 const providerImportSyncActiveRef = { value: false };
+// Marks the restore route as "claiming" the restore slot — set
+// synchronously after the busy-check, before the multipart upload
+// starts. Separate from dataMutationLockRef so we don't hold the
+// data-mutation barrier (which 503s every other admin write) for the
+// entire upload window. dataMutationLockRef is acquired later, just
+// before the actual swap.
+const restoreInProgressRef = { value: false };
 // dataMutationLockRef and waitForDataMutationLock are defined earlier
 // next to leaderboardStore so the constructor can wire the barrier.
 
@@ -2488,6 +2495,7 @@ app.use(
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     dataMutationLockRef,
+    restoreInProgressRef,
     backupMaxBytes: ENV_BACKUP_MAX_BYTES,
     backupIncludeProvidersDefault: ENV_BACKUP_INCLUDE_PROVIDERS_DEFAULT,
     backupRateLimiter

--- a/server.js
+++ b/server.js
@@ -2476,7 +2476,7 @@ function isDataLockExemptPath(reqUrl) {
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
   );
 }
-function gateDataMutationsDuringRestore(req, res, next) {
+function gateDataMutationsDuringDataLock(req, res, next) {
   const isMutating = req.method !== "GET" && req.method !== "HEAD" && req.method !== "OPTIONS";
   if (!isMutating) {
     next();
@@ -2498,7 +2498,7 @@ function gateDataMutationsDuringRestore(req, res, next) {
     code: "DATA_LOCK_HELD"
   });
 }
-app.use("/api", gateDataMutationsDuringRestore);
+app.use("/api", gateDataMutationsDuringDataLock);
 app.use("/api/admin", adminRateLimiter, requireAdminAccess, limitAdminWrites);
 
 function resolveAdminShellAssets() {

--- a/server.js
+++ b/server.js
@@ -2321,6 +2321,48 @@ function limitAdminWrites(req, res, next) {
   }
   adminWriteRateLimiter(req, res, next);
 }
+
+// Data-mutation lock: while a backup export or a restore apply is in
+// flight, refuse mutating requests to any /api/** endpoint that touches
+// data/. Without this gate, a player /api/stats/result POST or an admin
+// /api/word POST mid-restore could persist stale cached state over the
+// just-restored files, and a write between hash-time and archive-time
+// during export would tear the archive. The window is short (seconds)
+// and admin-initiated. The backup endpoints themselves are exempt
+// because they are the operations holding the lock.
+const DATA_LOCK_EXEMPT_PATHS = ["/api/admin/backup", "/api/admin/restore"];
+function isDataLockExemptPath(reqUrl) {
+  if (typeof reqUrl !== "string") return false;
+  // Strip query string if present.
+  const queryIdx = reqUrl.indexOf("?");
+  const pathname = queryIdx === -1 ? reqUrl : reqUrl.slice(0, queryIdx);
+  return DATA_LOCK_EXEMPT_PATHS.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+}
+function gateDataMutationsDuringRestore(req, res, next) {
+  const isMutating = req.method !== "GET" && req.method !== "HEAD" && req.method !== "OPTIONS";
+  if (!isMutating) {
+    next();
+    return;
+  }
+  if (!restoreActiveRef.value) {
+    next();
+    return;
+  }
+  // Use originalUrl so the exempt-prefix match works regardless of how
+  // the middleware is mounted (req.path is relative to the mount).
+  if (isDataLockExemptPath(req.originalUrl)) {
+    next();
+    return;
+  }
+  res.set("Retry-After", "5");
+  res.status(503).json({
+    error: "A backup/restore operation is in progress; data mutations are temporarily blocked.",
+    code: "DATA_LOCK_HELD"
+  });
+}
+app.use("/api", gateDataMutationsDuringRestore);
 app.use("/api/admin", adminRateLimiter, requireAdminAccess, limitAdminWrites);
 
 function resolveAdminShellAssets() {
@@ -2379,6 +2421,17 @@ app.use(
     appConfigStore,
     classesStore,
     rebuildLanguageRuntimeCatalog,
+    reloadWordData: () => {
+      // Re-read data/word.json from disk and refresh the in-memory cache
+      // backing /api/word and /daily. ensureWordData() falls back to the
+      // baked default if the file is missing or invalid.
+      const data = readWordData();
+      if (data) {
+        wordDataCache = data;
+      } else {
+        ensureWordData();
+      }
+    },
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     restoreActiveRef,

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require("express");
 const fs = require("fs");
 const fsp = fs.promises;
 const path = require("path");
+const nodeCrypto = require("node:crypto");
 const compression = require("compression");
 const helmet = require("helmet");
 const rateLimit = require("express-rate-limit");
@@ -1042,7 +1043,7 @@ let registeredLanguageCatalog = new Map();
 let availableLanguages = new Map();
 const providerImportQueueActiveRef = { value: false };
 const providerImportSyncActiveRef = { value: false };
-const restoreActiveRef = { value: false };
+const dataMutationLockRef = { value: false };
 
 function initializeRuntimeConfig() {
   let normalizePromise;
@@ -2136,7 +2137,7 @@ async function startProviderImportQueueIfNeeded() {
   if (
     providerImportQueueActiveRef.value
     || providerImportSyncActiveRef.value
-    || restoreActiveRef.value
+    || dataMutationLockRef.value
   ) {
     return;
   }
@@ -2346,7 +2347,7 @@ function gateDataMutationsDuringRestore(req, res, next) {
     next();
     return;
   }
-  if (!restoreActiveRef.value) {
+  if (!dataMutationLockRef.value) {
     next();
     return;
   }
@@ -2399,11 +2400,17 @@ const backupRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   // Throttle per admin key (when present) so two operators on the same IP
-  // don't share a single bucket. Falls back to express-rate-limit's
-  // built-in IPv6-aware ipKeyGenerator when no admin key is set.
+  // don't share a single bucket. The admin key itself is never used as the
+  // bucket id directly — we hash it first so the secret can't leak into
+  // rate-limit store dumps, logs, or metrics. Falls back to
+  // express-rate-limit's IPv6-aware ipKeyGenerator when no admin key is
+  // set.
   keyGenerator: (req, res) => {
     const key = req.headers["x-admin-key"];
-    if (typeof key === "string" && key.length > 0) return `admin:${key}`;
+    if (typeof key === "string" && key.length > 0) {
+      const digest = nodeCrypto.createHash("sha256").update(key).digest("hex").slice(0, 16);
+      return `admin:${digest}`;
+    }
     return rateLimitIpKeyGenerator(req, res);
   },
   message: { error: "Too many backup or restore requests. Try again later." }
@@ -2434,7 +2441,7 @@ app.use(
     },
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
-    restoreActiveRef,
+    dataMutationLockRef,
     backupMaxBytes: ENV_BACKUP_MAX_BYTES,
     backupIncludeProvidersDefault: ENV_BACKUP_INCLUDE_PROVIDERS_DEFAULT,
     backupRateLimiter
@@ -2482,7 +2489,7 @@ app.use(
     getProviderManualMaxFileBytes,
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
-    restoreActiveRef,
+    dataMutationLockRef,
     getEditableProviderManualMaxFileBytes,
     PROVIDER_MANUAL_MAX_FILE_BYTES_MIN,
     PROVIDER_COMMIT_PATTERN,

--- a/server.js
+++ b/server.js
@@ -2797,42 +2797,46 @@ app.get("/api/word", requireAdminAccess, (req, res) => {
 });
 
 app.post("/api/word", requireAdminAccess, async (req, res) => {
-  const word = normalizeWord(req.body.word);
-  const date = req.body.date ? String(req.body.date) : null;
-  const lang = resolveLang(req.body.lang);
-  if (!lang) {
-    return res.status(400).json({ error: "Unknown language." });
-  }
-
-  try {
-    assertWord(word, getMinLengthForLang(lang));
-  } catch (err) {
-    return res.status(400).json({ error: err.message });
-  }
-
-  const data = {
-    word,
-    lang,
-    date: date || null,
-    updatedAt: new Date().toISOString()
-  };
-
-  // Atomic claim: wait for the data-mutation lock, then increment the
-  // direct-write counter under one synchronous tick so a restore that
-  // claims the lock immediately after our wait can't race past us
-  // before saveWordDataAtomic runs. Restore busy check observes the
-  // counter and 409s while it's > 0.
+  // Claim the direct-write slot BEFORE validating. resolveLang() reads
+  // the live language registry, which a concurrent restore can swap
+  // out from under us. If we validated first and waited second, an
+  // archive that drops support for the requested lang would still let
+  // this request 200 — and persist a now-unsupported word over the
+  // freshly-restored data/word.json. Claiming first guarantees the
+  // restore (if any) has fully landed before we resolve lang/word.
   const releaseSlot = await claimDirectDataWriteSlot();
   try {
-    await saveWordDataAtomic(data);
-  } catch (err) {
-    console.error("Failed to persist daily word data.", err);
-    return res.status(500).json({ error: "Could not save daily word right now." });
+    const word = normalizeWord(req.body.word);
+    const date = req.body.date ? String(req.body.date) : null;
+    const lang = resolveLang(req.body.lang);
+    if (!lang) {
+      return res.status(400).json({ error: "Unknown language." });
+    }
+
+    try {
+      assertWord(word, getMinLengthForLang(lang));
+    } catch (err) {
+      return res.status(400).json({ error: err.message });
+    }
+
+    const data = {
+      word,
+      lang,
+      date: date || null,
+      updatedAt: new Date().toISOString()
+    };
+
+    try {
+      await saveWordDataAtomic(data);
+    } catch (err) {
+      console.error("Failed to persist daily word data.", err);
+      return res.status(500).json({ error: "Could not save daily word right now." });
+    }
+    wordDataCache = data;
+    res.json({ ok: true, data });
   } finally {
     releaseSlot();
   }
-  wordDataCache = data;
-  res.json({ ok: true, data });
 });
 
 // ============================================================================

--- a/server.js
+++ b/server.js
@@ -2182,13 +2182,16 @@ function toAdminJobResponse(job) {
 
 async function startProviderImportQueueIfNeeded() {
   // Bidirectional mutex with the restore router: don't start dequeueing
-  // jobs while a restore is mutating data/. Without this, a pending
-  // import could begin between the restore's pre-check and the leaderboard
-  // mutate and write data/providers/** concurrently with the swap.
+  // jobs while a restore is in flight. The restore now claims
+  // restoreInProgressRef synchronously (before the upload completes),
+  // and dataMutationLockRef later (right before the swap). Both must
+  // be checked here — checking only dataMutationLockRef would let an
+  // import start during the upload window and race the swap.
   if (
     providerImportQueueActiveRef.value
     || providerImportSyncActiveRef.value
     || dataMutationLockRef.value
+    || restoreInProgressRef.value
   ) {
     return;
   }
@@ -2544,6 +2547,7 @@ app.use(
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     dataMutationLockRef,
+    restoreInProgressRef,
     waitForDataMutationLock,
     getEditableProviderManualMaxFileBytes,
     PROVIDER_MANUAL_MAX_FILE_BYTES_MIN,

--- a/server.js
+++ b/server.js
@@ -147,6 +147,30 @@ const ENV_CLASSES_MAX_MEMBERS_PER_CLASS = clampEnvBounded(
   1000,
   "CLASSES_MAX_MEMBERS_PER_CLASS"
 );
+const ENV_BACKUP_MAX_BYTES = clampEnvBounded(
+  process.env.BACKUP_MAX_BYTES,
+  256 * 1024 * 1024,
+  1024 * 1024,
+  // Hard upper bound — operators wanting larger archives should split.
+  4 * 1024 * 1024 * 1024,
+  "BACKUP_MAX_BYTES"
+);
+const ENV_BACKUP_INCLUDE_PROVIDERS_DEFAULT =
+  String(process.env.BACKUP_INCLUDE_PROVIDERS_DEFAULT || "").toLowerCase() === "true";
+const ENV_BACKUP_RATE_LIMIT_WINDOW_MS = clampEnvBounded(
+  process.env.BACKUP_RATE_LIMIT_WINDOW_MS,
+  30 * 1000,
+  1000,
+  60 * 60 * 1000,
+  "BACKUP_RATE_LIMIT_WINDOW_MS"
+);
+const ENV_BACKUP_RATE_LIMIT_MAX = clampEnvBounded(
+  process.env.BACKUP_RATE_LIMIT_MAX,
+  1,
+  1,
+  100,
+  "BACKUP_RATE_LIMIT_MAX"
+);
 
 const MIN_LEN = 3;
 const MAX_LEN = 12;
@@ -1018,6 +1042,7 @@ let registeredLanguageCatalog = new Map();
 let availableLanguages = new Map();
 const providerImportQueueActiveRef = { value: false };
 const providerImportSyncActiveRef = { value: false };
+const restoreActiveRef = { value: false };
 
 function initializeRuntimeConfig() {
   let normalizePromise;
@@ -1508,6 +1533,26 @@ function rebuildLanguageRuntimeCatalog() {
 
 initializeRuntimeConfig();
 rebuildLanguageRuntimeCatalog();
+
+// Boot-time orphan check: a previous restore that crashed mid-apply leaves
+// .restore-staging-* / .restore-rollback-* dirs in data/. Log them loudly
+// rather than auto-deleting — operators may need to inspect or rewind.
+(async () => {
+  try {
+    const { findOrphanedRestoreDirs } = require("./lib/backup-store.js");
+    const orphans = await findOrphanedRestoreDirs(path.join(__dirname, "data"));
+    if (orphans.length > 0) {
+      const list = orphans.map((entry) => entry.name).join(", ");
+      console.warn(
+        `[backup-store] Found ${orphans.length} orphaned restore directory(ies) under data/: ${list}. ` +
+          "These are left over from a restore that did not complete. " +
+          "Inspect their contents before deleting; see docs/backup-restore.md."
+      );
+    }
+  } catch (err) {
+    console.warn(`[backup-store] Orphan-dir check failed: ${err?.message || String(err)}`);
+  }
+})();
 
 if (getDefinitionsMode() === "memory") {
   getOrLoadFullDefinitionsMap();
@@ -2297,6 +2342,44 @@ if (!fs.existsSync(ADMIN_SHELL.indexPath)) {
 }
 
 // Mount admin router first so GET /admin route takes precedence over static serving
+const { ipKeyGenerator: rateLimitIpKeyGenerator } = require("express-rate-limit");
+const backupRateLimiter = rateLimit({
+  windowMs: ENV_BACKUP_RATE_LIMIT_WINDOW_MS,
+  max: ENV_BACKUP_RATE_LIMIT_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  // Throttle per admin key (when present) so two operators on the same IP
+  // don't share a single bucket. Falls back to express-rate-limit's
+  // built-in IPv6-aware ipKeyGenerator when no admin key is set.
+  keyGenerator: (req, res) => {
+    const key = req.headers["x-admin-key"];
+    if (typeof key === "string" && key.length > 0) return `admin:${key}`;
+    return rateLimitIpKeyGenerator(req, res);
+  },
+  message: { error: "Too many backup or restore requests. Try again later." }
+});
+const createBackupRouter = require("./routes/backup.js");
+const BACKUP_PROJECT_ROOT = process.env.BACKUP_PROJECT_ROOT
+  ? path.resolve(process.env.BACKUP_PROJECT_ROOT)
+  : __dirname;
+app.use(
+  createBackupRouter({
+    projectRoot: BACKUP_PROJECT_ROOT,
+    leaderboardStore,
+    languageRegistryStore,
+    adminJobsStore,
+    appConfigStore,
+    classesStore,
+    rebuildLanguageRuntimeCatalog,
+    providerImportQueueActiveRef,
+    providerImportSyncActiveRef,
+    restoreActiveRef,
+    backupMaxBytes: ENV_BACKUP_MAX_BYTES,
+    backupIncludeProvidersDefault: ENV_BACKUP_INCLUDE_PROVIDERS_DEFAULT,
+    backupRateLimiter
+  })
+);
+
 const createAdminRouter = require("./routes/admin.js");
 app.use(
   createAdminRouter({

--- a/server.js
+++ b/server.js
@@ -259,22 +259,33 @@ const dataMutationLockRef = {
 };
 const waitForDataMutationLock = () => dataMutationLockRef.waitForRelease();
 
-// Atomic claim helper for direct data writers. Loops: wait for the
-// lock, then synchronously verify no restore is in flight and bump
-// the counter. Returns a release fn to call in finally. Without this,
-// a writer that simply awaits waitForDataMutationLock() can race a
-// new restore that claims the lock during the next event-loop tick.
+// Atomic claim helper for direct data writers. Loops: wait for
+// whichever barrier is holding things up, then synchronously verify
+// no restore/lock is in flight and bump the counter. Returns a
+// release fn to call in finally. Without this, a writer that simply
+// awaits waitForDataMutationLock() can race a new restore that claims
+// the lock during the next event-loop tick.
+//
+// Critically, restoreInProgressRef is held across the restore's
+// multipart upload (which can take many seconds) WITHOUT
+// dataMutationLockRef being held. Awaiting only the data-lock barrier
+// would resolve immediately and the loop would spin until the upload
+// finished — busy-looping on already-resolved awaits hangs the event
+// loop and stalls the upload itself. We pick the right barrier per
+// iteration so the wait is real every time.
 async function claimDirectDataWriteSlot() {
   while (true) {
-    await waitForDataMutationLock();
-    // Synchronous check + increment — no awaits in between, so no
-    // other handler can run.
-    if (
-      dataMutationLockRef.value
-      || restoreInProgressRef.value
-    ) {
+    if (dataMutationLockRef.value) {
+      await dataMutationLockRef.waitForRelease();
       continue;
     }
+    if (restoreInProgressRef.value) {
+      await restoreInProgressRef.waitForRelease();
+      continue;
+    }
+    // Neither flag is held — claim the slot in the same synchronous
+    // tick (no awaits between the check and the increment, so JS's
+    // single-threaded model guarantees no other handler interposes).
     directDataWriteActiveRef.value += 1;
     return () => {
       directDataWriteActiveRef.value -= 1;
@@ -1112,6 +1123,38 @@ const providerImportSyncActiveRef = { value: false };
 // staged upload + queued job orphaned. The restore busy check
 // observes this ref and 409s the restore in that window.
 const providerImportEnqueueActiveRef = { value: false };
+// Promise-barrier for restoreInProgressRef so direct writers can
+// `await` for the restore to release without busy-spinning on a
+// resolved data-lock barrier (the data lock isn't held during the
+// restore's upload phase). Mirrors the dataMutationLockRef shape.
+const restoreInProgressRef = (() => {
+  const ref = {
+    _value: false,
+    _resolveRelease: null,
+    _releasePromise: Promise.resolve(),
+    get value() {
+      return this._value;
+    },
+    set value(next) {
+      if (next && !this._value) {
+        this._value = true;
+        this._releasePromise = new Promise((resolve) => {
+          this._resolveRelease = resolve;
+        });
+      } else if (!next && this._value) {
+        this._value = false;
+        const resolve = this._resolveRelease;
+        this._resolveRelease = null;
+        if (resolve) resolve();
+      }
+    },
+    async waitForRelease() {
+      if (!this._value) return;
+      await this._releasePromise;
+    }
+  };
+  return ref;
+})();
 // Counter incremented by direct (non-store-mutate) data writers —
 // PUT /api/admin/runtime-config and POST /api/word — for the duration
 // of their validation+persist sequence. The restore busy check
@@ -1123,15 +1166,11 @@ const providerImportEnqueueActiveRef = { value: false };
 // and increment the counter (no awaits between the check and
 // increment).
 const directDataWriteActiveRef = { value: 0 };
-// Marks the restore route as "claiming" the restore slot — set
-// synchronously after the busy-check, before the multipart upload
-// starts. Separate from dataMutationLockRef so we don't hold the
-// data-mutation barrier (which 503s every other admin write) for the
-// entire upload window. dataMutationLockRef is acquired later, just
-// before the actual swap.
-const restoreInProgressRef = { value: false };
-// dataMutationLockRef and waitForDataMutationLock are defined earlier
-// next to leaderboardStore so the constructor can wire the barrier.
+// dataMutationLockRef, waitForDataMutationLock, restoreInProgressRef,
+// providerImportEnqueueActiveRef, directDataWriteActiveRef, and
+// claimDirectDataWriteSlot are all defined earlier alongside
+// leaderboardStore so the store constructor can wire the barrier and
+// admin/backup routes can share the helpers.
 
 function initializeRuntimeConfig() {
   let normalizePromise;

--- a/server.js
+++ b/server.js
@@ -257,7 +257,26 @@ const dataMutationLockRef = {
     await this._releasePromise;
   }
 };
-const waitForDataMutationLock = () => dataMutationLockRef.waitForRelease();
+// Stores call this at the top of every mutation. Waits until BOTH
+// dataMutationLockRef AND restoreInProgressRef are clear. The latter
+// is held across a restore's full multipart upload, before the data
+// lock is taken — so a mutation that arrives during the upload would
+// otherwise pass straight through, load pre-restore state, and then
+// (after the lock is taken and released) persist that stale state
+// over the just-restored file. Looping covers the case where a new
+// restore claims a flag between two `await waitForRelease()` calls.
+async function waitForDataMutationLock() {
+  while (dataMutationLockRef.value || restoreInProgressRef.value) {
+    if (dataMutationLockRef.value) {
+      await dataMutationLockRef.waitForRelease();
+      continue;
+    }
+    if (restoreInProgressRef.value) {
+      await restoreInProgressRef.waitForRelease();
+      continue;
+    }
+  }
+}
 
 // Atomic claim helper for direct data writers. Loops: wait for
 // whichever barrier is holding things up, then synchronously verify

--- a/tests/backup-restore.integration.test.js
+++ b/tests/backup-restore.integration.test.js
@@ -327,6 +327,41 @@ describe("Backup API: restore", () => {
   });
 });
 
+describe("Backup API: data mutation lock during export", () => {
+  test("blocks mutating /api/admin/* writes while an export is streaming", async () => {
+    const paths = makeTempState();
+    const app = loadFreshApp("secret", paths);
+
+    // Fire an export and a class-create concurrently. The export takes
+    // the data-lock for its entire stream; the class POST should
+    // observe the lock and 503. Either ordering is acceptable as long
+    // as one of them is 503 when both run while the lock is held.
+    const exportPromise = request(app)
+      .get("/api/admin/backup")
+      .set("x-admin-key", "secret")
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+    const writePromise = request(app)
+      .post("/api/admin/classes")
+      .set("x-admin-key", "secret")
+      .send({ name: "Mid-Export Class" });
+
+    const [exportRes, writeRes] = await Promise.all([exportPromise, writePromise]);
+    expect(exportRes.status).toBe(200);
+    // The write either landed before the lock was taken (200/201) or
+    // hit the lock and 503'd. Both outcomes leave the export consistent.
+    expect([200, 201, 503]).toContain(writeRes.status);
+    if (writeRes.status === 503) {
+      expect(writeRes.body.code).toBe("DATA_LOCK_HELD");
+      expect(writeRes.headers["retry-after"]).toBe("5");
+    }
+  });
+});
+
 describe("Backup API: oversize upload", () => {
   test("returns 413 when archive exceeds BACKUP_MAX_BYTES", async () => {
     const paths = makeTempState();

--- a/tests/backup-restore.integration.test.js
+++ b/tests/backup-restore.integration.test.js
@@ -281,49 +281,39 @@ describe("Backup API: restore", () => {
     ]));
   });
 
-  test("rejects restore when another restore is already in flight", async () => {
-    // Simulate the mutex by setting restoreActiveRef.value = true before
-    // the request. Since the ref is internal to server.js, we use a
-    // simulator: mutate the live process.env to force the rate limiter to
-    // lock things… actually the cleanest way is to mark the mutex via a
-    // POST that itself takes the mutex. Skipped here; covered indirectly
-    // by the unit-test layer (the route's busy check is straightforward).
-    // This test asserts the 409 returned by the route when mutex is held,
-    // which we exercise by issuing two concurrent restores against a
-    // server with no admin-key gating beyond the env wiring.
-    const paths = makeTempState();
-    const app = loadFreshApp("secret", paths);
-    const exportRes = await request(app)
-      .get("/api/admin/backup")
-      .set("x-admin-key", "secret")
-      .buffer(true)
-      .parse((response, callback) => {
-        const chunks = [];
-        response.on("data", (chunk) => chunks.push(chunk));
-        response.on("end", () => callback(null, Buffer.concat(chunks)));
-      });
+  test("rejects a restore request when the data-mutation lock is already held", async () => {
+    // Direct route-level test. We can't easily mock applyRestore through
+    // the server's destructured import without a fragile module-mock
+    // dance, so verify the busy path directly: import the backup router
+    // factory, hold the lock manually, fire one restore, and assert it
+    // returns 409 + RESTORE_BUSY.
+    const fsLib = require("fs");
+    const expressLib = require("express");
 
-    // Fire two restore requests "concurrently" — supertest runs them
-    // sequentially per agent, so this is best-effort. The first should
-    // succeed; if the second arrives during the first's mutex window it
-    // returns 409. If the mutex has already released, both succeed —
-    // either outcome is acceptable for this test (we're verifying the
-    // 409 path doesn't crash).
-    const firstPromise = request(app)
+    jest.resetModules();
+    resetEnv();
+    const dataMutationLockRef = { value: true };
+    const noopRef = { value: false };
+
+    const createBackupRouter = require("../routes/backup.js");
+    const backupRouter = createBackupRouter({
+      projectRoot: "/tmp",
+      providerImportQueueActiveRef: noopRef,
+      providerImportSyncActiveRef: noopRef,
+      dataMutationLockRef,
+      backupMaxBytes: 1024,
+      backupIncludeProvidersDefault: false
+    });
+
+    const app = expressLib();
+    app.use(backupRouter);
+
+    const res = await request(app)
       .post("/api/admin/restore")
-      .set("x-admin-key", "secret")
       .set(RESTORE_CONFIRM_HEADER, RESTORE_CONFIRM_VALUE)
-      .attach("archive", exportRes.body, "test.zip");
-    const secondPromise = request(app)
-      .post("/api/admin/restore")
-      .set("x-admin-key", "secret")
-      .set(RESTORE_CONFIRM_HEADER, RESTORE_CONFIRM_VALUE)
-      .attach("archive", exportRes.body, "test.zip");
-    const [first, second] = await Promise.all([firstPromise, secondPromise]);
-    const statuses = [first.status, second.status].sort();
-    // Either both 200 (no overlap) or one 200 + one 409 (overlapped).
-    expect(statuses[0]).toBe(200);
-    expect([200, 409]).toContain(statuses[1]);
+      .attach("archive", fsLib.readFileSync(__filename), "fake.zip");
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("RESTORE_BUSY");
   });
 });
 

--- a/tests/backup-restore.integration.test.js
+++ b/tests/backup-restore.integration.test.js
@@ -1,0 +1,355 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const request = require("supertest");
+
+const { RESTORE_CONFIRM_HEADER, RESTORE_CONFIRM_VALUE } = require("../routes/backup.js");
+
+const ORIGINAL_ENV = { ...process.env };
+const tempDirsToClean = [];
+
+function resetEnv() {
+  Object.keys(process.env).forEach((key) => {
+    if (!(key in ORIGINAL_ENV)) {
+      delete process.env[key];
+    }
+  });
+  Object.entries(ORIGINAL_ENV).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+}
+
+function makeTempState() {
+  // Build an isolated project root with the data/ schemas + sample state
+  // copied in. BACKUP_PROJECT_ROOT points the backup router here so
+  // export/restore operate on this temp tree rather than the repo's
+  // real data/ directory (no test-induced repo pollution).
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-backup-"));
+  tempDirsToClean.push(projectRoot);
+  const dir = path.join(projectRoot, "data");
+  fs.mkdirSync(dir, { recursive: true });
+  // Copy schemas from the real repo so digest checks have real bytes.
+  const repoRoot = path.resolve(__dirname, "..");
+  for (const rel of [
+    "data/leaderboard.schema.json",
+    "data/languages.schema.json",
+    "data/admin-jobs.schema.json",
+    "data/app-config.schema.json",
+    "data/classes.schema.json",
+    "data/backup-manifest.schema.json"
+  ]) {
+    const dest = path.join(projectRoot, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(path.join(repoRoot, rel), dest);
+  }
+  fs.mkdirSync(path.join(dir, "providers"), { recursive: true });
+  fs.copyFileSync(
+    path.join(repoRoot, "data/providers/provider-import-manifest.schema.json"),
+    path.join(dir, "providers/provider-import-manifest.schema.json")
+  );
+  // Copy languages.json (real schema is involved; just reuse the canonical)
+  fs.copyFileSync(
+    path.join(repoRoot, "data/languages.json"),
+    path.join(dir, "languages.json")
+  );
+  // Borrow package.json so readAppVersion finds the real version
+  fs.copyFileSync(
+    path.join(repoRoot, "package.json"),
+    path.join(projectRoot, "package.json")
+  );
+  // Synthetic word.json
+  fs.writeFileSync(
+    path.join(dir, "word.json"),
+    `${JSON.stringify({ word: "TESTS", date: "2026-01-01" })}\n`,
+    "utf8"
+  );
+  const statsPath = path.join(dir, "leaderboard.json");
+  const classesPath = path.join(dir, "classes.json");
+  const adminJobsPath = path.join(dir, "admin-jobs.json");
+  const appConfigPath = path.join(dir, "app-config.json");
+  fs.writeFileSync(
+    statsPath,
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: new Date(0).toISOString(),
+      profiles: [],
+      resultsByProfile: {}
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    classesPath,
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: new Date(0).toISOString(),
+      classes: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    adminJobsPath,
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: new Date(0).toISOString(),
+      jobs: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    appConfigPath,
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: new Date(0).toISOString(),
+      overrides: {}
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  return { statsPath, classesPath, adminJobsPath, appConfigPath, projectRoot };
+}
+
+function loadFreshApp(adminKey, paths, extraEnv = {}) {
+  jest.resetModules();
+  resetEnv();
+  process.env.ADMIN_KEY = adminKey;
+  process.env.STATS_STORE_PATH = paths.statsPath;
+  process.env.CLASSES_STORE_PATH = paths.classesPath;
+  process.env.ADMIN_JOBS_STORE_PATH = paths.adminJobsPath;
+  process.env.APP_CONFIG_PATH = paths.appConfigPath;
+  process.env.RATE_LIMIT_MAX = "1000";
+  process.env.ADMIN_RATE_LIMIT_MAX = "1000";
+  process.env.ADMIN_WRITE_RATE_LIMIT_MAX = "1000";
+  // Generous backup rate limit so successive test calls don't 429.
+  process.env.BACKUP_RATE_LIMIT_MAX = "100";
+  process.env.BACKUP_RATE_LIMIT_WINDOW_MS = "1000";
+  // Isolate backup operations to the temp project root so tests don't
+  // touch the real repo's data/ directory.
+  if (paths.projectRoot) {
+    process.env.BACKUP_PROJECT_ROOT = paths.projectRoot;
+  }
+  for (const [key, value] of Object.entries(extraEnv)) {
+    if (value === undefined || value === null) continue;
+    process.env[key] = String(value);
+  }
+  return require("../server");
+}
+
+afterEach(() => {
+  resetEnv();
+  jest.resetModules();
+});
+
+afterAll(() => {
+  for (const dir of tempDirsToClean) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+  tempDirsToClean.length = 0;
+});
+
+describe("Backup API: export", () => {
+  test("requires admin key", async () => {
+    const paths = makeTempState();
+    const app = loadFreshApp("secret", paths);
+    const res = await request(app).get("/api/admin/backup");
+    expect(res.status).toBe(401);
+  });
+
+  test("streams a zip archive with expected Content-Disposition", async () => {
+    const paths = makeTempState();
+    const app = loadFreshApp("secret", paths);
+    const res = await request(app)
+      .get("/api/admin/backup")
+      .set("x-admin-key", "secret")
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/application\/zip/);
+    expect(res.headers["content-disposition"]).toMatch(/attachment; filename="wordle-backup-/);
+    expect(Buffer.isBuffer(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(64);
+    // Zip magic number
+    expect(res.body.slice(0, 2).toString("ascii")).toBe("PK");
+  });
+});
+
+describe("Backup API: preview", () => {
+  test("returns manifest summary for a freshly-exported archive", async () => {
+    const paths = makeTempState();
+    const app = loadFreshApp("secret", paths);
+
+    const exportRes = await request(app)
+      .get("/api/admin/backup")
+      .set("x-admin-key", "secret")
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+    expect(exportRes.status).toBe(200);
+
+    const previewRes = await request(app)
+      .post("/api/admin/backup/preview")
+      .set("x-admin-key", "secret")
+      .attach("archive", exportRes.body, "test.zip");
+    expect(previewRes.status).toBe(200);
+    expect(previewRes.body.ok).toBe(true);
+    expect(previewRes.body.manifestVersion).toBe(1);
+    expect(Array.isArray(previewRes.body.files)).toBe(true);
+    expect(previewRes.body.files.length).toBeGreaterThan(0);
+    expect(typeof previewRes.body.totalBytes).toBe("number");
+  });
+
+  test("rejects malformed archive with 400", async () => {
+    const paths = makeTempState();
+    const app = loadFreshApp("secret", paths);
+    const res = await request(app)
+      .post("/api/admin/backup/preview")
+      .set("x-admin-key", "secret")
+      .attach("archive", Buffer.from("not a zip"), "fake.zip");
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+});
+
+describe("Backup API: restore", () => {
+  test("requires the confirm header", async () => {
+    const paths = makeTempState();
+    const app = loadFreshApp("secret", paths);
+    const exportRes = await request(app)
+      .get("/api/admin/backup")
+      .set("x-admin-key", "secret")
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+    expect(exportRes.status).toBe(200);
+
+    const res = await request(app)
+      .post("/api/admin/restore")
+      .set("x-admin-key", "secret")
+      .attach("archive", exportRes.body, "test.zip");
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("RESTORE_CONFIRM_MISSING");
+  });
+
+  test("accepts a freshly-exported archive and reports cache reloads", async () => {
+    // Note: the byte-level round-trip is verified by the lib/backup-store
+    // unit tests (which control the projectRoot end-to-end). Here we
+    // verify the HTTP layer: the route accepts a valid archive, runs
+    // apply, and surfaces the post-apply cache-reload results — with the
+    // env-redirected store paths, the canonical applyRestore writes to
+    // the real <projectRoot>/data/, so we can't assert against the temp
+    // store paths here without leaking into the repo.
+    const paths = makeTempState();
+    const app = loadFreshApp("secret", paths);
+    const exportRes = await request(app)
+      .get("/api/admin/backup")
+      .set("x-admin-key", "secret")
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+    expect(exportRes.status).toBe(200);
+
+    const restoreRes = await request(app)
+      .post("/api/admin/restore")
+      .set("x-admin-key", "secret")
+      .set(RESTORE_CONFIRM_HEADER, RESTORE_CONFIRM_VALUE)
+      .attach("archive", exportRes.body, "test.zip");
+    expect(restoreRes.status).toBe(200);
+    expect(restoreRes.body.ok).toBe(true);
+    expect(restoreRes.body.rolledBackOnError).toBe(false);
+    expect(restoreRes.body.filesRestored).toBeGreaterThan(0);
+    expect(Array.isArray(restoreRes.body.reloads)).toBe(true);
+    const reloadNames = restoreRes.body.reloads.map((entry) => entry.name);
+    expect(reloadNames).toEqual(expect.arrayContaining([
+      "leaderboardStore",
+      "classesStore",
+      "appConfigStore"
+    ]));
+  });
+
+  test("rejects restore when another restore is already in flight", async () => {
+    // Simulate the mutex by setting restoreActiveRef.value = true before
+    // the request. Since the ref is internal to server.js, we use a
+    // simulator: mutate the live process.env to force the rate limiter to
+    // lock things… actually the cleanest way is to mark the mutex via a
+    // POST that itself takes the mutex. Skipped here; covered indirectly
+    // by the unit-test layer (the route's busy check is straightforward).
+    // This test asserts the 409 returned by the route when mutex is held,
+    // which we exercise by issuing two concurrent restores against a
+    // server with no admin-key gating beyond the env wiring.
+    const paths = makeTempState();
+    const app = loadFreshApp("secret", paths);
+    const exportRes = await request(app)
+      .get("/api/admin/backup")
+      .set("x-admin-key", "secret")
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+
+    // Fire two restore requests "concurrently" — supertest runs them
+    // sequentially per agent, so this is best-effort. The first should
+    // succeed; if the second arrives during the first's mutex window it
+    // returns 409. If the mutex has already released, both succeed —
+    // either outcome is acceptable for this test (we're verifying the
+    // 409 path doesn't crash).
+    const firstPromise = request(app)
+      .post("/api/admin/restore")
+      .set("x-admin-key", "secret")
+      .set(RESTORE_CONFIRM_HEADER, RESTORE_CONFIRM_VALUE)
+      .attach("archive", exportRes.body, "test.zip");
+    const secondPromise = request(app)
+      .post("/api/admin/restore")
+      .set("x-admin-key", "secret")
+      .set(RESTORE_CONFIRM_HEADER, RESTORE_CONFIRM_VALUE)
+      .attach("archive", exportRes.body, "test.zip");
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+    const statuses = [first.status, second.status].sort();
+    // Either both 200 (no overlap) or one 200 + one 409 (overlapped).
+    expect(statuses[0]).toBe(200);
+    expect([200, 409]).toContain(statuses[1]);
+  });
+});
+
+describe("Backup API: oversize upload", () => {
+  test("returns 413 when archive exceeds BACKUP_MAX_BYTES", async () => {
+    const paths = makeTempState();
+    // First produce a valid archive against a server with the normal cap.
+    const exportApp = loadFreshApp("secret", paths);
+    const exportRes = await request(exportApp)
+      .get("/api/admin/backup")
+      .set("x-admin-key", "secret")
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+    // Pad the archive over the cap so we trigger the upload-time guard.
+    const padded = Buffer.concat([exportRes.body, Buffer.alloc(2 * 1024 * 1024)]);
+    // Reload the small-cap server so we have a fresh request handler.
+    const limitedApp = loadFreshApp("secret", paths, { BACKUP_MAX_BYTES: "1048576" });
+    const res = await request(limitedApp)
+      .post("/api/admin/backup/preview")
+      .set("x-admin-key", "secret")
+      .attach("archive", padded, "test.zip");
+    expect(res.status).toBe(413);
+    expect(res.body.code).toBe("ARCHIVE_TOO_LARGE");
+  });
+});

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -286,11 +286,15 @@ describe("validateArchive rejection cases", () => {
     await archive.finalize();
     await new Promise((resolve) => out.on("close", resolve));
 
+    // Schema enforces `manifestVersion: { const: 1 }`, so the mismatch
+    // is caught at schema-validation time (MANIFEST_INVALID) before the
+    // runtime version check (MANIFEST_VERSION_UNSUPPORTED) ever runs.
+    // Either error means the same thing operationally — version 999 is
+    // rejected — but the schema layer is the cheaper and earlier guard.
     await expect(
       validateArchive(tamperedPath, { projectRoot })
     ).rejects.toMatchObject({
-      code: "MANIFEST_VERSION_UNSUPPORTED",
-      details: expect.objectContaining({ expected: 1, got: 999 })
+      code: "MANIFEST_INVALID"
     });
   });
 

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -398,6 +398,99 @@ describe("validateArchive rejection cases", () => {
   });
 });
 
+describe("validateArchive security guards", () => {
+  test("rejects manifest with optionalSet entry outside the allowed prefix", async () => {
+    const projectRoot = await tempProject();
+    const archiver = require("archiver");
+    const archivePath = path.join(projectRoot, "evil-optional.zip");
+    const archive = archiver("zip");
+    const out = fs.createWriteStream(archivePath);
+    archive.pipe(out);
+    const evilBytes = Buffer.from("evil");
+    archive.append(JSON.stringify({
+      manifestVersion: 1,
+      appVersion: "0.0.0",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      nodeId: "evil",
+      files: [
+        {
+          path: "server.js",
+          bytes: evilBytes.length,
+          sha256: sha256OfBuffer(evilBytes),
+          optionalSet: "providers"
+        }
+      ],
+      optionalSets: ["providers"]
+    }, null, 2), { name: "manifest.json" });
+    archive.append(evilBytes, { name: "server.js" });
+    await archive.finalize();
+    await new Promise((resolve) => out.on("close", resolve));
+
+    await expect(
+      validateArchive(archivePath, { projectRoot })
+    ).rejects.toMatchObject({
+      code: "OPTIONAL_SET_PATH_INVALID"
+    });
+  });
+
+  test("rejects archive with duplicate paths", async () => {
+    const projectRoot = await tempProject();
+    const archiver = require("archiver");
+    const archivePath = path.join(projectRoot, "dup.zip");
+    const archive = archiver("zip");
+    const out = fs.createWriteStream(archivePath);
+    archive.pipe(out);
+    const buf = Buffer.from("{}");
+    archive.append(JSON.stringify({
+      manifestVersion: 1,
+      appVersion: "0.0.0",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      nodeId: "dup",
+      files: [
+        { path: "data/word.json", bytes: buf.length, sha256: sha256OfBuffer(buf) },
+        { path: "data/word.json", bytes: buf.length, sha256: sha256OfBuffer(buf) }
+      ],
+      optionalSets: []
+    }, null, 2), { name: "manifest.json" });
+    archive.append(buf, { name: "data/word.json" });
+    archive.append(buf, { name: "data/word.json" });
+    await archive.finalize();
+    await new Promise((resolve) => out.on("close", resolve));
+
+    await expect(
+      validateArchive(archivePath, { projectRoot })
+    ).rejects.toMatchObject({
+      code: "MANIFEST_DUPLICATE_PATH"
+    });
+  });
+
+  test("ignores explicit directory entries instead of rejecting them", async () => {
+    const projectRoot = await tempProject();
+    const archiver = require("archiver");
+    const archivePath = path.join(projectRoot, "with-dirs.zip");
+    const archive = archiver("zip");
+    const out = fs.createWriteStream(archivePath);
+    archive.pipe(out);
+    // Build a normal manifest from the project, then append a stray
+    // directory entry to the archive to verify it doesn't break validation.
+    const manifest = await buildManifest({
+      projectRoot,
+      includeProviders: false,
+      includeDictionaries: false
+    });
+    archive.append(`${JSON.stringify(manifest, null, 2)}\n`, { name: "manifest.json" });
+    for (const entry of manifest.files) {
+      archive.file(path.join(projectRoot, entry.path), { name: entry.path });
+    }
+    archive.append("", { name: "data/providers/" });
+    await archive.finalize();
+    await new Promise((resolve) => out.on("close", resolve));
+
+    const result = await validateArchive(archivePath, { projectRoot });
+    expect(result.manifest.manifestVersion).toBe(1);
+  });
+});
+
 describe("applyRestore happy path", () => {
   test("replaces in-scope files byte-equal to archive contents", async () => {
     const projectRoot = await tempProject();

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -289,7 +289,8 @@ describe("validateArchive rejection cases", () => {
     await expect(
       validateArchive(tamperedPath, { projectRoot })
     ).rejects.toMatchObject({
-      code: "MANIFEST_INVALID"
+      code: "MANIFEST_VERSION_UNSUPPORTED",
+      details: expect.objectContaining({ expected: 1, got: 999 })
     });
   });
 

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -526,6 +526,34 @@ describe("applyRestore happy path", () => {
     const orphans = await findOrphanedRestoreDirs(path.join(projectRoot, "data"));
     expect(orphans).toEqual([]);
   });
+
+  test("provider-inclusive restore preserves the diagnostic provider schema", async () => {
+    // Phase 2.5's optional-root prune walks data/providers/** and
+    // queues for deletion any file that's NOT in restorablePaths. The
+    // diagnostic provider-import-manifest.schema.json lives under that
+    // prefix but is intentionally not restorable — it's bundled as
+    // read-only metadata. The prune must skip it so future schema
+    // checks don't break.
+    const projectRoot = await tempProject();
+    // Add a provider artifact so providers are non-empty in the archive.
+    const providerDir = path.join(projectRoot, "data/providers/en-US/abc123");
+    await fsp.mkdir(providerDir, { recursive: true });
+    await fsp.writeFile(path.join(providerDir, "en_US.dic"), "1\nWORLD\n", "utf8");
+
+    const { archivePath } = await exportArchiveToFile(projectRoot, {
+      includeProviders: true
+    });
+
+    const schemaAbs = path.join(projectRoot, "data/providers/provider-import-manifest.schema.json");
+    expect(await fsp.access(schemaAbs).then(() => true, () => false)).toBe(true);
+
+    const result = await applyRestore({ archivePath, projectRoot });
+    expect(result.rolledBack).toBe(false);
+    expect(result.removed).not.toContain("data/providers/provider-import-manifest.schema.json");
+
+    // Schema file still on disk after the restore.
+    expect(await fsp.access(schemaAbs).then(() => true, () => false)).toBe(true);
+  });
 });
 
 describe("applyRestore rollback on mid-write failure", () => {

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -286,15 +286,11 @@ describe("validateArchive rejection cases", () => {
     await archive.finalize();
     await new Promise((resolve) => out.on("close", resolve));
 
-    // Schema enforces `manifestVersion: { const: 1 }`, so the mismatch
-    // is caught at schema-validation time (MANIFEST_INVALID) before the
-    // runtime version check (MANIFEST_VERSION_UNSUPPORTED) ever runs.
-    // Either error means the same thing operationally — version 999 is
-    // rejected — but the schema layer is the cheaper and earlier guard.
     await expect(
       validateArchive(tamperedPath, { projectRoot })
     ).rejects.toMatchObject({
-      code: "MANIFEST_INVALID"
+      code: "MANIFEST_VERSION_UNSUPPORTED",
+      details: expect.objectContaining({ expected: 1, got: 999 })
     });
   });
 

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -178,6 +178,41 @@ describe("buildManifest", () => {
     }
   });
 
+  test("includeProviders does not duplicate the diagnostic provider-import-manifest schema", async () => {
+    const projectRoot = await tempProject();
+    // Add a provider artifact alongside the schema that's already present
+    // under data/providers/. Without dedup the diagnostic schema would
+    // appear twice in the manifest (once as DIAGNOSTIC, once via the
+    // providers walk), and restore would conflict on the staging path.
+    const providerDir = path.join(projectRoot, "data/providers/en-US/abc123");
+    await fsp.mkdir(providerDir, { recursive: true });
+    await fsp.writeFile(path.join(providerDir, "en_US.dic"), "1\nWORLD\n", "utf8");
+    const manifest = await buildManifest({
+      projectRoot,
+      includeProviders: true,
+      includeDictionaries: false
+    });
+    const counts = new Map();
+    for (const entry of manifest.files) {
+      counts.set(entry.path, (counts.get(entry.path) || 0) + 1);
+    }
+    for (const [archivePath, count] of counts) {
+      expect({ archivePath, count }).toEqual({ archivePath, count: 1 });
+    }
+    // The provider artifact is included with the providers tag;
+    // the diagnostic schema is not double-tagged.
+    const providerEntry = manifest.files.find(
+      (entry) => entry.path === "data/providers/en-US/abc123/en_US.dic"
+    );
+    expect(providerEntry).toBeDefined();
+    expect(providerEntry.optionalSet).toBe("providers");
+    const schemaEntry = manifest.files.find(
+      (entry) => entry.path === "data/providers/provider-import-manifest.schema.json"
+    );
+    expect(schemaEntry).toBeDefined();
+    expect(schemaEntry.optionalSet).toBeUndefined();
+  });
+
   test("attaches schema digest for files that have a schema", async () => {
     const projectRoot = await tempProject();
     const manifest = await buildManifest({

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -1,0 +1,485 @@
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const os = require("node:os");
+const nodeCrypto = require("node:crypto");
+
+const {
+  BackupError,
+  MANIFEST_VERSION,
+  IN_SCOPE_FILES,
+  buildManifest,
+  createArchive,
+  validateArchive,
+  applyRestore,
+  findOrphanedRestoreDirs,
+  isPathSafe,
+  sha256OfBuffer
+} = require("../lib/backup-store.js");
+
+// Each test gets its own temp project root populated with a minimal data/
+// tree. Schemas are copied from the real repo so schema-digest checks have
+// real bytes to hash; data files are tiny but schema-valid.
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+async function copyFileFromRepo(rel, destProjectRoot) {
+  const src = path.join(REPO_ROOT, rel);
+  const dest = path.join(destProjectRoot, rel);
+  await fsp.mkdir(path.dirname(dest), { recursive: true });
+  await fsp.copyFile(src, dest);
+}
+
+async function makeProjectRoot() {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "backup-store-"));
+  await fsp.mkdir(path.join(dir, "data"), { recursive: true });
+  // Copy schemas (these get bundled in the archive and used for validation)
+  for (const rel of [
+    "data/leaderboard.schema.json",
+    "data/languages.schema.json",
+    "data/admin-jobs.schema.json",
+    "data/app-config.schema.json",
+    "data/classes.schema.json",
+    "data/backup-manifest.schema.json"
+  ]) {
+    await copyFileFromRepo(rel, dir);
+  }
+  await fsp.mkdir(path.join(dir, "data", "providers"), { recursive: true });
+  await copyFileFromRepo("data/providers/provider-import-manifest.schema.json", dir);
+  // Minimal package.json so readAppVersion finds something
+  await fsp.writeFile(
+    path.join(dir, "package.json"),
+    `${JSON.stringify({ name: "test-app", version: "0.0.0-test" })}\n`,
+    "utf8"
+  );
+  // Schema-valid data files (only what each schema requires)
+  await fsp.writeFile(
+    path.join(dir, "data", "leaderboard.json"),
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      profiles: [],
+      resultsByProfile: {}
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  await fsp.writeFile(
+    path.join(dir, "data", "admin-jobs.json"),
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      jobs: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  await fsp.writeFile(
+    path.join(dir, "data", "app-config.json"),
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      overrides: {}
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  await fsp.writeFile(
+    path.join(dir, "data", "classes.json"),
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      classes: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  // Borrow real languages.json — its schema is more involved
+  await copyFileFromRepo("data/languages.json", dir);
+  // Optional: word.json — schema-less, can be anything
+  await fsp.writeFile(
+    path.join(dir, "data", "word.json"),
+    `${JSON.stringify({ word: "TESTS", date: "2026-01-01" })}\n`,
+    "utf8"
+  );
+  return dir;
+}
+
+const tempRoots = [];
+async function tempProject() {
+  const dir = await makeProjectRoot();
+  tempRoots.push(dir);
+  return dir;
+}
+
+afterAll(async () => {
+  for (const dir of tempRoots) {
+    await fsp.rm(dir, { recursive: true, force: true });
+  }
+  tempRoots.length = 0;
+});
+
+function streamToBuffer(stream) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    stream.on("data", (chunk) => chunks.push(chunk));
+    stream.on("end", () => resolve(Buffer.concat(chunks)));
+    stream.on("error", reject);
+  });
+}
+
+async function exportArchiveToFile(projectRoot, options = {}) {
+  const { archive } = createArchive({ projectRoot, ...options });
+  const buf = await streamToBuffer(archive);
+  const archivePath = path.join(projectRoot, `archive-${nodeCrypto.randomBytes(4).toString("hex")}.zip`);
+  await fsp.writeFile(archivePath, buf);
+  return { archivePath, bytes: buf.length };
+}
+
+describe("isPathSafe", () => {
+  test.each([
+    ["data/leaderboard.json", true],
+    ["data/providers/en-US/abc/file.txt", true],
+    ["manifest.json", true],
+    ["", false],
+    ["../etc/passwd", false],
+    ["data/../../etc/passwd", false],
+    ["/etc/passwd", false],
+    ["data\\windows\\bad", false],
+    ["data//double-slash", false],
+    ["data/has spaces.json", false]
+  ])("isPathSafe(%j) === %j", (input, expected) => {
+    expect(isPathSafe(input)).toBe(expected);
+  });
+});
+
+describe("sha256OfBuffer", () => {
+  test("matches known vector for empty buffer", () => {
+    expect(sha256OfBuffer(Buffer.from(""))).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+});
+
+describe("buildManifest", () => {
+  test("includes every existing in-scope file with correct sha256 and bytes", async () => {
+    const projectRoot = await tempProject();
+    const manifest = await buildManifest({
+      projectRoot,
+      includeProviders: false,
+      includeDictionaries: false
+    });
+    expect(manifest.manifestVersion).toBe(MANIFEST_VERSION);
+    expect(manifest.appVersion).toBe("0.0.0-test");
+    expect(manifest.optionalSets).toEqual([]);
+    const inScopeEntries = manifest.files.filter((f) => IN_SCOPE_FILES.includes(f.path));
+    // word.json + leaderboard + admin-jobs + app-config + classes + languages = 6
+    expect(inScopeEntries).toHaveLength(IN_SCOPE_FILES.length);
+    for (const entry of inScopeEntries) {
+      const buf = await fsp.readFile(path.join(projectRoot, entry.path));
+      expect(entry.bytes).toBe(buf.length);
+      expect(entry.sha256).toBe(sha256OfBuffer(buf));
+    }
+  });
+
+  test("attaches schema digest for files that have a schema", async () => {
+    const projectRoot = await tempProject();
+    const manifest = await buildManifest({
+      projectRoot,
+      includeProviders: false,
+      includeDictionaries: false
+    });
+    const leaderboardEntry = manifest.files.find((f) => f.path === "data/leaderboard.json");
+    expect(leaderboardEntry.schema).toBeDefined();
+    expect(leaderboardEntry.schema.schemaPath).toBe("data/leaderboard.schema.json");
+    expect(leaderboardEntry.schema.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("createArchive + validateArchive round-trip", () => {
+  test("happy path round-trip validates", async () => {
+    const projectRoot = await tempProject();
+    const { archivePath } = await exportArchiveToFile(projectRoot);
+    const result = await validateArchive(archivePath, { projectRoot });
+    expect(result.manifest.manifestVersion).toBe(MANIFEST_VERSION);
+    expect(result.fileChecks.every((entry) => entry.ok)).toBe(true);
+  });
+});
+
+describe("validateArchive rejection cases", () => {
+  test("rejects archive whose manifest version is unsupported", async () => {
+    const projectRoot = await tempProject();
+    const { archivePath } = await exportArchiveToFile(projectRoot);
+    // Tamper: rebuild the zip with a manifest claiming version 999.
+    const yauzl = require("yauzl");
+    const archiver = require("archiver");
+    const tamperedPath = `${archivePath}.tampered`;
+
+    // Read all entries from the original.
+    const entries = await new Promise((resolve, reject) => {
+      yauzl.open(archivePath, { lazyEntries: true, autoClose: false }, (err, zip) => {
+        if (err) return reject(err);
+        const out = [];
+        zip.on("entry", (entry) => {
+          zip.openReadStream(entry, (e, rs) => {
+            if (e) return reject(e);
+            const chunks = [];
+            rs.on("data", (c) => chunks.push(c));
+            rs.on("end", () => {
+              out.push({ name: entry.fileName, buf: Buffer.concat(chunks) });
+              zip.readEntry();
+            });
+            rs.on("error", reject);
+          });
+        });
+        zip.on("end", () => {
+          zip.close();
+          resolve(out);
+        });
+        zip.readEntry();
+      });
+    });
+
+    const archive = archiver("zip");
+    const out = fs.createWriteStream(tamperedPath);
+    archive.pipe(out);
+    for (const entry of entries) {
+      if (entry.name === "manifest.json") {
+        const manifest = JSON.parse(entry.buf.toString("utf8"));
+        manifest.manifestVersion = 999;
+        archive.append(`${JSON.stringify(manifest, null, 2)}\n`, { name: "manifest.json" });
+      } else {
+        archive.append(entry.buf, { name: entry.name });
+      }
+    }
+    await archive.finalize();
+    await new Promise((resolve) => out.on("close", resolve));
+
+    await expect(
+      validateArchive(tamperedPath, { projectRoot })
+    ).rejects.toMatchObject({
+      code: "MANIFEST_INVALID"
+    });
+  });
+
+  test("rejects archive whose declared sha256 differs from entry bytes", async () => {
+    const projectRoot = await tempProject();
+    const { archivePath } = await exportArchiveToFile(projectRoot);
+    // Tamper: rebuild zip with a leaderboard.json whose contents are
+    // changed but the manifest still has the original sha256.
+    const yauzl = require("yauzl");
+    const archiver = require("archiver");
+    const tamperedPath = `${archivePath}.tampered2`;
+    const entries = await new Promise((resolve, reject) => {
+      yauzl.open(archivePath, { lazyEntries: true, autoClose: false }, (err, zip) => {
+        if (err) return reject(err);
+        const out = [];
+        zip.on("entry", (entry) => {
+          zip.openReadStream(entry, (e, rs) => {
+            if (e) return reject(e);
+            const chunks = [];
+            rs.on("data", (c) => chunks.push(c));
+            rs.on("end", () => {
+              out.push({ name: entry.fileName, buf: Buffer.concat(chunks) });
+              zip.readEntry();
+            });
+            rs.on("error", reject);
+          });
+        });
+        zip.on("end", () => {
+          zip.close();
+          resolve(out);
+        });
+        zip.readEntry();
+      });
+    });
+    const archive = archiver("zip");
+    const out = fs.createWriteStream(tamperedPath);
+    archive.pipe(out);
+    for (const entry of entries) {
+      if (entry.name === "data/leaderboard.json") {
+        // Pad the bytes — same length, different content
+        const altered = Buffer.from(
+          entry.buf.toString("utf8").replace("\"profiles\":", "\"profiles\":  ")
+        );
+        archive.append(altered, { name: entry.name });
+      } else {
+        archive.append(entry.buf, { name: entry.name });
+      }
+    }
+    await archive.finalize();
+    await new Promise((resolve) => out.on("close", resolve));
+    await expect(
+      validateArchive(tamperedPath, { projectRoot })
+    ).rejects.toMatchObject({
+      code: expect.stringMatching(/SHA256_MISMATCH|BYTES_MISMATCH/)
+    });
+  });
+
+  test("rejects archive that contains a path-traversal entry", async () => {
+    // Defense in depth: even when the archive itself contains a malicious
+    // entry path, the validator must reject before any extraction.
+    // archiver sanitizes ".." on the way in, so the check that ultimately
+    // fires here is the manifest/entry-set mismatch (the manifest claims
+    // a path the archive doesn't actually carry under that name). The
+    // pure isPathSafe unit tests above cover the post-yauzl path-safety
+    // check directly.
+    const projectRoot = await tempProject();
+    const archiver = require("archiver");
+    const archivePath = path.join(projectRoot, "evil.zip");
+    const archive = archiver("zip");
+    const out = fs.createWriteStream(archivePath);
+    archive.pipe(out);
+    archive.append(JSON.stringify({
+      manifestVersion: 1,
+      appVersion: "0.0.0",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      nodeId: "evil",
+      files: [
+        {
+          path: "../etc/passwd",
+          bytes: 4,
+          sha256: sha256OfBuffer(Buffer.from("evil"))
+        }
+      ],
+      optionalSets: []
+    }, null, 2), { name: "manifest.json" });
+    archive.append(Buffer.from("evil"), { name: "../etc/passwd" });
+    await archive.finalize();
+    await new Promise((resolve) => out.on("close", resolve));
+
+    await expect(
+      validateArchive(archivePath, { projectRoot })
+    ).rejects.toMatchObject({
+      code: expect.stringMatching(/MANIFEST_INVALID|MANIFEST_MISMATCH|PATH_UNSAFE|ENTRY_MISSING/)
+    });
+  });
+
+  test("rejects archive whose total uncompressed size exceeds totalMaxBytes", async () => {
+    const projectRoot = await tempProject();
+    const { archivePath } = await exportArchiveToFile(projectRoot);
+    await expect(
+      validateArchive(archivePath, { projectRoot, totalMaxBytes: 16 })
+    ).rejects.toMatchObject({
+      code: "ARCHIVE_TOO_LARGE"
+    });
+  });
+});
+
+describe("applyRestore happy path", () => {
+  test("replaces in-scope files byte-equal to archive contents", async () => {
+    const projectRoot = await tempProject();
+    const { archivePath } = await exportArchiveToFile(projectRoot);
+
+    const beforeLeaderboard = await fsp.readFile(
+      path.join(projectRoot, "data/leaderboard.json"),
+      "utf8"
+    );
+
+    // Mutate the live file so we can prove restore overwrites it.
+    await fsp.writeFile(
+      path.join(projectRoot, "data/leaderboard.json"),
+      `${JSON.stringify({
+        version: 1,
+        updatedAt: "2026-12-31T00:00:00.000Z",
+        profiles: [],
+        resultsByProfile: {}
+      })}\n`,
+      "utf8"
+    );
+
+    const result = await applyRestore({ archivePath, projectRoot });
+    expect(result.rolledBack).toBe(false);
+    expect(result.restored).toContain("data/leaderboard.json");
+
+    const afterLeaderboard = await fsp.readFile(
+      path.join(projectRoot, "data/leaderboard.json"),
+      "utf8"
+    );
+    expect(afterLeaderboard).toBe(beforeLeaderboard);
+
+    const orphans = await findOrphanedRestoreDirs(path.join(projectRoot, "data"));
+    expect(orphans).toEqual([]);
+  });
+});
+
+describe("applyRestore rollback on mid-write failure", () => {
+  test("rewinds renames when an in-flight rename throws", async () => {
+    const projectRoot = await tempProject();
+    const { archivePath } = await exportArchiveToFile(projectRoot);
+
+    const beforeLeaderboard = await fsp.readFile(
+      path.join(projectRoot, "data/leaderboard.json"),
+      "utf8"
+    );
+    const beforeAdminJobs = await fsp.readFile(
+      path.join(projectRoot, "data/admin-jobs.json"),
+      "utf8"
+    );
+
+    // Spy on rename and throw on the Nth call. The applyRestore phase 3
+    // does N renames per file (snapshot + swap), so picking call #5 lands
+    // mid-batch. The exact number isn't fragile because the test checks
+    // post-rollback state rather than which call threw.
+    let callCount = 0;
+    const realRename = fsp.rename.bind(fsp);
+    const spy = jest.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
+      callCount += 1;
+      if (callCount === 5) {
+        const err = new Error("simulated EIO mid-restore");
+        err.code = "EIO";
+        throw err;
+      }
+      return realRename(from, to);
+    });
+
+    try {
+      await expect(applyRestore({ archivePath, projectRoot })).rejects.toThrow(/simulated EIO/);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // Live files should be byte-equal to their pre-restore state.
+    const afterLeaderboard = await fsp.readFile(
+      path.join(projectRoot, "data/leaderboard.json"),
+      "utf8"
+    );
+    const afterAdminJobs = await fsp.readFile(
+      path.join(projectRoot, "data/admin-jobs.json"),
+      "utf8"
+    );
+    expect(afterLeaderboard).toBe(beforeLeaderboard);
+    expect(afterAdminJobs).toBe(beforeAdminJobs);
+
+    // Staging + rollback dirs are intentionally left in place on failure.
+    const orphans = await findOrphanedRestoreDirs(path.join(projectRoot, "data"));
+    expect(orphans.length).toBeGreaterThanOrEqual(1);
+    for (const orphan of orphans) {
+      await fsp.rm(orphan.path, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("applyRestore schema-drift rejection", () => {
+  test("rejects when archive's bundled schema digest differs from current schema on disk", async () => {
+    const projectRoot = await tempProject();
+    const { archivePath } = await exportArchiveToFile(projectRoot);
+    // Modify the live schema after export — simulates a server upgrade
+    // that changed the schema between archive creation and restore.
+    const liveSchemaPath = path.join(projectRoot, "data/leaderboard.schema.json");
+    const original = await fsp.readFile(liveSchemaPath, "utf8");
+    const tampered = original.replace(/"version"/, "\"VERSION_RENAMED\"");
+    await fsp.writeFile(liveSchemaPath, tampered, "utf8");
+    await expect(
+      applyRestore({ archivePath, projectRoot })
+    ).rejects.toMatchObject({
+      code: "SCHEMA_DRIFT"
+    });
+  });
+});
+
+describe("BackupError shape", () => {
+  test("carries code + details", () => {
+    const err = new BackupError("X_TEST", "boom", { foo: 1 });
+    expect(err.code).toBe("X_TEST");
+    expect(err.details).toEqual({ foo: 1 });
+    expect(err.message).toBe("boom");
+    expect(err.name).toBe("BackupError");
+  });
+});

--- a/tests/ui/admin-data.spec.js
+++ b/tests/ui/admin-data.spec.js
@@ -109,7 +109,21 @@ test("admin Data tab supports export, preview, typed-confirm gate, and apply", a
   });
 
   await page.route("/api/admin/backup/preview", (route) => fulfillJson(route, PREVIEW_RESPONSE));
-  await page.route("/api/admin/restore", (route) => fulfillJson(route, RESTORE_RESPONSE));
+  // Assert the destructive headers on the restore mock — the typed-confirm
+  // gate is the headline guarantee of this PR, so a future regression in
+  // app.js that drops x-admin-key or x-admin-confirm should fail this test
+  // rather than silently pass.
+  await page.route("/api/admin/restore", (route) => {
+    const headers = route.request().headers();
+    if (headers["x-admin-key"] !== "demo-key" || headers["x-admin-confirm"] !== "I-UNDERSTAND") {
+      return route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "missing required restore confirm headers" })
+      });
+    }
+    return fulfillJson(route, RESTORE_RESPONSE);
+  });
 
   await page.goto("/admin", { waitUntil: "commit" });
   await page.fill("#adminKeyInput", "demo-key");

--- a/tests/ui/admin-data.spec.js
+++ b/tests/ui/admin-data.spec.js
@@ -138,7 +138,10 @@ test("admin Data tab supports export, preview, typed-confirm gate, and apply", a
   });
   await page.click("#backupRestorePreviewBtn");
   await expect(page.locator("#backupRestoreDialog")).toBeVisible();
-  await expect(page.locator("#backupRestorePreviewSummary")).toContainText("Manifest version: 1");
+  // Summary now renders as a definition list; assert label + value
+  // appear together in the panel text without being colon-joined.
+  await expect(page.locator("#backupRestorePreviewSummary")).toContainText("Manifest version");
+  await expect(page.locator("#backupRestorePreviewSummary dd").first()).toHaveText("1");
   await expect(page.locator("#backupRestoreApplyBtn")).toBeDisabled();
 
   // Typed-confirm gate — wrong text leaves it disabled.

--- a/tests/ui/admin-data.spec.js
+++ b/tests/ui/admin-data.spec.js
@@ -1,0 +1,153 @@
+const { test, expect } = require("./fixtures");
+
+test.use({ serviceWorkers: "block" });
+
+async function blockServiceWorkerScript(page) {
+  await page.route("**/sw.js", async (route) => {
+    await route.fulfill({
+      status: 404,
+      contentType: "application/javascript",
+      body: ""
+    });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await blockServiceWorkerScript(page);
+});
+
+const RUNTIME_CONFIG_RESPONSE = {
+  effective: {
+    definitions: { mode: "memory", cacheSize: 0, cacheTtlMs: 0, shardCacheSize: 0 },
+    limits: {
+      providerManualMaxFileBytes: 1048576,
+      leaderboardMaxProfiles: 50,
+      leaderboardMaxResultsPerProfile: 400
+    },
+    diagnostics: { perfLogging: false }
+  },
+  sources: {},
+  locks: {}
+};
+
+const PROVIDERS_RESPONSE = {
+  providers: []
+};
+
+const PROFILES_RESPONSE = {
+  profiles: [],
+  meta: {
+    leaderboardMaxProfiles: 50,
+    leaderboardMaxResultsPerProfile: 400,
+    leaderboardMaxProfilesEnvLocked: false,
+    leaderboardMaxResultsPerProfileEnvLocked: false
+  }
+};
+
+const JOBS_RESPONSE = {
+  jobs: [],
+  queue: { active: false, syncActive: false, queueDepth: 0 }
+};
+
+const CLASSES_RESPONSE = { classes: [] };
+
+const PREVIEW_RESPONSE = {
+  ok: true,
+  manifestVersion: 1,
+  appVersion: "1.0.0-test",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  nodeId: "test-node",
+  files: [
+    { path: "data/leaderboard.json", bytes: 128, sha256: "0".repeat(64), ok: true },
+    { path: "data/admin-jobs.json", bytes: 64, sha256: "1".repeat(64), ok: true }
+  ],
+  totalBytes: 192,
+  warnings: []
+};
+
+const RESTORE_RESPONSE = {
+  ok: true,
+  restored: ["data/leaderboard.json", "data/admin-jobs.json"],
+  filesRestored: 2,
+  rolledBackOnError: false,
+  warnings: [],
+  reloads: [
+    { name: "leaderboardStore", ok: true },
+    { name: "adminJobsStore", ok: true }
+  ]
+};
+
+async function fulfillJson(route, body, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body)
+  });
+}
+
+test("admin Data tab supports export, preview, typed-confirm gate, and apply", async ({ page }) => {
+  await page.route("/api/admin/runtime-config", (route) => fulfillJson(route, RUNTIME_CONFIG_RESPONSE));
+  await page.route("/api/admin/providers", (route) => fulfillJson(route, PROVIDERS_RESPONSE));
+  await page.route(/\/api\/admin\/stats\/profiles(\?.*)?$/, (route) =>
+    fulfillJson(route, PROFILES_RESPONSE)
+  );
+  await page.route(/\/api\/admin\/jobs(\?.*)?$/, (route) => fulfillJson(route, JOBS_RESPONSE));
+  await page.route(/\/api\/admin\/classes(\?.*)?$/, (route) => fulfillJson(route, CLASSES_RESPONSE));
+
+  // Export: serve a tiny fake zip with a Content-Disposition header so the
+  // client's download path triggers without a real archiver in play.
+  await page.route(/\/api\/admin\/backup(\?.*)?$/, (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/zip",
+      headers: {
+        "Content-Disposition": 'attachment; filename="wordle-backup-test.zip"'
+      },
+      body: Buffer.from([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    });
+  });
+
+  await page.route("/api/admin/backup/preview", (route) => fulfillJson(route, PREVIEW_RESPONSE));
+  await page.route("/api/admin/restore", (route) => fulfillJson(route, RESTORE_RESPONSE));
+
+  await page.goto("/admin", { waitUntil: "commit" });
+  await page.fill("#adminKeyInput", "demo-key");
+  await page.click("#unlockForm button[type=submit]");
+  await expect(page.locator("#shellPanel")).toBeVisible();
+
+  // Activate Data tab
+  await page.click("#admin-tab-data");
+  await expect(page.locator("#admin-panel-data")).toBeVisible();
+  await expect(page.locator("#backupExportBtn")).toBeVisible();
+
+  // Export — wait for the download to start (browser will catch the
+  // attachment response).
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.click("#backupExportBtn")
+  ]);
+  expect(download.suggestedFilename()).toContain("wordle-backup");
+  await expect(page.locator("#backupExportStatus")).toContainText("Downloaded");
+
+  // Preview — upload a fake zip file.
+  await page.setInputFiles("#backupRestoreFile", {
+    name: "test-archive.zip",
+    mimeType: "application/zip",
+    buffer: Buffer.from("PK")
+  });
+  await page.click("#backupRestorePreviewBtn");
+  await expect(page.locator("#backupRestoreDialog")).toBeVisible();
+  await expect(page.locator("#backupRestorePreviewSummary")).toContainText("Manifest version: 1");
+  await expect(page.locator("#backupRestoreApplyBtn")).toBeDisabled();
+
+  // Typed-confirm gate — wrong text leaves it disabled.
+  await page.fill("#backupRestoreConfirmInput", "WRONG");
+  await expect(page.locator("#backupRestoreApplyBtn")).toBeDisabled();
+
+  // Right text enables apply, then apply succeeds.
+  await page.fill("#backupRestoreConfirmInput", "RESTORE");
+  await expect(page.locator("#backupRestoreApplyBtn")).toBeEnabled();
+  await page.click("#backupRestoreApplyBtn");
+  await expect(page.locator("#backupRestoreStatus")).toContainText("Restore complete");
+});

--- a/tests/ui/admin-shell.spec.js
+++ b/tests/ui/admin-shell.spec.js
@@ -686,7 +686,7 @@ test("admin shell tablist supports keyboard tab navigation", async ({ page }) =>
 
   const providersTab = page.locator("#admin-tab-providers");
   const importsTab = page.locator("#admin-tab-imports");
-  const classesTab = page.locator("#admin-tab-classes");
+  const dataTab = page.locator("#admin-tab-data");
 
   await providersTab.focus();
   await page.keyboard.press("ArrowRight");
@@ -695,8 +695,8 @@ test("admin shell tablist supports keyboard tab navigation", async ({ page }) =>
   await expect(page.locator("#admin-panel-imports")).toBeVisible();
 
   await page.keyboard.press("End");
-  await expect(classesTab).toBeFocused();
-  await expect(classesTab).toHaveAttribute("aria-selected", "true");
+  await expect(dataTab).toBeFocused();
+  await expect(dataTab).toHaveAttribute("aria-selected", "true");
 
   await page.keyboard.press("Home");
   await expect(providersTab).toBeFocused();


### PR DESCRIPTION
Closes #87.

## Summary
- New `lib/backup-store.js` with manifest-driven multi-file zip archives, sha256+schema-digest per entry, and atomic apply via staging+rollback dirs.
- New endpoints under `/api/admin/*`: `GET /backup`, `POST /backup/preview`, `POST /restore` (busboy streaming, single-flight mutex shared with provider import, per-route rate limiter keyed by admin key).
- New Data tab in the admin shell with export checkboxes, preview dialog, typed-confirmation gate (operator types "RESTORE"), and partial-failure messaging.
- New env vars: `BACKUP_MAX_BYTES` (256 MiB default, conservative for 1-3 language deployments), `BACKUP_INCLUDE_PROVIDERS_DEFAULT`, `BACKUP_RATE_LIMIT_*`, `BACKUP_PROJECT_ROOT`.
- Boot-time orphan check warns about leftover `.restore-staging-*` / `.restore-rollback-*` dirs without auto-deleting (operator forensics).
- `scripts/restore-from-disk.js` CLI fallback for post-corruption boot loops.
- `reload()` / `reloadSync()` added to leaderboard, admin-jobs, classes, and app-config stores; language-registry already had it.
- `docs/backup-restore.md` runbook + cross-links from README and admin-platform-architecture-contract.

## Locked decisions adhered to
- zip format with deterministic ordering ✓
- `data/backup-manifest.schema.json` (Draft 2020-12) wired into `npm run schema:check` ✓
- Replace-all atomic restore via staging dir + rename swap, rewind on failure ✓
- Admin-key only, no public endpoint ✓
- Manifest version 1 hard-locked; mismatch → `MANIFEST_VERSION_UNSUPPORTED` 400 ✓
- Per-entry + total uncompressed caps (zip-bomb defense) ✓
- Schema-drift guard via per-file schema digest in manifest ✓
- `requiresRestart` not surfaced yet (no restart-required overrides triggered by this PR; classes-store reload + leaderboard reload + app-config reloadSync + language-registry reloadSync + runtime catalog rebuild cover the in-memory caches)

## New deps
- `archiver` (streaming zip write)
- `yauzl` (streaming zip read)
- `busboy` (streaming multipart upload — provider-import's base64-in-JSON doesn't scale to 256 MiB)

Conservative SBOM additions: all three are widely-deployed, well-maintained Node libs.

## Test plan
- [x] `npm run check` (lint + schema + guardrails + jest) — 342 tests pass (was 312, +30 from this PR)
- [x] Unit tests cover the mid-write rollback (`jest.spyOn` on `fsp.rename` throwing on the 5th call) and prove all in-scope files are byte-equal to pre-restore state
- [x] Integration tests cover admin-key gating, zip Content-Disposition, manifest preview, malformed-archive 400, missing-confirm 400, mutex 409, oversize 413
- [x] Playwright contract test for the Data tab — export download, preview dialog, typed-confirm gate, apply success
- [x] No repo data/ pollution from tests (BACKUP_PROJECT_ROOT isolates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin Console “Data” tab: download versioned backup ZIP (toggle providers/dictionaries), preview archives, and a guarded restore flow with typed confirmation; triggers in-memory reloads.
  * CLI to apply a backup from disk.

* **Documentation**
  * Operator runbook for backup/restore and updated data-contract docs including manifest format and semantics.

* **Tests**
  * New integration, unit, and UI tests covering export, preview, restore, and rollback/failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->