### PR TITLE
feat(admin): outbound webhooks with HMAC-signed deliveries and retry queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,18 @@ PERF_LOGGING=false
 # SCHEDULE_TIMEZONE_DEFAULT=America/New_York
 # SCHEDULER_CHECK_INTERVAL_MS=60000
 # SCHEDULE_RETENTION_DAYS=90
+
+# Outbound webhooks. Disabled by default — emit logic is a no-op until
+# WEBHOOKS_ENABLED=true. Subscriptions can still be managed and persisted
+# via the admin UI even when the dispatcher is off; events queued at
+# previous startups will resume on next start with WEBHOOKS_ENABLED=true.
+# WEBHOOKS_ENABLED=false
+# WEBHOOK_REQUEST_TIMEOUT_MS=10000
+# WEBHOOK_MAX_BODY_BYTES=65536
+# WEBHOOK_DELIVERY_HISTORY_MAX=200
+# WEBHOOK_MAX_ATTEMPTS_DEFAULT=5
+# WEBHOOK_GLOBAL_INFLIGHT_LIMIT=4
+# Set WEBHOOK_ALLOW_PRIVATE_NETWORKS=true ONLY for local development. In
+# production the SSRF guard rejects RFC1918, loopback, and link-local
+# addresses to prevent metadata-service exfil.
+# WEBHOOK_ALLOW_PRIVATE_NETWORKS=false

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ logs/security/
 data/admin-jobs.json
 data/app-config.json
 data/schedule.json
+data/webhooks.json
+data/webhook-deliveries.json

--- a/data/webhook-deliveries.example.json
+++ b/data/webhook-deliveries.example.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "updatedAt": "2026-05-09T00:00:00.000Z",
+  "deliveries": []
+}

--- a/data/webhook-deliveries.schema.json
+++ b/data/webhook-deliveries.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wordle-local/webhook-deliveries.schema.json",
+  "title": "Webhook delivery history",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "updatedAt", "deliveries"],
+  "properties": {
+    "version": { "type": "integer", "const": 1 },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "deliveries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "subscriptionId", "event", "status", "attempts", "createdAt", "updatedAt"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "subscriptionId": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "event": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "status": {
+            "type": "string",
+            "enum": ["queued", "running", "succeeded", "failed", "canceled"]
+          },
+          "attempts": { "type": "integer", "minimum": 0, "maximum": 100 },
+          "url": { "type": "string", "maxLength": 2048 },
+          "responseStatus": { "type": "integer" },
+          "responseSnippet": { "type": "string", "maxLength": 4096 },
+          "lastError": { "type": "string", "maxLength": 2048 },
+          "nextAttemptAt": { "type": "string", "format": "date-time" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  }
+}

--- a/data/webhook-deliveries.schema.json
+++ b/data/webhook-deliveries.schema.json
@@ -25,11 +25,19 @@
           "attempts": { "type": "integer", "minimum": 0, "maximum": 100 },
           "url": { "type": "string", "maxLength": 2048 },
           "responseStatus": { "type": "integer" },
-          "responseSnippet": { "type": "string", "maxLength": 4096 },
+          "responseSnippet": {
+            "description": "Persisted snippet of the response body. Capped at 4096 chars by lib/webhook-delivery-store.js even though the dispatcher's runtime fetch reads up to WEBHOOK_MAX_BODY_BYTES (default 65536). The schema cap matches the persisted clamp so a hand-edited file outside this size is rejected at load.",
+            "type": "string",
+            "maxLength": 4096
+          },
           "lastError": { "type": "string", "maxLength": 2048 },
           "nextAttemptAt": { "type": "string", "format": "date-time" },
           "createdAt": { "type": "string", "format": "date-time" },
-          "updatedAt": { "type": "string", "format": "date-time" }
+          "updatedAt": { "type": "string", "format": "date-time" },
+          "payload": {
+            "description": "Original event payload, persisted at enqueue time so boot recovery and manual retries can resend the real body instead of an empty object. Capped at 8 KiB serialized size.",
+            "type": "object"
+          }
         }
       }
     }

--- a/data/webhooks.example.json
+++ b/data/webhooks.example.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "updatedAt": "2026-05-09T00:00:00.000Z",
+  "subscriptions": []
+}

--- a/data/webhooks.schema.json
+++ b/data/webhooks.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wordle-local/webhooks.schema.json",
+  "title": "Webhook subscriptions",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "updatedAt", "subscriptions"],
+  "properties": {
+    "version": { "type": "integer", "const": 1 },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "subscriptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "url", "events", "enabled", "secret", "maxAttempts", "createdAt", "updatedAt"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "url": { "type": "string", "minLength": 1, "maxLength": 2048 },
+          "events": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1, "maxLength": 64 }
+          },
+          "enabled": { "type": "boolean" },
+          "secret": { "type": "string", "minLength": 16, "maxLength": 256 },
+          "maxAttempts": { "type": "integer", "minimum": 1, "maximum": 20 },
+          "label": { "type": "string", "maxLength": 80 },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  }
+}

--- a/data/webhooks.schema.json
+++ b/data/webhooks.schema.json
@@ -15,15 +15,36 @@
         "additionalProperties": false,
         "required": ["id", "url", "events", "enabled", "secret", "maxAttempts", "createdAt", "updatedAt"],
         "properties": {
-          "id": { "type": "string", "minLength": 1, "maxLength": 64 },
-          "url": { "type": "string", "minLength": 1, "maxLength": 2048 },
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9_-]{1,64}$"
+          },
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2048,
+            "pattern": "^https?://"
+          },
           "events": {
             "type": "array",
             "minItems": 1,
-            "items": { "type": "string", "minLength": 1, "maxLength": 64 }
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64,
+              "pattern": "^[a-z][a-z0-9._-]{0,63}$"
+            }
           },
           "enabled": { "type": "boolean" },
-          "secret": { "type": "string", "minLength": 16, "maxLength": 256 },
+          "secret": {
+            "type": "string",
+            "minLength": 16,
+            "maxLength": 256,
+            "pattern": "^[a-f0-9]+$"
+          },
           "maxAttempts": { "type": "integer", "minimum": 1, "maximum": 20 },
           "label": { "type": "string", "maxLength": 80 },
           "createdAt": { "type": "string", "format": "date-time" },

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,170 @@
+# Webhooks
+
+Outbound HTTP notifications for admin-significant events. Subscribers
+receive a signed JSON `POST` whose body the recipient should verify with
+HMAC-SHA-256 before trusting the payload.
+
+The dispatcher is **disabled by default**. Subscriptions can still be
+created, edited, and persisted at any time, but no requests are sent until
+the operator restarts the server with `WEBHOOKS_ENABLED=true`.
+
+## Event catalog
+
+| Event                          | When fired                                                                                              | Payload fields                                                                |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `provider.import.completed`    | After a provider import (sync or async) succeeds.                                                       | `jobId`, `variant`, `commit`, `sourceType`, `filterMode`, `counts`, `artifacts` |
+| `provider.import.failed`       | After a provider import (sync or async) fails. Errors are logged and re-emitted, never silenced.        | `jobId`, `variant`, `sourceType`, `error`                                     |
+| `webhook.test`                 | When an operator clicks **Test** in the admin Webhooks tab. Used to verify endpoint reachability.       | `message`, `subscriptionId`, `requestedAt`                                    |
+
+`jobId` is `null` for sync imports (the synchronous path doesn't enqueue a
+record into `data/admin-jobs.json`).
+
+## Request format
+
+The dispatcher sends `POST <subscription.url>` with these headers:
+
+| Header                  | Value                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `content-type`          | `application/json`                                                                     |
+| `user-agent`            | `wordle-local-webhook/1`                                                               |
+| `x-webhook-id`          | The delivery's id (base64url, ≤ 64 chars). Stable across retries.                       |
+| `x-webhook-event`       | The event name (e.g. `provider.import.completed`).                                     |
+| `x-webhook-timestamp`   | ISO-8601 timestamp of the attempt.                                                     |
+| `x-webhook-attempt`     | 1-indexed attempt counter. Increments on every retry.                                  |
+| `x-webhook-signature`   | `sha256=<hex>` HMAC-SHA-256 of the full request body, keyed with the subscription secret. |
+
+The body is a JSON object:
+
+```json
+{
+  "id": "<delivery id>",
+  "event": "<event name>",
+  "timestamp": "<ISO-8601>",
+  "attempt": 1,
+  "payload": { ... event-specific fields ... }
+}
+```
+
+## Verifying the signature
+
+The recipient should recompute the HMAC over the **raw request body**
+(not the parsed JSON) using the subscription secret and compare it with
+`x-webhook-signature` using a constant-time comparison.
+
+### Node.js example
+
+```js
+const crypto = require("node:crypto");
+
+function verify(rawBody, headerValue, secret) {
+  const expected = "sha256=" + crypto.createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("hex");
+  // Buffer.byteLength check guards timingSafeEqual against length-mismatch throw
+  if (Buffer.byteLength(headerValue) !== Buffer.byteLength(expected)) return false;
+  return crypto.timingSafeEqual(Buffer.from(headerValue), Buffer.from(expected));
+}
+```
+
+### Python example
+
+```python
+import hmac, hashlib
+
+def verify(raw_body: bytes, header: str, secret: str) -> bool:
+    expected = "sha256=" + hmac.new(
+        secret.encode("utf-8"), raw_body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(header, expected)
+```
+
+## Retries and backoff
+
+Failed deliveries are retried with exponential backoff. The default
+schedule is `[1s, 5s, 30s, 2m, 10m]`. Each subscription has its own
+`maxAttempts` (default 5, 1–20) and the dispatcher stops once that is
+reached, marking the delivery as `failed`. An admin can manually retry a
+failed delivery from the Webhooks tab.
+
+A `Retry-After` header on the response (numeric seconds OR HTTP-date) is
+honored, but capped at 10 minutes so a misbehaving recipient cannot
+strand a delivery forever.
+
+### HTTP status classification
+
+| Status range            | Outcome                                              |
+| ----------------------- | ---------------------------------------------------- |
+| `2xx`                   | success — delivery marked `succeeded`                |
+| `408`, `429`            | retriable — schedule next attempt with backoff       |
+| `4xx` (other)           | non-retriable — delivery marked `failed` immediately |
+| `5xx` and network errors | retriable                                            |
+
+## SSRF guard
+
+Outbound URLs are checked before the request is sent. The default policy
+**rejects**:
+
+- IPv4 in RFC1918 (`10/8`, `172.16/12`, `192.168/16`), loopback (`127/8`), link-local (`169.254/16`), and `0.0.0.0`
+- IPv6 loopback (`::1`), link-local (`fe80::/10`), unique-local (`fc00::/7`)
+- IPv4-mapped IPv6 forms of the above (e.g. `::ffff:10.0.0.1`)
+- Hostnames whose DNS resolution returns ANY private/loopback address (verbatim, both A and AAAA records)
+
+Set `WEBHOOK_ALLOW_PRIVATE_NETWORKS=true` to bypass this guard for local
+development. **Do not enable this in production** — it allows the
+webhook dispatcher to reach the cloud-metadata service (`169.254.169.254`)
+and any internal service reachable from the host.
+
+## Restart recovery
+
+Deliveries left in `running` (the previous process died mid-flight) or
+`queued` (the in-memory timer was lost) at boot are requeued
+automatically. `running` rows get a 1-second backoff to avoid
+hammering the recipient if the prior process died from a crash loop;
+`queued` rows honor their persisted `nextAttemptAt`.
+
+## Storage
+
+| File                                | Schema                                | Retention                                                         |
+| ----------------------------------- | ------------------------------------- | ----------------------------------------------------------------- |
+| `data/webhooks.json`                | `data/webhooks.schema.json`           | All subscriptions; bounded by operator action (no auto-eviction). |
+| `data/webhook-deliveries.json`      | `data/webhook-deliveries.schema.json` | Capped at `WEBHOOK_DELIVERY_HISTORY_MAX` rows (default 200).      |
+
+Both files are part of the standard backup/restore set. Restoring from a
+backup also restores webhook subscriptions and recent deliveries.
+
+## Environment variables
+
+| Var                                | Default | Range            | Purpose                                                              |
+| ---------------------------------- | ------- | ---------------- | -------------------------------------------------------------------- |
+| `WEBHOOKS_ENABLED`                 | `false` | bool             | Master switch. Off → emits are no-ops.                               |
+| `WEBHOOK_REQUEST_TIMEOUT_MS`       | `10000` | 1000–60000       | Per-attempt fetch timeout.                                           |
+| `WEBHOOK_MAX_BODY_BYTES`           | `65536` | 1024–1048576     | Max bytes captured from the response body for `responseSnippet`.     |
+| `WEBHOOK_DELIVERY_HISTORY_MAX`     | `200`   | 10–10000         | Retention cap for `data/webhook-deliveries.json`.                    |
+| `WEBHOOK_MAX_ATTEMPTS_DEFAULT`     | `5`     | 1–20             | Default `maxAttempts` for new subscriptions.                         |
+| `WEBHOOK_GLOBAL_INFLIGHT_LIMIT`    | `4`     | 1–64             | Concurrent in-flight delivery cap across all subscriptions.          |
+| `WEBHOOK_ALLOW_PRIVATE_NETWORKS`   | `false` | bool             | Bypass SSRF guard. Local dev only — never enable in production.      |
+| `WEBHOOKS_STORE_PATH`              | `data/webhooks.json` | path | Override the subscription store location (e.g. for tests). |
+| `WEBHOOK_DELIVERIES_STORE_PATH`    | `data/webhook-deliveries.json` | path | Override the delivery store location.            |
+
+## Admin API
+
+All endpoints sit under `/api/admin/webhooks` and require the admin key
+when `REQUIRE_ADMIN_KEY=true` (the production default). All write paths
+acquire the data-mutation slot so they are serialized against backup and
+restore.
+
+| Method | Path                                                   | Notes                                                                             |
+| ------ | ------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| GET    | `/api/admin/webhooks`                                  | List subscriptions (secrets redacted).                                            |
+| POST   | `/api/admin/webhooks`                                  | Create a subscription. **Returns the secret one-time** in the response.            |
+| PATCH  | `/api/admin/webhooks/:id`                              | Edit fields. Pass `rotateSecret: true` to issue a new secret (revealed in response). |
+| DELETE | `/api/admin/webhooks/:id`                              | Delete a subscription and cascade its delivery rows.                              |
+| POST   | `/api/admin/webhooks/:id/test`                         | Queue a `webhook.test` event for that subscription.                               |
+| GET    | `/api/admin/webhooks/:id/deliveries?limit=&status=&event=` | Recent deliveries (newest first; `limit` 1–500, default 50).                  |
+| POST   | `/api/admin/webhooks/:id/deliveries/:deliveryId/retry` | Manually retry a `failed` delivery.                                               |
+
+Audit log entries are emitted on every write under
+`[webhook] subscription.create`, `subscription.update`,
+`subscription.delete`, `subscription.test`, and `delivery.retry`. The
+`actor` field is the SHA-256 fingerprint of the admin key (first 12 hex
+chars), never the key itself.

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -19,6 +19,8 @@ const IN_SCOPE_FILES = Object.freeze([
   "data/app-config.json",
   "data/classes.json",
   "data/schedule.json",
+  "data/webhooks.json",
+  "data/webhook-deliveries.json",
   "data/word.json"
 ]);
 
@@ -28,7 +30,9 @@ const IN_SCOPE_SCHEMAS = Object.freeze({
   "data/admin-jobs.json": "data/admin-jobs.schema.json",
   "data/app-config.json": "data/app-config.schema.json",
   "data/classes.json": "data/classes.schema.json",
-  "data/schedule.json": "data/schedule.schema.json"
+  "data/schedule.json": "data/schedule.schema.json",
+  "data/webhooks.json": "data/webhooks.schema.json",
+  "data/webhook-deliveries.json": "data/webhook-deliveries.schema.json"
 });
 
 const DIAGNOSTIC_SCHEMAS = Object.freeze([
@@ -38,6 +42,8 @@ const DIAGNOSTIC_SCHEMAS = Object.freeze([
   "data/app-config.schema.json",
   "data/classes.schema.json",
   "data/schedule.schema.json",
+  "data/webhooks.schema.json",
+  "data/webhook-deliveries.schema.json",
   "data/backup-manifest.schema.json",
   "data/providers/provider-import-manifest.schema.json"
 ]);

--- a/lib/webhook-delivery-store.js
+++ b/lib/webhook-delivery-store.js
@@ -249,11 +249,33 @@ class WebhookDeliveryStore {
       }
       const current = this.state ? cloneState(this.state) : await this.load();
       const next = updater(current);
-      // Apply retention cap before normalization. Oldest entries (sorted
-      // first by normalizeStore) get dropped when count exceeds the cap.
+      // Apply retention cap before normalization. Only evict TERMINAL
+      // rows (succeeded/failed/canceled) when the count exceeds the
+      // cap — pruning a `queued` or `running` row would orphan its
+      // timer and silently drop the delivery (executeOnce would log
+      // "delivery not found" and never retry). In a sustained burst
+      // bigger than `historyMax`, the oldest active rows are kept and
+      // the file may temporarily exceed historyMax until they reach a
+      // terminal state.
       if (Array.isArray(next.deliveries) && next.deliveries.length > this.historyMax) {
-        const overflow = next.deliveries.length - this.historyMax;
-        next.deliveries = next.deliveries.slice(overflow);
+        const ACTIVE = new Set(["queued", "running"]);
+        const sorted = next.deliveries.slice().sort(
+          (a, b) => (a.createdAt || "").localeCompare(b.createdAt || "")
+            || (a.id || "").localeCompare(b.id || "")
+        );
+        const target = this.historyMax;
+        let toEvict = sorted.length - target;
+        const survivorIds = new Set();
+        const evictedIds = new Set();
+        for (const d of sorted) {
+          if (toEvict > 0 && !ACTIVE.has(d.status)) {
+            evictedIds.add(d.id);
+            toEvict -= 1;
+          } else {
+            survivorIds.add(d.id);
+          }
+        }
+        next.deliveries = next.deliveries.filter((d) => survivorIds.has(d.id) || !evictedIds.has(d.id));
       }
       next.updatedAt = this.now().toISOString();
       const finalState = normalizeStore(next);

--- a/lib/webhook-delivery-store.js
+++ b/lib/webhook-delivery-store.js
@@ -9,6 +9,11 @@ const STATUSES = Object.freeze(["queued", "running", "succeeded", "failed", "can
 const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const RESPONSE_SNIPPET_MAX = 4096;
 const LAST_ERROR_MAX = 2048;
+// Cap on serialized payload bytes. Persisted with the delivery row so
+// boot recovery and manual retries can resend the original body. The
+// cap exists so a malicious or buggy emit can't swell
+// data/webhook-deliveries.json without bound.
+const PAYLOAD_MAX_BYTES = 8 * 1024;
 const WINDOWS_RENAME_OVERWRITE_CODES = new Set(["EEXIST", "EPERM", "EACCES"]);
 
 class WebhookDeliveryStoreError extends Error {
@@ -56,6 +61,16 @@ function normalizeDelivery(raw) {
   if (!Number.isInteger(raw.attempts) || raw.attempts < 0) {
     throw new WebhookDeliveryStoreError("INVALID_DELIVERY", "attempts must be a non-negative integer.");
   }
+  // createdAt/updatedAt must be non-empty strings — without this guard
+  // a hand-edited file could pass non-string values straight through to
+  // normalizeStore's localeCompare sort and crash with a TypeError far
+  // from the validation site.
+  if (typeof raw.createdAt !== "string" || !raw.createdAt) {
+    throw new WebhookDeliveryStoreError("INVALID_DELIVERY", "createdAt is required.");
+  }
+  if (typeof raw.updatedAt !== "string" || !raw.updatedAt) {
+    throw new WebhookDeliveryStoreError("INVALID_DELIVERY", "updatedAt is required.");
+  }
   const out = {
     id: raw.id,
     subscriptionId: raw.subscriptionId,
@@ -72,6 +87,21 @@ function normalizeDelivery(raw) {
   const lastError = clampString(raw.lastError, LAST_ERROR_MAX);
   if (lastError !== undefined) out.lastError = lastError;
   if (typeof raw.nextAttemptAt === "string") out.nextAttemptAt = raw.nextAttemptAt;
+  if (isPlainObject(raw.payload)) {
+    // Drop oversized payloads silently; the delivery is still
+    // executable, just with `{}` as the recovered payload. We prefer
+    // dropping over rejecting the whole row because the alternative
+    // (refusing to load the store on a single oversized payload) would
+    // wedge the dispatcher for every other delivery in the file.
+    try {
+      const serialized = JSON.stringify(raw.payload);
+      if (serialized && serialized.length <= PAYLOAD_MAX_BYTES) {
+        out.payload = JSON.parse(serialized);
+      }
+    } catch (_err) {
+      // unrepresentable as JSON — drop
+    }
+  }
   return out;
 }
 
@@ -146,6 +176,12 @@ class WebhookDeliveryStore {
     this.historyMax = Number.isInteger(options.historyMax) && options.historyMax > 0
       ? options.historyMax
       : 200;
+    // See WebhookStore for the rationale; background delivery attempts
+    // hit `update()` continuously, so without this barrier a delivery
+    // mid-flight could tear a backup or land after a restore.
+    this.waitForDataMutationLock = typeof options.waitForDataMutationLock === "function"
+      ? options.waitForDataMutationLock
+      : null;
     this.state = null;
     this.loadPromise = null;
     this.commitQueue = Promise.resolve();
@@ -208,6 +244,9 @@ class WebhookDeliveryStore {
 
   async #commit(updater) {
     const run = async () => {
+      if (this.waitForDataMutationLock) {
+        await this.waitForDataMutationLock();
+      }
       const current = this.state ? cloneState(this.state) : await this.load();
       const next = updater(current);
       // Apply retention cap before normalization. Oldest entries (sorted
@@ -227,7 +266,7 @@ class WebhookDeliveryStore {
     return next;
   }
 
-  async enqueue({ subscriptionId, event, url, nextAttemptAt }) {
+  async enqueue({ subscriptionId, event, url, nextAttemptAt, payload }) {
     if (!ID_PATTERN.test(String(subscriptionId || ""))) {
       throw new WebhookDeliveryStoreError("INVALID_REQUEST", "subscriptionId is required.");
     }
@@ -247,6 +286,19 @@ class WebhookDeliveryStore {
     };
     if (typeof url === "string") delivery.url = url;
     if (typeof nextAttemptAt === "string") delivery.nextAttemptAt = nextAttemptAt;
+    if (isPlainObject(payload)) {
+      // Skip if serialized payload exceeds the cap. We prefer dropping
+      // the payload to rejecting the whole enqueue — the delivery can
+      // still fire (with `{}`) but won't bloat the persisted store.
+      try {
+        const serialized = JSON.stringify(payload);
+        if (serialized && serialized.length <= PAYLOAD_MAX_BYTES) {
+          delivery.payload = JSON.parse(serialized);
+        }
+      } catch (_err) {
+        // unrepresentable — proceed without payload
+      }
+    }
     await this.#commit((state) => {
       state.deliveries.push(delivery);
       return state;

--- a/lib/webhook-delivery-store.js
+++ b/lib/webhook-delivery-store.js
@@ -243,10 +243,15 @@ class WebhookDeliveryStore {
   }
 
   async #commit(updater) {
+    // Pause BEFORE enqueueing — see WebhookStore.#commit for the
+    // deadlock rationale. The backup drain awaits this commitQueue
+    // while holding the data-mutation lock; if the queued run re-
+    // checked the lock, it would block forever waiting for backup
+    // to finish.
+    if (this.waitForDataMutationLock) {
+      await this.waitForDataMutationLock();
+    }
     const run = async () => {
-      if (this.waitForDataMutationLock) {
-        await this.waitForDataMutationLock();
-      }
       const current = this.state ? cloneState(this.state) : await this.load();
       const next = updater(current);
       // Apply retention cap before normalization. Only evict TERMINAL

--- a/lib/webhook-delivery-store.js
+++ b/lib/webhook-delivery-store.js
@@ -89,13 +89,14 @@ function normalizeDelivery(raw) {
   if (typeof raw.nextAttemptAt === "string") out.nextAttemptAt = raw.nextAttemptAt;
   if (isPlainObject(raw.payload)) {
     // Drop oversized payloads silently; the delivery is still
-    // executable, just with `{}` as the recovered payload. We prefer
-    // dropping over rejecting the whole row because the alternative
-    // (refusing to load the store on a single oversized payload) would
-    // wedge the dispatcher for every other delivery in the file.
+    // executable, just with `{}` as the recovered payload. Compare in
+    // BYTES (Buffer.byteLength), not String.length — JSON.stringify
+    // returns a UTF-16 string but the persisted file is UTF-8, so a
+    // payload with multi-byte characters could otherwise sneak past a
+    // .length check.
     try {
       const serialized = JSON.stringify(raw.payload);
-      if (serialized && serialized.length <= PAYLOAD_MAX_BYTES) {
+      if (serialized && Buffer.byteLength(serialized, "utf8") <= PAYLOAD_MAX_BYTES) {
         out.payload = JSON.parse(serialized);
       }
     } catch (_err) {
@@ -176,11 +177,13 @@ class WebhookDeliveryStore {
     this.historyMax = Number.isInteger(options.historyMax) && options.historyMax > 0
       ? options.historyMax
       : 200;
-    // See WebhookStore for the rationale; background delivery attempts
-    // hit `update()` continuously, so without this barrier a delivery
-    // mid-flight could tear a backup or land after a restore.
-    this.waitForDataMutationLock = typeof options.waitForDataMutationLock === "function"
-      ? options.waitForDataMutationLock
+    // Atomic data-write claim — see WebhookStore for the rationale.
+    // Background `executeOnce()` calls `update()` outside the admin
+    // `withSlot()` wrapper, so without this slot, an in-flight
+    // delivery could rename `webhook-deliveries.json` underneath a
+    // backup that just observed the queue as empty.
+    this.claimDirectDataWriteSlot = typeof options.claimDirectDataWriteSlot === "function"
+      ? options.claimDirectDataWriteSlot
       : null;
     this.state = null;
     this.loadPromise = null;
@@ -243,50 +246,51 @@ class WebhookDeliveryStore {
   }
 
   async #commit(updater) {
-    // Pause BEFORE enqueueing — see WebhookStore.#commit for the
-    // deadlock rationale. The backup drain awaits this commitQueue
-    // while holding the data-mutation lock; if the queued run re-
-    // checked the lock, it would block forever waiting for backup
-    // to finish.
-    if (this.waitForDataMutationLock) {
-      await this.waitForDataMutationLock();
+    // Atomically claim a direct-write slot — see WebhookStore.#commit.
+    let releaseSlot = null;
+    if (this.claimDirectDataWriteSlot) {
+      releaseSlot = await this.claimDirectDataWriteSlot();
     }
     const run = async () => {
-      const current = this.state ? cloneState(this.state) : await this.load();
-      const next = updater(current);
-      // Apply retention cap before normalization. Only evict TERMINAL
-      // rows (succeeded/failed/canceled) when the count exceeds the
-      // cap — pruning a `queued` or `running` row would orphan its
-      // timer and silently drop the delivery (executeOnce would log
-      // "delivery not found" and never retry). In a sustained burst
-      // bigger than `historyMax`, the oldest active rows are kept and
-      // the file may temporarily exceed historyMax until they reach a
-      // terminal state.
-      if (Array.isArray(next.deliveries) && next.deliveries.length > this.historyMax) {
-        const ACTIVE = new Set(["queued", "running"]);
-        const sorted = next.deliveries.slice().sort(
-          (a, b) => (a.createdAt || "").localeCompare(b.createdAt || "")
-            || (a.id || "").localeCompare(b.id || "")
-        );
-        const target = this.historyMax;
-        let toEvict = sorted.length - target;
-        const survivorIds = new Set();
-        const evictedIds = new Set();
-        for (const d of sorted) {
-          if (toEvict > 0 && !ACTIVE.has(d.status)) {
-            evictedIds.add(d.id);
-            toEvict -= 1;
-          } else {
-            survivorIds.add(d.id);
+      try {
+        const current = this.state ? cloneState(this.state) : await this.load();
+        const next = updater(current);
+        // Apply retention cap before normalization. Only evict TERMINAL
+        // rows (succeeded/failed/canceled) when the count exceeds the
+        // cap — pruning a `queued` or `running` row would orphan its
+        // timer and silently drop the delivery (executeOnce would log
+        // "delivery not found" and never retry). In a sustained burst
+        // bigger than `historyMax`, the oldest active rows are kept
+        // and the file may temporarily exceed historyMax until they
+        // reach a terminal state.
+        if (Array.isArray(next.deliveries) && next.deliveries.length > this.historyMax) {
+          const ACTIVE = new Set(["queued", "running"]);
+          const sorted = next.deliveries.slice().sort(
+            (a, b) => (a.createdAt || "").localeCompare(b.createdAt || "")
+              || (a.id || "").localeCompare(b.id || "")
+          );
+          const target = this.historyMax;
+          let toEvict = sorted.length - target;
+          const survivorIds = new Set();
+          const evictedIds = new Set();
+          for (const d of sorted) {
+            if (toEvict > 0 && !ACTIVE.has(d.status)) {
+              evictedIds.add(d.id);
+              toEvict -= 1;
+            } else {
+              survivorIds.add(d.id);
+            }
           }
+          next.deliveries = next.deliveries.filter((d) => survivorIds.has(d.id) || !evictedIds.has(d.id));
         }
-        next.deliveries = next.deliveries.filter((d) => survivorIds.has(d.id) || !evictedIds.has(d.id));
+        next.updatedAt = this.now().toISOString();
+        const finalState = normalizeStore(next);
+        await writeJsonAtomic(this.filePath, finalState);
+        this.state = finalState;
+        return cloneState(this.state);
+      } finally {
+        if (releaseSlot) releaseSlot();
       }
-      next.updatedAt = this.now().toISOString();
-      const finalState = normalizeStore(next);
-      await writeJsonAtomic(this.filePath, finalState);
-      this.state = finalState;
-      return cloneState(this.state);
     };
     const next = this.commitQueue.then(run, run);
     this.commitQueue = next.then(() => undefined, () => undefined);
@@ -314,12 +318,11 @@ class WebhookDeliveryStore {
     if (typeof url === "string") delivery.url = url;
     if (typeof nextAttemptAt === "string") delivery.nextAttemptAt = nextAttemptAt;
     if (isPlainObject(payload)) {
-      // Skip if serialized payload exceeds the cap. We prefer dropping
-      // the payload to rejecting the whole enqueue — the delivery can
-      // still fire (with `{}`) but won't bloat the persisted store.
+      // Drop oversized payloads (UTF-8 byte count, not String.length).
+      // The delivery still fires; the recovered payload will be `{}`.
       try {
         const serialized = JSON.stringify(payload);
-        if (serialized && serialized.length <= PAYLOAD_MAX_BYTES) {
+        if (serialized && Buffer.byteLength(serialized, "utf8") <= PAYLOAD_MAX_BYTES) {
           delivery.payload = JSON.parse(serialized);
         }
       } catch (_err) {

--- a/lib/webhook-delivery-store.js
+++ b/lib/webhook-delivery-store.js
@@ -1,0 +1,362 @@
+"use strict";
+
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const nodeCrypto = require("node:crypto");
+
+const STORE_VERSION = 1;
+const STATUSES = Object.freeze(["queued", "running", "succeeded", "failed", "canceled"]);
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+const RESPONSE_SNIPPET_MAX = 4096;
+const LAST_ERROR_MAX = 2048;
+const WINDOWS_RENAME_OVERWRITE_CODES = new Set(["EEXIST", "EPERM", "EACCES"]);
+
+class WebhookDeliveryStoreError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = "WebhookDeliveryStoreError";
+    this.code = code;
+    if (options.cause) this.cause = options.cause;
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function generateDeliveryId() {
+  return nodeCrypto.randomBytes(16).toString("base64url");
+}
+
+function clampString(value, max) {
+  if (typeof value !== "string") return undefined;
+  if (value.length <= max) return value;
+  return value.slice(0, max);
+}
+
+function normalizeDelivery(raw) {
+  if (!isPlainObject(raw)) {
+    throw new WebhookDeliveryStoreError("INVALID_DELIVERY", "Delivery must be an object.");
+  }
+  if (!ID_PATTERN.test(raw.id || "")) {
+    throw new WebhookDeliveryStoreError("INVALID_DELIVERY", `Invalid delivery id: ${raw.id}`);
+  }
+  if (!ID_PATTERN.test(raw.subscriptionId || "")) {
+    throw new WebhookDeliveryStoreError(
+      "INVALID_DELIVERY",
+      `Invalid subscriptionId: ${raw.subscriptionId}`
+    );
+  }
+  if (typeof raw.event !== "string" || !raw.event) {
+    throw new WebhookDeliveryStoreError("INVALID_DELIVERY", "event is required.");
+  }
+  if (!STATUSES.includes(raw.status)) {
+    throw new WebhookDeliveryStoreError("INVALID_DELIVERY", `Invalid status: ${raw.status}`);
+  }
+  if (!Number.isInteger(raw.attempts) || raw.attempts < 0) {
+    throw new WebhookDeliveryStoreError("INVALID_DELIVERY", "attempts must be a non-negative integer.");
+  }
+  const out = {
+    id: raw.id,
+    subscriptionId: raw.subscriptionId,
+    event: raw.event,
+    status: raw.status,
+    attempts: raw.attempts,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt
+  };
+  if (typeof raw.url === "string") out.url = raw.url;
+  if (Number.isInteger(raw.responseStatus)) out.responseStatus = raw.responseStatus;
+  const snippet = clampString(raw.responseSnippet, RESPONSE_SNIPPET_MAX);
+  if (snippet !== undefined) out.responseSnippet = snippet;
+  const lastError = clampString(raw.lastError, LAST_ERROR_MAX);
+  if (lastError !== undefined) out.lastError = lastError;
+  if (typeof raw.nextAttemptAt === "string") out.nextAttemptAt = raw.nextAttemptAt;
+  return out;
+}
+
+function buildDefaultStore() {
+  return {
+    version: STORE_VERSION,
+    updatedAt: new Date().toISOString(),
+    deliveries: []
+  };
+}
+
+function normalizeStore(raw) {
+  if (!isPlainObject(raw)) {
+    throw new WebhookDeliveryStoreError("INVALID_STORE", "Store must be an object.");
+  }
+  if (raw.version !== STORE_VERSION) {
+    throw new WebhookDeliveryStoreError(
+      "VERSION_UNSUPPORTED",
+      `Webhook delivery store version ${raw.version} is not supported.`
+    );
+  }
+  if (typeof raw.updatedAt !== "string") {
+    throw new WebhookDeliveryStoreError("INVALID_STORE", "updatedAt is required.");
+  }
+  if (!Array.isArray(raw.deliveries)) {
+    throw new WebhookDeliveryStoreError("INVALID_STORE", "deliveries must be an array.");
+  }
+  const seen = new Set();
+  const deliveries = [];
+  for (const d of raw.deliveries) {
+    const norm = normalizeDelivery(d);
+    if (seen.has(norm.id)) continue;
+    seen.add(norm.id);
+    deliveries.push(norm);
+  }
+  // Sort by createdAt ascending so retention prunes the oldest first.
+  deliveries.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+  return { version: STORE_VERSION, updatedAt: raw.updatedAt, deliveries };
+}
+
+async function writeJsonAtomic(filePath, payload) {
+  const tempPath = `${filePath}.${process.pid}.${nodeCrypto.randomUUID()}.tmp`;
+  try {
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+    await fsp.writeFile(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    try {
+      await fsp.rename(tempPath, filePath);
+    } catch (renameErr) {
+      if (!renameErr || !WINDOWS_RENAME_OVERWRITE_CODES.has(renameErr.code)) throw renameErr;
+      await fsp.rm(filePath, { force: true });
+      await fsp.rename(tempPath, filePath);
+    }
+  } catch (err) {
+    try { await fsp.rm(tempPath, { force: true }); } catch (_e) { /* best-effort */ }
+    throw new WebhookDeliveryStoreError(
+      "STORE_WRITE_FAILED",
+      `Failed to persist delivery store to ${filePath}: ${err.message}`,
+      { cause: err }
+    );
+  }
+}
+
+class WebhookDeliveryStore {
+  constructor(options = {}) {
+    if (!options.filePath) {
+      throw new WebhookDeliveryStoreError("INVALID_REQUEST", "filePath is required.");
+    }
+    this.filePath = options.filePath;
+    this.logger = options.logger || console;
+    this.now = typeof options.now === "function" ? options.now : () => new Date();
+    // History cap; oldest get evicted when the count exceeds this.
+    this.historyMax = Number.isInteger(options.historyMax) && options.historyMax > 0
+      ? options.historyMax
+      : 200;
+    this.state = null;
+    this.loadPromise = null;
+    this.commitQueue = Promise.resolve();
+  }
+
+  async load() {
+    if (this.state) return cloneState(this.state);
+    if (!this.loadPromise) {
+      this.loadPromise = this.#loadInternal().catch((err) => {
+        this.loadPromise = null;
+        throw err;
+      });
+    }
+    await this.loadPromise;
+    return cloneState(this.state);
+  }
+
+  async #loadInternal() {
+    let raw;
+    try {
+      raw = await fsp.readFile(this.filePath, "utf8");
+    } catch (err) {
+      if (err && err.code === "ENOENT") {
+        const fresh = buildDefaultStore();
+        fresh.updatedAt = this.now().toISOString();
+        await writeJsonAtomic(this.filePath, fresh);
+        this.state = fresh;
+        return;
+      }
+      throw new WebhookDeliveryStoreError(
+        "STORE_READ_FAILED",
+        `Failed to read delivery store from ${this.filePath}: ${err.message}`,
+        { cause: err }
+      );
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new WebhookDeliveryStoreError(
+        "STORE_PARSE_FAILED",
+        `Delivery store ${this.filePath} is not valid JSON: ${err.message}`,
+        { cause: err }
+      );
+    }
+    this.state = normalizeStore(parsed);
+  }
+
+  async getSnapshot() {
+    return this.load();
+  }
+
+  async reload() {
+    await this.commitQueue.catch(() => {});
+    if (this.loadPromise) await this.loadPromise.catch(() => {});
+    this.state = null;
+    this.loadPromise = null;
+    return this.load();
+  }
+
+  async #commit(updater) {
+    const run = async () => {
+      const current = this.state ? cloneState(this.state) : await this.load();
+      const next = updater(current);
+      // Apply retention cap before normalization. Oldest entries (sorted
+      // first by normalizeStore) get dropped when count exceeds the cap.
+      if (Array.isArray(next.deliveries) && next.deliveries.length > this.historyMax) {
+        const overflow = next.deliveries.length - this.historyMax;
+        next.deliveries = next.deliveries.slice(overflow);
+      }
+      next.updatedAt = this.now().toISOString();
+      const finalState = normalizeStore(next);
+      await writeJsonAtomic(this.filePath, finalState);
+      this.state = finalState;
+      return cloneState(this.state);
+    };
+    const next = this.commitQueue.then(run, run);
+    this.commitQueue = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  async enqueue({ subscriptionId, event, url, nextAttemptAt }) {
+    if (!ID_PATTERN.test(String(subscriptionId || ""))) {
+      throw new WebhookDeliveryStoreError("INVALID_REQUEST", "subscriptionId is required.");
+    }
+    if (typeof event !== "string" || !event) {
+      throw new WebhookDeliveryStoreError("INVALID_REQUEST", "event is required.");
+    }
+    const id = generateDeliveryId();
+    const nowIso = this.now().toISOString();
+    const delivery = {
+      id,
+      subscriptionId,
+      event,
+      status: "queued",
+      attempts: 0,
+      createdAt: nowIso,
+      updatedAt: nowIso
+    };
+    if (typeof url === "string") delivery.url = url;
+    if (typeof nextAttemptAt === "string") delivery.nextAttemptAt = nextAttemptAt;
+    await this.#commit((state) => {
+      state.deliveries.push(delivery);
+      return state;
+    });
+    return cloneState(delivery);
+  }
+
+  async update(id, patch) {
+    if (!ID_PATTERN.test(String(id || ""))) {
+      throw new WebhookDeliveryStoreError("INVALID_REQUEST", "Invalid delivery id.");
+    }
+    if (!isPlainObject(patch)) {
+      throw new WebhookDeliveryStoreError("INVALID_REQUEST", "patch must be an object.");
+    }
+    let updated;
+    await this.#commit((state) => {
+      const idx = state.deliveries.findIndex((d) => d.id === id);
+      if (idx === -1) {
+        throw new WebhookDeliveryStoreError("DELIVERY_NOT_FOUND", `No delivery with id ${id}.`);
+      }
+      const merged = { ...state.deliveries[idx] };
+      if (patch.status !== undefined) {
+        if (!STATUSES.includes(patch.status)) {
+          throw new WebhookDeliveryStoreError("INVALID_REQUEST", `Invalid status: ${patch.status}`);
+        }
+        merged.status = patch.status;
+      }
+      if (patch.attempts !== undefined) {
+        if (!Number.isInteger(patch.attempts) || patch.attempts < 0) {
+          throw new WebhookDeliveryStoreError("INVALID_REQUEST", "attempts must be a non-negative integer.");
+        }
+        merged.attempts = patch.attempts;
+      }
+      if (patch.responseStatus !== undefined) {
+        if (!Number.isInteger(patch.responseStatus)) {
+          throw new WebhookDeliveryStoreError("INVALID_REQUEST", "responseStatus must be an integer.");
+        }
+        merged.responseStatus = patch.responseStatus;
+      }
+      if (patch.responseSnippet !== undefined) {
+        merged.responseSnippet = clampString(patch.responseSnippet, RESPONSE_SNIPPET_MAX);
+      }
+      if (patch.lastError !== undefined) {
+        const trimmed = clampString(patch.lastError, LAST_ERROR_MAX);
+        if (trimmed === undefined || trimmed === "") delete merged.lastError;
+        else merged.lastError = trimmed;
+      }
+      if (patch.nextAttemptAt !== undefined) {
+        if (patch.nextAttemptAt === null || patch.nextAttemptAt === "") {
+          delete merged.nextAttemptAt;
+        } else {
+          merged.nextAttemptAt = patch.nextAttemptAt;
+        }
+      }
+      merged.updatedAt = this.now().toISOString();
+      state.deliveries.splice(idx, 1, merged);
+      updated = merged;
+      return state;
+    });
+    return cloneState(updated);
+  }
+
+  async findById(id) {
+    const snap = await this.load();
+    return snap.deliveries.find((d) => d.id === id) || null;
+  }
+
+  async findRecent({ subscriptionId, status, event, limit }) {
+    const snap = await this.load();
+    let rows = snap.deliveries.slice();
+    if (subscriptionId) rows = rows.filter((d) => d.subscriptionId === subscriptionId);
+    if (status) rows = rows.filter((d) => d.status === status);
+    if (event) rows = rows.filter((d) => d.event === event);
+    rows.reverse(); // newest first
+    const cap = Number.isInteger(limit) && limit > 0 ? limit : rows.length;
+    return rows.slice(0, cap);
+  }
+
+  async findRecoverable() {
+    // Anything in `running` at boot is a candidate for restart recovery —
+    // the previous process died mid-flight.
+    const snap = await this.load();
+    return snap.deliveries.filter((d) => d.status === "running" || d.status === "queued");
+  }
+
+  async deleteForSubscription(subscriptionId) {
+    if (!ID_PATTERN.test(String(subscriptionId || ""))) {
+      throw new WebhookDeliveryStoreError("INVALID_REQUEST", "Invalid subscription id.");
+    }
+    let removed = 0;
+    await this.#commit((state) => {
+      const before = state.deliveries.length;
+      state.deliveries = state.deliveries.filter((d) => d.subscriptionId !== subscriptionId);
+      removed = before - state.deliveries.length;
+      return state;
+    });
+    return removed;
+  }
+}
+
+function cloneState(state) {
+  return JSON.parse(JSON.stringify(state));
+}
+
+module.exports = {
+  WebhookDeliveryStore,
+  WebhookDeliveryStoreError,
+  generateDeliveryId,
+  normalizeDelivery,
+  normalizeStore,
+  STORE_VERSION,
+  STATUSES
+};

--- a/lib/webhook-service.js
+++ b/lib/webhook-service.js
@@ -63,9 +63,12 @@ function isPrivateIPv4(ip) {
 }
 
 function isPrivateIPv6(ip) {
-  // ::1 (loopback), fe80::/10 (link-local), fc00::/7 (unique-local)
+  // ::1 (loopback), fe80::/10 (link-local), fc00::/7 (unique-local),
+  // :: (unspecified — used by servers that bind to all interfaces; a
+  // client connecting here on the same host hits the loopback path,
+  // so block it like 0.0.0.0).
   const lower = ip.toLowerCase();
-  if (lower === "::1") return true;
+  if (lower === "::1" || lower === "::") return true;
   if (lower.startsWith("fe8") || lower.startsWith("fe9")
     || lower.startsWith("fea") || lower.startsWith("feb")) return true;
   if (lower.startsWith("fc") || lower.startsWith("fd")) return true;

--- a/lib/webhook-service.js
+++ b/lib/webhook-service.js
@@ -2,6 +2,18 @@
 
 const dnsPromises = require("node:dns/promises");
 const nodeCrypto = require("node:crypto");
+let undiciAgentRef = null;
+function getUndiciAgent() {
+  if (undiciAgentRef !== null) return undiciAgentRef;
+  try {
+    // Lazy-require so the module loads cleanly in environments that
+    // don't ship undici (e.g. ancient Node), even though Node 18+ does.
+    undiciAgentRef = require("undici").Agent;
+  } catch (_err) {
+    undiciAgentRef = false;
+  }
+  return undiciAgentRef;
+}
 
 // Backoff schedule per the spec — total wait is roughly 12.5 minutes
 // across 5 attempts before dead-letter.
@@ -93,7 +105,7 @@ async function assertOutboundUrlAllowed(rawUrl, { allowPrivateNetworks = false }
       { retriable: false }
     );
   }
-  if (allowPrivateNetworks) return parsed;
+  if (allowPrivateNetworks) return { url: parsed, addresses: null };
   const hostname = parsed.hostname;
   // If the hostname is already a literal IP, check it directly.
   if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
@@ -104,17 +116,18 @@ async function assertOutboundUrlAllowed(rawUrl, { allowPrivateNetworks = false }
         { retriable: false }
       );
     }
-    return parsed;
+    return { url: parsed, addresses: [{ address: hostname, family: 4 }] };
   }
   if (hostname.includes(":")) {
-    if (isPrivateIPv6(hostname.replace(/^\[|\]$/g, ""))) {
+    const stripped = hostname.replace(/^\[|\]$/g, "");
+    if (isPrivateIPv6(stripped)) {
       throw new WebhookSendError(
         "PRIVATE_ADDRESS_BLOCKED",
         `Outbound IPv6 ${hostname} is in a private/loopback range.`,
         { retriable: false }
       );
     }
-    return parsed;
+    return { url: parsed, addresses: [{ address: stripped, family: 6 }] };
   }
   const records = await resolveHost(hostname);
   for (const rec of records) {
@@ -127,7 +140,48 @@ async function assertOutboundUrlAllowed(rawUrl, { allowPrivateNetworks = false }
       );
     }
   }
-  return parsed;
+  return { url: parsed, addresses: records };
+}
+
+// Builds a node:dns/promises-style lookup function that resolves the
+// given hostname only to one of the pre-validated addresses. Pinning
+// the resolution closes the DNS-rebinding window between
+// assertOutboundUrlAllowed's check and fetch's own DNS lookup.
+function buildPinnedLookup(hostname, addresses) {
+  return (lookupHost, options, cb) => {
+    let callback = cb;
+    let opts = options;
+    if (typeof options === "function") {
+      callback = options;
+      opts = {};
+    }
+    if (lookupHost !== hostname) {
+      // Different hostname — fall through to default DNS. Shouldn't
+      // happen in practice (we pin per-request), but be safe.
+      dnsPromises
+        .lookup(lookupHost, opts || {})
+        .then((res) => {
+          if (Array.isArray(res)) callback(null, res);
+          else callback(null, res.address, res.family);
+        })
+        .catch(callback);
+      return;
+    }
+    const valid = addresses.filter(
+      (a) => !opts?.family || opts.family === 0 || opts.family === a.family
+    );
+    if (valid.length === 0) {
+      const err = new Error(`No validated addresses for ${lookupHost}`);
+      err.code = "ENOTFOUND";
+      callback(err);
+      return;
+    }
+    if (opts?.all) {
+      callback(null, valid.map((a) => ({ address: a.address, family: a.family })));
+    } else {
+      callback(null, valid[0].address, valid[0].family);
+    }
+  };
 }
 
 function signPayload(body, secret) {
@@ -197,7 +251,8 @@ async function sendWebhookRequest({
   headers,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   maxBodyBytes = DEFAULT_MAX_BODY_BYTES,
-  fetchImpl = globalThis.fetch
+  fetchImpl = globalThis.fetch,
+  dispatcher = null
 }) {
   if (typeof fetchImpl !== "function") {
     throw new WebhookSendError(
@@ -210,7 +265,7 @@ async function sendWebhookRequest({
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   let response;
   try {
-    response = await fetchImpl(url, {
+    const init = {
       method: "POST",
       headers,
       body,
@@ -218,7 +273,9 @@ async function sendWebhookRequest({
       // Don't follow redirects automatically; the recipient should
       // accept the URL we configured and not bounce us elsewhere.
       redirect: "manual"
-    });
+    };
+    if (dispatcher) init.dispatcher = dispatcher;
+    response = await fetchImpl(url, init);
   } catch (err) {
     clearTimeout(timer);
     if (err.name === "AbortError") {
@@ -278,10 +335,15 @@ class WebhookService {
     const subs = await this.subscriptionStore.findEnabledForEvent(event);
     const out = [];
     for (const sub of subs) {
+      // Persist the payload on the delivery row so boot recovery and
+      // manual retries can resend the original body. Without this,
+      // recovered/retried deliveries would only have the empty `{}`
+      // fallback because runtimeContext lives in process memory.
       const delivery = await this.deliveryStore.enqueue({
         subscriptionId: sub.id,
         event,
-        url: sub.url
+        url: sub.url,
+        payload
       });
       out.push(delivery);
       this.scheduleDelivery(delivery.id, 0, { event, payload, subscription: sub });
@@ -290,9 +352,12 @@ class WebhookService {
   }
 
   // Schedule a single delivery to run after delayMs. Stores a timer ref so
-  // shutdown can clear pending work cleanly.
+  // shutdown can clear pending work cleanly. Gated on `enabled` so admin
+  // routes (and recoverOnBoot) can call this directly without bypassing
+  // the WEBHOOKS_ENABLED contract.
   scheduleDelivery(deliveryId, delayMs = 0, runtimeContext = null) {
     if (this.shutdownRequested) return;
+    if (!this.enabled) return;
     const timer = setTimeout(() => {
       this.scheduledTimers.delete(timer);
       this.enqueueReady(deliveryId, runtimeContext);
@@ -302,11 +367,13 @@ class WebhookService {
   }
 
   enqueueReady(deliveryId, runtimeContext) {
+    if (!this.enabled) return;
     this.readyQueue.push({ deliveryId, runtimeContext });
     this.drain();
   }
 
   drain() {
+    if (!this.enabled) return;
     while (this.activeCount < this.globalInflight && this.readyQueue.length > 0 && !this.shutdownRequested) {
       const item = this.readyQueue.shift();
       this.activeCount += 1;
@@ -332,8 +399,12 @@ class WebhookService {
       // duplicate timer).
       return;
     }
-    const sub = runtimeContext?.subscription
-      || (await this.subscriptionStore.findById(delivery.subscriptionId));
+    // Always look up the subscription fresh from the store. Caching
+    // it on runtimeContext (as an earlier draft did) would let same-
+    // process retries post to the OLD url and sign with the OLD
+    // secret even after the operator edited or rotated. The store
+    // is the source of truth for subscription state at attempt time.
+    const sub = await this.subscriptionStore.findById(delivery.subscriptionId);
     if (!sub || !sub.enabled) {
       await this.deliveryStore.update(delivery.id, {
         status: "canceled",
@@ -350,19 +421,28 @@ class WebhookService {
     let result;
     let nonRetriableError;
     try {
+      // Prefer in-memory payload (fast path for fresh emits), fall
+      // back to the persisted row for boot recovery / manual retries
+      // where runtimeContext is empty.
+      const payload = runtimeContext?.payload
+        ?? delivery.payload
+        ?? {};
       const body = JSON.stringify({
         id: delivery.id,
         event: delivery.event,
         timestamp: this.now().toISOString(),
         attempt: attemptNumber,
-        payload: runtimeContext?.payload || {}
+        payload
       });
       const signature = signPayload(body, sub.secret);
       // Pre-flight URL check (every attempt — DNS could change, and the
       // operator could have edited the URL after the delivery was
       // enqueued). Throws WebhookSendError with retriable=false on
       // policy violations so the outer logic stops retrying.
-      await assertOutboundUrlAllowed(sub.url, { allowPrivateNetworks: this.allowPrivateNetworks });
+      const { url: parsedUrl, addresses } = await assertOutboundUrlAllowed(sub.url, {
+        allowPrivateNetworks: this.allowPrivateNetworks
+      });
+      const dispatcher = this.#buildPinnedDispatcher(parsedUrl, addresses);
       const headers = {
         "content-type": "application/json",
         "user-agent": "wordle-local-webhook/1",
@@ -378,7 +458,8 @@ class WebhookService {
         headers,
         timeoutMs: this.timeoutMs,
         maxBodyBytes: this.maxBodyBytes,
-        fetchImpl: this.fetchImpl
+        fetchImpl: this.fetchImpl,
+        dispatcher
       });
     } catch (err) {
       if (err instanceof WebhookSendError) {
@@ -511,6 +592,19 @@ class WebhookService {
     for (const t of this.scheduledTimers) clearTimeout(t);
     this.scheduledTimers.clear();
     this.readyQueue.length = 0;
+  }
+
+  // Returns an undici Agent that pins DNS resolution for `parsedUrl`'s
+  // hostname to the addresses we already validated, closing the
+  // DNS-rebinding window between assertOutboundUrlAllowed's lookup and
+  // fetch's own resolution. Returns null if undici isn't available
+  // (allowPrivateNetworks bypass) or pin information is missing.
+  #buildPinnedDispatcher(parsedUrl, addresses) {
+    if (!Array.isArray(addresses) || addresses.length === 0) return null;
+    const Agent = getUndiciAgent();
+    if (!Agent) return null;
+    const lookup = buildPinnedLookup(parsedUrl.hostname, addresses);
+    return new Agent({ connect: { lookup } });
   }
 }
 

--- a/lib/webhook-service.js
+++ b/lib/webhook-service.js
@@ -265,6 +265,11 @@ async function sendWebhookRequest({
     );
   }
   const controller = new AbortController();
+  // Single timer covers BOTH the request and the response-body read.
+  // If we cleared the timer when fetch() resolves (the previous shape
+  // of this function), a recipient that streamed headers and stalled
+  // the body would leave readResponseSnippet awaiting forever, hold
+  // the global in-flight slot, and eventually starve the dispatcher.
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   let response;
   try {
@@ -285,12 +290,27 @@ async function sendWebhookRequest({
       throw new WebhookSendError("TIMEOUT", `Webhook request timed out after ${timeoutMs}ms.`, { retriable: true, cause: err });
     }
     throw new WebhookSendError("NETWORK_ERROR", `Network error: ${err.message}`, { retriable: true, cause: err });
+  }
+  let responseStatus;
+  let snippet;
+  let retryAfter;
+  try {
+    responseStatus = response.status;
+    snippet = await readResponseSnippet(response, maxBodyBytes);
+    retryAfter = parseRetryAfterHeader(response.headers.get?.("retry-after"), new Date());
+  } catch (err) {
+    clearTimeout(timer);
+    if (err.name === "AbortError") {
+      throw new WebhookSendError(
+        "TIMEOUT",
+        `Webhook response body read timed out after ${timeoutMs}ms.`,
+        { retriable: true, cause: err }
+      );
+    }
+    throw err;
   } finally {
     clearTimeout(timer);
   }
-  const responseStatus = response.status;
-  const snippet = await readResponseSnippet(response, maxBodyBytes);
-  const retryAfter = parseRetryAfterHeader(response.headers.get?.("retry-after"), new Date());
   return { responseStatus, responseSnippet: snippet, retryAfterMs: retryAfter };
 }
 
@@ -424,11 +444,17 @@ class WebhookService {
     let result;
     let nonRetriableError;
     try {
-      // Prefer in-memory payload (fast path for fresh emits), fall
-      // back to the persisted row for boot recovery / manual retries
-      // where runtimeContext is empty.
-      const payload = runtimeContext?.payload
-        ?? delivery.payload
+      // ALWAYS prefer the persisted payload from the delivery row.
+      // The store clamps oversized payloads (8 KiB) and drops
+      // unrepresentable ones at enqueue, so first-attempt fresh
+      // emits and recovered/manually-retried attempts both deliver
+      // the same (clamped) body. Falling back to runtimeContext
+      // for the first attempt would let an oversize payload escape
+      // the cap on attempt 1, then truncate to `{}` on retry —
+      // inconsistent and surprising. The fallback to `{}` is for
+      // pre-payload-persistence rows in the delivery file.
+      const payload = delivery.payload
+        ?? runtimeContext?.payload
         ?? {};
       const body = JSON.stringify({
         id: delivery.id,

--- a/lib/webhook-service.js
+++ b/lib/webhook-service.js
@@ -1,0 +1,528 @@
+"use strict";
+
+const dnsPromises = require("node:dns/promises");
+const nodeCrypto = require("node:crypto");
+
+// Backoff schedule per the spec — total wait is roughly 12.5 minutes
+// across 5 attempts before dead-letter.
+const DEFAULT_BACKOFF_MS = Object.freeze([1000, 5000, 30000, 120000, 600000]);
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_BODY_BYTES = 64 * 1024;
+const DEFAULT_GLOBAL_INFLIGHT = 4;
+const DEFAULT_RETRY_AFTER_CAP_MS = 600_000; // never wait more than the longest backoff slot
+
+class WebhookSendError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = "WebhookSendError";
+    this.code = code;
+    this.retriable = options.retriable === true;
+    this.responseStatus = options.responseStatus;
+    this.responseSnippet = options.responseSnippet;
+    this.retryAfterMs = options.retryAfterMs;
+    if (options.cause) this.cause = options.cause;
+  }
+}
+
+function nextBackoffMs(attemptNumber, schedule = DEFAULT_BACKOFF_MS) {
+  // attemptNumber is 1-indexed (the attempt that just failed). The backoff
+  // for the NEXT attempt is schedule[attemptNumber-1] when retrying for
+  // the second time, etc. If we've used the whole schedule, we cap at
+  // the last slot (so a 6th attempt — if maxAttempts allowed it — still
+  // gets the 10-minute slot).
+  const idx = Math.max(0, Math.min(attemptNumber - 1, schedule.length - 1));
+  return schedule[idx];
+}
+
+function isPrivateIPv4(ip) {
+  // RFC1918 + loopback + link-local + 0.0.0.0
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return true; // unparseable → treat as unsafe
+  }
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 0 && b === 0 && parts[2] === 0 && parts[3] === 0) return true;
+  return false;
+}
+
+function isPrivateIPv6(ip) {
+  // ::1 (loopback), fe80::/10 (link-local), fc00::/7 (unique-local)
+  const lower = ip.toLowerCase();
+  if (lower === "::1") return true;
+  if (lower.startsWith("fe8") || lower.startsWith("fe9")
+    || lower.startsWith("fea") || lower.startsWith("feb")) return true;
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  // Also IPv4-mapped IPv6 (::ffff:10.0.0.1 etc.). Strip prefix and re-check.
+  if (lower.startsWith("::ffff:")) {
+    return isPrivateIPv4(lower.slice("::ffff:".length));
+  }
+  return false;
+}
+
+async function resolveHost(hostname) {
+  // Returns array of resolved IP addresses (both v4 and v6 if present).
+  // Throws on resolution failure.
+  try {
+    const records = await dnsPromises.lookup(hostname, { all: true, verbatim: true });
+    return records.map((r) => ({ address: r.address, family: r.family }));
+  } catch (err) {
+    throw new WebhookSendError(
+      "DNS_RESOLUTION_FAILED",
+      `Could not resolve ${hostname}: ${err.message}`,
+      { retriable: true, cause: err }
+    );
+  }
+}
+
+async function assertOutboundUrlAllowed(rawUrl, { allowPrivateNetworks = false } = {}) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch (err) {
+    throw new WebhookSendError("INVALID_URL", `Could not parse URL: ${rawUrl}`, { retriable: false });
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new WebhookSendError(
+      "INVALID_URL",
+      `Webhook URL scheme must be http(s); got ${parsed.protocol}`,
+      { retriable: false }
+    );
+  }
+  if (allowPrivateNetworks) return parsed;
+  const hostname = parsed.hostname;
+  // If the hostname is already a literal IP, check it directly.
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
+    if (isPrivateIPv4(hostname)) {
+      throw new WebhookSendError(
+        "PRIVATE_ADDRESS_BLOCKED",
+        `Outbound address ${hostname} is in a private/loopback range.`,
+        { retriable: false }
+      );
+    }
+    return parsed;
+  }
+  if (hostname.includes(":")) {
+    if (isPrivateIPv6(hostname.replace(/^\[|\]$/g, ""))) {
+      throw new WebhookSendError(
+        "PRIVATE_ADDRESS_BLOCKED",
+        `Outbound IPv6 ${hostname} is in a private/loopback range.`,
+        { retriable: false }
+      );
+    }
+    return parsed;
+  }
+  const records = await resolveHost(hostname);
+  for (const rec of records) {
+    const isPrivate = rec.family === 6 ? isPrivateIPv6(rec.address) : isPrivateIPv4(rec.address);
+    if (isPrivate) {
+      throw new WebhookSendError(
+        "PRIVATE_ADDRESS_BLOCKED",
+        `Outbound host ${hostname} resolves to a private/loopback address (${rec.address}).`,
+        { retriable: false }
+      );
+    }
+  }
+  return parsed;
+}
+
+function signPayload(body, secret) {
+  const hmac = nodeCrypto.createHmac("sha256", secret);
+  hmac.update(body);
+  return `sha256=${hmac.digest("hex")}`;
+}
+
+function parseRetryAfterHeader(value, now) {
+  if (!value) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  // Numeric seconds form
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    return Math.max(0, seconds * 1000);
+  }
+  // HTTP-date form
+  const ts = Date.parse(trimmed);
+  if (!Number.isNaN(ts)) {
+    return Math.max(0, ts - now.getTime());
+  }
+  return null;
+}
+
+function classifyHttpStatus(status) {
+  // 2xx success; 4xx (excluding 408/429) non-retriable; rest retriable.
+  if (status >= 200 && status < 300) return { ok: true, retriable: false };
+  if (status === 408 || status === 429) return { ok: false, retriable: true };
+  if (status >= 400 && status < 500) return { ok: false, retriable: false };
+  return { ok: false, retriable: true }; // 5xx + everything else
+}
+
+async function readResponseSnippet(response, maxBytes) {
+  // Read at most maxBytes from the response. Truncate without exploding
+  // memory; some recipients return giant HTML error pages.
+  const reader = response.body?.getReader?.();
+  if (!reader) return "";
+  let collected = 0;
+  const chunks = [];
+  try {
+    while (collected < maxBytes) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const remaining = maxBytes - collected;
+      const slice = value.length > remaining ? value.slice(0, remaining) : value;
+      chunks.push(slice);
+      collected += slice.length;
+      if (collected >= maxBytes) {
+        try { await reader.cancel(); } catch (_e) { /* best-effort */ }
+        break;
+      }
+    }
+  } catch (_err) {
+    // best-effort; we still return what we got
+  }
+  try {
+    return Buffer.concat(chunks).toString("utf8");
+  } catch (_err) {
+    return "";
+  }
+}
+
+async function sendWebhookRequest({
+  url,
+  body,
+  headers,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  maxBodyBytes = DEFAULT_MAX_BODY_BYTES,
+  fetchImpl = globalThis.fetch
+}) {
+  if (typeof fetchImpl !== "function") {
+    throw new WebhookSendError(
+      "FETCH_UNAVAILABLE",
+      "Global fetch is not available in this Node runtime.",
+      { retriable: false }
+    );
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers,
+      body,
+      signal: controller.signal,
+      // Don't follow redirects automatically; the recipient should
+      // accept the URL we configured and not bounce us elsewhere.
+      redirect: "manual"
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    if (err.name === "AbortError") {
+      throw new WebhookSendError("TIMEOUT", `Webhook request timed out after ${timeoutMs}ms.`, { retriable: true, cause: err });
+    }
+    throw new WebhookSendError("NETWORK_ERROR", `Network error: ${err.message}`, { retriable: true, cause: err });
+  } finally {
+    clearTimeout(timer);
+  }
+  const responseStatus = response.status;
+  const snippet = await readResponseSnippet(response, maxBodyBytes);
+  const retryAfter = parseRetryAfterHeader(response.headers.get?.("retry-after"), new Date());
+  return { responseStatus, responseSnippet: snippet, retryAfterMs: retryAfter };
+}
+
+class WebhookService {
+  constructor(options = {}) {
+    if (!options.subscriptionStore) {
+      throw new Error("WebhookService: subscriptionStore is required.");
+    }
+    if (!options.deliveryStore) {
+      throw new Error("WebhookService: deliveryStore is required.");
+    }
+    this.subscriptionStore = options.subscriptionStore;
+    this.deliveryStore = options.deliveryStore;
+    this.logger = options.logger || console;
+    this.now = typeof options.now === "function" ? options.now : () => new Date();
+    this.allowPrivateNetworks = options.allowPrivateNetworks === true;
+    this.timeoutMs = Number.isInteger(options.timeoutMs) && options.timeoutMs > 0
+      ? options.timeoutMs
+      : DEFAULT_TIMEOUT_MS;
+    this.maxBodyBytes = Number.isInteger(options.maxBodyBytes) && options.maxBodyBytes > 0
+      ? options.maxBodyBytes
+      : DEFAULT_MAX_BODY_BYTES;
+    this.globalInflight = Number.isInteger(options.globalInflight) && options.globalInflight > 0
+      ? options.globalInflight
+      : DEFAULT_GLOBAL_INFLIGHT;
+    this.backoffSchedule = Array.isArray(options.backoffSchedule) && options.backoffSchedule.length > 0
+      ? options.backoffSchedule
+      : DEFAULT_BACKOFF_MS;
+    this.fetchImpl = options.fetchImpl || globalThis.fetch;
+    this.enabled = options.enabled !== false;
+    // Pending due timers — tracked so shutdown can clear them.
+    this.scheduledTimers = new Set();
+    // Concurrency semaphore — counts in-flight executeOnce() calls.
+    this.activeCount = 0;
+    // Queue of delivery IDs ready to run when a slot frees up.
+    this.readyQueue = [];
+    this.shutdownRequested = false;
+  }
+
+  async emit(event, payload = {}) {
+    if (!this.enabled) return [];
+    if (typeof event !== "string" || !event) {
+      throw new Error("emit(): event is required.");
+    }
+    const subs = await this.subscriptionStore.findEnabledForEvent(event);
+    const out = [];
+    for (const sub of subs) {
+      const delivery = await this.deliveryStore.enqueue({
+        subscriptionId: sub.id,
+        event,
+        url: sub.url
+      });
+      out.push(delivery);
+      this.scheduleDelivery(delivery.id, 0, { event, payload, subscription: sub });
+    }
+    return out;
+  }
+
+  // Schedule a single delivery to run after delayMs. Stores a timer ref so
+  // shutdown can clear pending work cleanly.
+  scheduleDelivery(deliveryId, delayMs = 0, runtimeContext = null) {
+    if (this.shutdownRequested) return;
+    const timer = setTimeout(() => {
+      this.scheduledTimers.delete(timer);
+      this.enqueueReady(deliveryId, runtimeContext);
+    }, Math.max(0, delayMs));
+    if (typeof timer.unref === "function") timer.unref();
+    this.scheduledTimers.add(timer);
+  }
+
+  enqueueReady(deliveryId, runtimeContext) {
+    this.readyQueue.push({ deliveryId, runtimeContext });
+    this.drain();
+  }
+
+  drain() {
+    while (this.activeCount < this.globalInflight && this.readyQueue.length > 0 && !this.shutdownRequested) {
+      const item = this.readyQueue.shift();
+      this.activeCount += 1;
+      this.executeOnce(item.deliveryId, item.runtimeContext)
+        .catch((err) => {
+          this.logger.error?.(`[webhook] executeOnce crashed for ${item.deliveryId}:`, err);
+        })
+        .finally(() => {
+          this.activeCount -= 1;
+          this.drain();
+        });
+    }
+  }
+
+  async executeOnce(deliveryId, runtimeContext) {
+    const delivery = await this.deliveryStore.findById(deliveryId);
+    if (!delivery) {
+      this.logger.warn?.(`[webhook] delivery ${deliveryId} not found at execute time.`);
+      return;
+    }
+    if (delivery.status !== "queued" && delivery.status !== "running") {
+      // Already handled by another path (manual retry / cancellation /
+      // duplicate timer).
+      return;
+    }
+    const sub = runtimeContext?.subscription
+      || (await this.subscriptionStore.findById(delivery.subscriptionId));
+    if (!sub || !sub.enabled) {
+      await this.deliveryStore.update(delivery.id, {
+        status: "canceled",
+        lastError: sub ? "Subscription disabled" : "Subscription removed"
+      });
+      return;
+    }
+    const attemptNumber = delivery.attempts + 1;
+    await this.deliveryStore.update(delivery.id, {
+      status: "running",
+      attempts: attemptNumber,
+      nextAttemptAt: null
+    });
+    let result;
+    let nonRetriableError;
+    try {
+      const body = JSON.stringify({
+        id: delivery.id,
+        event: delivery.event,
+        timestamp: this.now().toISOString(),
+        attempt: attemptNumber,
+        payload: runtimeContext?.payload || {}
+      });
+      const signature = signPayload(body, sub.secret);
+      // Pre-flight URL check (every attempt — DNS could change, and the
+      // operator could have edited the URL after the delivery was
+      // enqueued). Throws WebhookSendError with retriable=false on
+      // policy violations so the outer logic stops retrying.
+      await assertOutboundUrlAllowed(sub.url, { allowPrivateNetworks: this.allowPrivateNetworks });
+      const headers = {
+        "content-type": "application/json",
+        "user-agent": "wordle-local-webhook/1",
+        "x-webhook-id": delivery.id,
+        "x-webhook-event": delivery.event,
+        "x-webhook-timestamp": this.now().toISOString(),
+        "x-webhook-attempt": String(attemptNumber),
+        "x-webhook-signature": signature
+      };
+      result = await sendWebhookRequest({
+        url: sub.url,
+        body,
+        headers,
+        timeoutMs: this.timeoutMs,
+        maxBodyBytes: this.maxBodyBytes,
+        fetchImpl: this.fetchImpl
+      });
+    } catch (err) {
+      if (err instanceof WebhookSendError) {
+        if (!err.retriable) {
+          nonRetriableError = err;
+        } else {
+          result = {
+            responseStatus: err.responseStatus,
+            responseSnippet: err.responseSnippet,
+            retryAfterMs: err.retryAfterMs,
+            errorMessage: err.message,
+            errorRetriable: true
+          };
+        }
+      } else {
+        // Unexpected — treat as non-retriable to avoid retry storms on
+        // programming errors. Logged loudly.
+        nonRetriableError = err;
+        this.logger.error?.(`[webhook] unexpected error for delivery ${deliveryId}:`, err);
+      }
+    }
+    if (nonRetriableError) {
+      await this.deliveryStore.update(delivery.id, {
+        status: "failed",
+        lastError: nonRetriableError.message
+      });
+      return;
+    }
+    if (result && result.responseStatus !== undefined) {
+      const classification = classifyHttpStatus(result.responseStatus);
+      if (classification.ok) {
+        await this.deliveryStore.update(delivery.id, {
+          status: "succeeded",
+          responseStatus: result.responseStatus,
+          responseSnippet: result.responseSnippet,
+          lastError: ""
+        });
+        return;
+      }
+      if (!classification.retriable || attemptNumber >= sub.maxAttempts) {
+        await this.deliveryStore.update(delivery.id, {
+          status: "failed",
+          responseStatus: result.responseStatus,
+          responseSnippet: result.responseSnippet,
+          lastError: `HTTP ${result.responseStatus}`
+        });
+        return;
+      }
+      const backoffMs = Math.min(
+        Math.max(result.retryAfterMs ?? 0, nextBackoffMs(attemptNumber, this.backoffSchedule)),
+        DEFAULT_RETRY_AFTER_CAP_MS
+      );
+      const nextAt = new Date(this.now().getTime() + backoffMs).toISOString();
+      await this.deliveryStore.update(delivery.id, {
+        status: "queued",
+        responseStatus: result.responseStatus,
+        responseSnippet: result.responseSnippet,
+        lastError: `HTTP ${result.responseStatus}; retrying`,
+        nextAttemptAt: nextAt
+      });
+      this.scheduleDelivery(delivery.id, backoffMs, runtimeContext);
+      return;
+    }
+    // Reached here: result has an errorMessage (network/timeout) — treat as retriable.
+    if (attemptNumber >= sub.maxAttempts) {
+      await this.deliveryStore.update(delivery.id, {
+        status: "failed",
+        lastError: result?.errorMessage || "Unknown error"
+      });
+      return;
+    }
+    const backoffMs = nextBackoffMs(attemptNumber, this.backoffSchedule);
+    const nextAt = new Date(this.now().getTime() + backoffMs).toISOString();
+    await this.deliveryStore.update(delivery.id, {
+      status: "queued",
+      lastError: result?.errorMessage || "Unknown error",
+      nextAttemptAt: nextAt
+    });
+    this.scheduleDelivery(delivery.id, backoffMs, runtimeContext);
+  }
+
+  async retryDelivery(deliveryId) {
+    const d = await this.deliveryStore.findById(deliveryId);
+    if (!d) return null;
+    if (d.status !== "failed") {
+      return d;
+    }
+    const sub = await this.subscriptionStore.findById(d.subscriptionId);
+    if (!sub) return d;
+    await this.deliveryStore.update(deliveryId, {
+      status: "queued",
+      lastError: ""
+    });
+    this.scheduleDelivery(deliveryId, 0, { subscription: sub });
+    return this.deliveryStore.findById(deliveryId);
+  }
+
+  async recoverOnBoot() {
+    if (!this.enabled) return 0;
+    const candidates = await this.deliveryStore.findRecoverable();
+    if (candidates.length === 0) return 0;
+    let recovered = 0;
+    for (const d of candidates) {
+      if (d.status === "running") {
+        // The previous process died mid-flight; requeue with a small
+        // backoff so a tight crash loop doesn't hammer the recipient.
+        await this.deliveryStore.update(d.id, {
+          status: "queued",
+          lastError: "Recovered after restart",
+          nextAttemptAt: new Date(this.now().getTime() + 1000).toISOString()
+        });
+        this.scheduleDelivery(d.id, 1000);
+        recovered += 1;
+      } else if (d.status === "queued") {
+        // Honor the persisted nextAttemptAt if any; otherwise schedule
+        // immediately.
+        let delay = 0;
+        if (d.nextAttemptAt) {
+          delay = Math.max(0, new Date(d.nextAttemptAt).getTime() - this.now().getTime());
+        }
+        this.scheduleDelivery(d.id, delay);
+        recovered += 1;
+      }
+    }
+    return recovered;
+  }
+
+  shutdown() {
+    this.shutdownRequested = true;
+    for (const t of this.scheduledTimers) clearTimeout(t);
+    this.scheduledTimers.clear();
+    this.readyQueue.length = 0;
+  }
+}
+
+module.exports = {
+  WebhookService,
+  WebhookSendError,
+  signPayload,
+  parseRetryAfterHeader,
+  classifyHttpStatus,
+  isPrivateIPv4,
+  isPrivateIPv6,
+  assertOutboundUrlAllowed,
+  nextBackoffMs,
+  DEFAULT_BACKOFF_MS
+};

--- a/lib/webhook-store.js
+++ b/lib/webhook-store.js
@@ -302,14 +302,16 @@ class WebhookStore {
   }
 
   async #commit(updater) {
+    // Pause callers BEFORE they enter the queue. Awaiting the lock
+    // INSIDE the queued run would deadlock the backup drain path,
+    // which holds the lock and then awaits this same `commitQueue`:
+    // a queued run that re-checks the lock would block forever waiting
+    // for the lock to release, while backup waits forever for the
+    // queue to drain. Mirrors ClassesStore.#enqueueWrite.
+    if (this.waitForDataMutationLock) {
+      await this.waitForDataMutationLock();
+    }
     const run = async () => {
-      // Pause if backup/restore is holding the lock. We do this AFTER
-      // loading current state but BEFORE writing — a delivery row
-      // committed while the archive is being copied would otherwise
-      // leave the persisted state in a torn state.
-      if (this.waitForDataMutationLock) {
-        await this.waitForDataMutationLock();
-      }
       const current = this.state ? cloneState(this.state) : await this.load();
       const next = updater(current);
       next.updatedAt = this.now().toISOString();

--- a/lib/webhook-store.js
+++ b/lib/webhook-store.js
@@ -1,0 +1,408 @@
+"use strict";
+
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const nodeCrypto = require("node:crypto");
+
+const STORE_VERSION = 1;
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+const URL_PATTERN = /^https?:\/\//i;
+const EVENT_PATTERN = /^[a-z][a-z0-9._-]{0,63}$/;
+const LABEL_MAX_LENGTH = 80;
+const URL_MAX_LENGTH = 2048;
+const SECRET_MIN_LENGTH = 16;
+const SECRET_MAX_LENGTH = 256;
+const MAX_ATTEMPTS_MIN = 1;
+const MAX_ATTEMPTS_MAX = 20;
+// Mirror admin-jobs-store.js — Windows surfaces these on rename-over-existing.
+const WINDOWS_RENAME_OVERWRITE_CODES = new Set(["EEXIST", "EPERM", "EACCES"]);
+
+class WebhookStoreError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = "WebhookStoreError";
+    this.code = code;
+    if (options.cause) this.cause = options.cause;
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function generateSubscriptionId() {
+  // 16 random bytes → 22-char base64url is plenty for a single-instance
+  // deployment and stays inside the schema's id pattern.
+  return nodeCrypto.randomBytes(16).toString("base64url");
+}
+
+function generateSecret() {
+  // 32 bytes hex (64 chars) — same convention the salvage branch used.
+  return nodeCrypto.randomBytes(32).toString("hex");
+}
+
+function normalizeUrl(raw) {
+  if (typeof raw !== "string") {
+    throw new WebhookStoreError("INVALID_URL", "URL must be a string.");
+  }
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.length > URL_MAX_LENGTH) {
+    throw new WebhookStoreError("INVALID_URL", "URL must be 1–2048 characters.");
+  }
+  if (!URL_PATTERN.test(trimmed)) {
+    throw new WebhookStoreError("INVALID_URL", "URL must use http(s) scheme.");
+  }
+  // Try parsing to flush early on malformed authority/path.
+  try {
+    new URL(trimmed);
+  } catch (_err) {
+    throw new WebhookStoreError("INVALID_URL", `Could not parse URL: ${trimmed}`);
+  }
+  return trimmed;
+}
+
+function normalizeEvents(raw) {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new WebhookStoreError("INVALID_EVENTS", "events must be a non-empty array.");
+  }
+  const out = [];
+  const seen = new Set();
+  for (const evt of raw) {
+    if (typeof evt !== "string" || !EVENT_PATTERN.test(evt)) {
+      throw new WebhookStoreError("INVALID_EVENTS", `Invalid event name: ${evt}`);
+    }
+    if (seen.has(evt)) continue;
+    seen.add(evt);
+    out.push(evt);
+  }
+  return out;
+}
+
+function normalizeMaxAttempts(raw, fallback) {
+  if (raw === undefined || raw === null) return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < MAX_ATTEMPTS_MIN || n > MAX_ATTEMPTS_MAX) {
+    throw new WebhookStoreError(
+      "INVALID_MAX_ATTEMPTS",
+      `maxAttempts must be an integer between ${MAX_ATTEMPTS_MIN} and ${MAX_ATTEMPTS_MAX}.`
+    );
+  }
+  return n;
+}
+
+function normalizeLabel(raw) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  if (typeof raw !== "string" || raw.length > LABEL_MAX_LENGTH) {
+    throw new WebhookStoreError(
+      "INVALID_LABEL",
+      `Label must be a string up to ${LABEL_MAX_LENGTH} chars.`
+    );
+  }
+  return raw;
+}
+
+function normalizeSubscription(raw) {
+  if (!isPlainObject(raw)) {
+    throw new WebhookStoreError("INVALID_SUBSCRIPTION", "Subscription must be an object.");
+  }
+  if (!ID_PATTERN.test(raw.id || "")) {
+    throw new WebhookStoreError("INVALID_SUBSCRIPTION", `Invalid subscription id: ${raw.id}`);
+  }
+  if (typeof raw.secret !== "string" || raw.secret.length < SECRET_MIN_LENGTH || raw.secret.length > SECRET_MAX_LENGTH) {
+    throw new WebhookStoreError("INVALID_SUBSCRIPTION", "secret must be a hex string 16–256 chars long.");
+  }
+  if (typeof raw.enabled !== "boolean") {
+    throw new WebhookStoreError("INVALID_SUBSCRIPTION", "enabled must be a boolean.");
+  }
+  if (typeof raw.createdAt !== "string" || !raw.createdAt) {
+    throw new WebhookStoreError("INVALID_SUBSCRIPTION", "createdAt is required.");
+  }
+  if (typeof raw.updatedAt !== "string" || !raw.updatedAt) {
+    throw new WebhookStoreError("INVALID_SUBSCRIPTION", "updatedAt is required.");
+  }
+  const out = {
+    id: raw.id,
+    url: normalizeUrl(raw.url),
+    events: normalizeEvents(raw.events),
+    enabled: raw.enabled,
+    secret: raw.secret,
+    maxAttempts: normalizeMaxAttempts(raw.maxAttempts, 5),
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt
+  };
+  const label = normalizeLabel(raw.label);
+  if (label !== undefined) out.label = label;
+  return out;
+}
+
+function buildDefaultStore() {
+  return {
+    version: STORE_VERSION,
+    updatedAt: new Date().toISOString(),
+    subscriptions: []
+  };
+}
+
+function normalizeStore(raw) {
+  if (!isPlainObject(raw)) {
+    throw new WebhookStoreError("INVALID_STORE", "Store must be an object.");
+  }
+  if (raw.version !== STORE_VERSION) {
+    throw new WebhookStoreError(
+      "VERSION_UNSUPPORTED",
+      `Webhook store version ${raw.version} is not supported (expected ${STORE_VERSION}).`
+    );
+  }
+  if (typeof raw.updatedAt !== "string") {
+    throw new WebhookStoreError("INVALID_STORE", "updatedAt is required.");
+  }
+  if (!Array.isArray(raw.subscriptions)) {
+    throw new WebhookStoreError("INVALID_STORE", "subscriptions must be an array.");
+  }
+  const seen = new Set();
+  const subscriptions = [];
+  for (const sub of raw.subscriptions) {
+    const normalized = normalizeSubscription(sub);
+    if (seen.has(normalized.id)) continue; // duplicate-id tolerance on load
+    seen.add(normalized.id);
+    subscriptions.push(normalized);
+  }
+  subscriptions.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+  return {
+    version: STORE_VERSION,
+    updatedAt: raw.updatedAt,
+    subscriptions
+  };
+}
+
+async function writeJsonAtomic(filePath, payload) {
+  const tempPath = `${filePath}.${process.pid}.${nodeCrypto.randomUUID()}.tmp`;
+  try {
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+    await fsp.writeFile(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    try {
+      await fsp.rename(tempPath, filePath);
+    } catch (renameErr) {
+      if (!renameErr || !WINDOWS_RENAME_OVERWRITE_CODES.has(renameErr.code)) throw renameErr;
+      await fsp.rm(filePath, { force: true });
+      await fsp.rename(tempPath, filePath);
+    }
+  } catch (err) {
+    try { await fsp.rm(tempPath, { force: true }); } catch (_e) { /* best-effort */ }
+    throw new WebhookStoreError(
+      "STORE_WRITE_FAILED",
+      `Failed to persist webhook store to ${filePath}: ${err.message}`,
+      { cause: err }
+    );
+  }
+}
+
+class WebhookStore {
+  constructor(options = {}) {
+    if (!options.filePath) {
+      throw new WebhookStoreError("INVALID_REQUEST", "filePath is required.");
+    }
+    this.filePath = options.filePath;
+    this.logger = options.logger || console;
+    this.now = typeof options.now === "function" ? options.now : () => new Date();
+    this.defaultMaxAttempts = Number.isInteger(options.defaultMaxAttempts) && options.defaultMaxAttempts > 0
+      ? options.defaultMaxAttempts
+      : 5;
+    this.state = null;
+    this.loadPromise = null;
+    this.commitQueue = Promise.resolve();
+  }
+
+  async load() {
+    if (this.state) return cloneState(this.state);
+    if (!this.loadPromise) {
+      this.loadPromise = this.#loadInternal().catch((err) => {
+        this.loadPromise = null;
+        throw err;
+      });
+    }
+    await this.loadPromise;
+    return cloneState(this.state);
+  }
+
+  async #loadInternal() {
+    let raw;
+    try {
+      raw = await fsp.readFile(this.filePath, "utf8");
+    } catch (err) {
+      if (err && err.code === "ENOENT") {
+        const fresh = buildDefaultStore();
+        fresh.updatedAt = this.now().toISOString();
+        await writeJsonAtomic(this.filePath, fresh);
+        this.state = fresh;
+        return;
+      }
+      throw new WebhookStoreError(
+        "STORE_READ_FAILED",
+        `Failed to read webhook store from ${this.filePath}: ${err.message}`,
+        { cause: err }
+      );
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new WebhookStoreError(
+        "STORE_PARSE_FAILED",
+        `Webhook store ${this.filePath} is not valid JSON: ${err.message}`,
+        { cause: err }
+      );
+    }
+    this.state = normalizeStore(parsed);
+  }
+
+  async getSnapshot() {
+    return this.load();
+  }
+
+  async reload() {
+    await this.commitQueue.catch(() => {});
+    if (this.loadPromise) await this.loadPromise.catch(() => {});
+    this.state = null;
+    this.loadPromise = null;
+    return this.load();
+  }
+
+  async #commit(updater) {
+    const run = async () => {
+      const current = this.state ? cloneState(this.state) : await this.load();
+      const next = updater(current);
+      next.updatedAt = this.now().toISOString();
+      const finalState = normalizeStore(next);
+      await writeJsonAtomic(this.filePath, finalState);
+      this.state = finalState;
+      return cloneState(this.state);
+    };
+    const next = this.commitQueue.then(run, run);
+    this.commitQueue = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  async create({ url, events, enabled = true, maxAttempts, label } = {}) {
+    const normalizedUrl = normalizeUrl(url);
+    const normalizedEvents = normalizeEvents(events);
+    const normalizedMaxAttempts = normalizeMaxAttempts(maxAttempts, this.defaultMaxAttempts);
+    const normalizedLabel = normalizeLabel(label);
+    if (typeof enabled !== "boolean") {
+      throw new WebhookStoreError("INVALID_REQUEST", "enabled must be boolean.");
+    }
+    const id = generateSubscriptionId();
+    const secret = generateSecret();
+    const nowIso = this.now().toISOString();
+    const sub = {
+      id,
+      url: normalizedUrl,
+      events: normalizedEvents,
+      enabled,
+      secret,
+      maxAttempts: normalizedMaxAttempts,
+      createdAt: nowIso,
+      updatedAt: nowIso
+    };
+    if (normalizedLabel !== undefined) sub.label = normalizedLabel;
+    await this.#commit((state) => {
+      state.subscriptions.push(sub);
+      return state;
+    });
+    return cloneState(sub);
+  }
+
+  async update(id, patch) {
+    if (!ID_PATTERN.test(String(id || ""))) {
+      throw new WebhookStoreError("INVALID_REQUEST", "Invalid subscription id.");
+    }
+    if (!isPlainObject(patch)) {
+      throw new WebhookStoreError("INVALID_REQUEST", "patch must be an object.");
+    }
+    let updated;
+    await this.#commit((state) => {
+      const idx = state.subscriptions.findIndex((s) => s.id === id);
+      if (idx === -1) {
+        throw new WebhookStoreError("SUBSCRIPTION_NOT_FOUND", `No subscription with id ${id}.`);
+      }
+      const merged = { ...state.subscriptions[idx] };
+      if (patch.url !== undefined) merged.url = normalizeUrl(patch.url);
+      if (patch.events !== undefined) merged.events = normalizeEvents(patch.events);
+      if (patch.enabled !== undefined) {
+        if (typeof patch.enabled !== "boolean") {
+          throw new WebhookStoreError("INVALID_REQUEST", "enabled must be boolean.");
+        }
+        merged.enabled = patch.enabled;
+      }
+      if (patch.maxAttempts !== undefined) {
+        merged.maxAttempts = normalizeMaxAttempts(patch.maxAttempts, this.defaultMaxAttempts);
+      }
+      if (patch.label !== undefined) {
+        const lbl = normalizeLabel(patch.label);
+        if (lbl === undefined) delete merged.label;
+        else merged.label = lbl;
+      }
+      if (patch.rotateSecret === true) {
+        merged.secret = generateSecret();
+      }
+      merged.updatedAt = this.now().toISOString();
+      state.subscriptions.splice(idx, 1, merged);
+      updated = merged;
+      return state;
+    });
+    return cloneState(updated);
+  }
+
+  async remove(id) {
+    if (!ID_PATTERN.test(String(id || ""))) {
+      throw new WebhookStoreError("INVALID_REQUEST", "Invalid subscription id.");
+    }
+    let removed = null;
+    await this.#commit((state) => {
+      const idx = state.subscriptions.findIndex((s) => s.id === id);
+      if (idx === -1) {
+        throw new WebhookStoreError("SUBSCRIPTION_NOT_FOUND", `No subscription with id ${id}.`);
+      }
+      removed = state.subscriptions[idx];
+      state.subscriptions.splice(idx, 1);
+      return state;
+    });
+    return cloneState(removed);
+  }
+
+  async findById(id) {
+    const snap = await this.load();
+    return snap.subscriptions.find((s) => s.id === id) || null;
+  }
+
+  async findEnabledForEvent(eventName) {
+    const snap = await this.load();
+    return snap.subscriptions.filter((s) => s.enabled && s.events.includes(eventName));
+  }
+}
+
+function cloneState(state) {
+  return JSON.parse(JSON.stringify(state));
+}
+
+// Strip the secret from a subscription for response payloads. Used by the
+// listing endpoint and any update path that doesn't return the secret.
+function redactSecret(sub) {
+  if (!sub) return sub;
+  const out = cloneState(sub);
+  delete out.secret;
+  return out;
+}
+
+module.exports = {
+  WebhookStore,
+  WebhookStoreError,
+  generateSubscriptionId,
+  generateSecret,
+  redactSecret,
+  normalizeSubscription,
+  normalizeStore,
+  STORE_VERSION,
+  ID_PATTERN,
+  EVENT_PATTERN
+};

--- a/lib/webhook-store.js
+++ b/lib/webhook-store.js
@@ -8,6 +8,13 @@ const STORE_VERSION = 1;
 const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const URL_PATTERN = /^https?:\/\//i;
 const EVENT_PATTERN = /^[a-z][a-z0-9._-]{0,63}$/;
+// Lowercase hex; matches generateSecret() output and the
+// HMAC-SHA-256 signing convention documented in docs/webhooks.md.
+// Enforcing the pattern at normalize time means a hand-edited
+// data/webhooks.json that contains a non-hex secret fails to load
+// instead of silently returning a delivery whose signature can't be
+// recomputed by the recipient.
+const SECRET_PATTERN = /^[a-f0-9]+$/;
 const LABEL_MAX_LENGTH = 80;
 const URL_MAX_LENGTH = 2048;
 const SECRET_MIN_LENGTH = 16;
@@ -52,11 +59,22 @@ function normalizeUrl(raw) {
   if (!URL_PATTERN.test(trimmed)) {
     throw new WebhookStoreError("INVALID_URL", "URL must use http(s) scheme.");
   }
-  // Try parsing to flush early on malformed authority/path.
+  // Try parsing to flush early on malformed authority/path. Also
+  // reject embedded credentials — `https://user:pass@host/...` parses
+  // cleanly but turns admin-pasted secrets into stored, listed,
+  // backed-up data outside the HMAC-secret flow. The recipient's auth
+  // belongs in `Authorization` headers it controls, not the URL.
+  let parsed;
   try {
-    new URL(trimmed);
+    parsed = new URL(trimmed);
   } catch (_err) {
     throw new WebhookStoreError("INVALID_URL", `Could not parse URL: ${trimmed}`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new WebhookStoreError(
+      "INVALID_URL",
+      "URL must not include embedded user:password credentials."
+    );
   }
   return trimmed;
 }
@@ -108,8 +126,16 @@ function normalizeSubscription(raw) {
   if (!ID_PATTERN.test(raw.id || "")) {
     throw new WebhookStoreError("INVALID_SUBSCRIPTION", `Invalid subscription id: ${raw.id}`);
   }
-  if (typeof raw.secret !== "string" || raw.secret.length < SECRET_MIN_LENGTH || raw.secret.length > SECRET_MAX_LENGTH) {
-    throw new WebhookStoreError("INVALID_SUBSCRIPTION", "secret must be a hex string 16–256 chars long.");
+  if (
+    typeof raw.secret !== "string"
+    || raw.secret.length < SECRET_MIN_LENGTH
+    || raw.secret.length > SECRET_MAX_LENGTH
+    || !SECRET_PATTERN.test(raw.secret)
+  ) {
+    throw new WebhookStoreError(
+      "INVALID_SUBSCRIPTION",
+      "secret must be a lowercase-hex string 16–256 chars long."
+    );
   }
   if (typeof raw.enabled !== "boolean") {
     throw new WebhookStoreError("INVALID_SUBSCRIPTION", "enabled must be a boolean.");
@@ -208,6 +234,13 @@ class WebhookStore {
     this.defaultMaxAttempts = Number.isInteger(options.defaultMaxAttempts) && options.defaultMaxAttempts > 0
       ? options.defaultMaxAttempts
       : 5;
+    // Pause writes while a backup/restore is in flight so a delivery
+    // landing mid-archive doesn't tear the snapshot, and a write that
+    // already passed the /api gate can't land on top of a restored
+    // file. Mirrors the LeaderboardStore/ClassesStore wiring.
+    this.waitForDataMutationLock = typeof options.waitForDataMutationLock === "function"
+      ? options.waitForDataMutationLock
+      : null;
     this.state = null;
     this.loadPromise = null;
     this.commitQueue = Promise.resolve();
@@ -270,6 +303,13 @@ class WebhookStore {
 
   async #commit(updater) {
     const run = async () => {
+      // Pause if backup/restore is holding the lock. We do this AFTER
+      // loading current state but BEFORE writing — a delivery row
+      // committed while the archive is being copied would otherwise
+      // leave the persisted state in a torn state.
+      if (this.waitForDataMutationLock) {
+        await this.waitForDataMutationLock();
+      }
       const current = this.state ? cloneState(this.state) : await this.load();
       const next = updater(current);
       next.updatedAt = this.now().toISOString();

--- a/lib/webhook-store.js
+++ b/lib/webhook-store.js
@@ -59,11 +59,15 @@ function normalizeUrl(raw) {
   if (!URL_PATTERN.test(trimmed)) {
     throw new WebhookStoreError("INVALID_URL", "URL must use http(s) scheme.");
   }
-  // Try parsing to flush early on malformed authority/path. Also
-  // reject embedded credentials — `https://user:pass@host/...` parses
-  // cleanly but turns admin-pasted secrets into stored, listed,
-  // backed-up data outside the HMAC-secret flow. The recipient's auth
-  // belongs in `Authorization` headers it controls, not the URL.
+  // Parse + canonicalize. The case-insensitive URL_PATTERN above
+  // accepts `HTTPS://example.com`, but the persisted-file schema
+  // (data/webhooks.schema.json) uses a case-sensitive `^https?://`
+  // pattern, so we'd write an UPPERCASE-scheme URL that subsequently
+  // failed restore-time schema validation. URL serialization
+  // lowercases the scheme + host for us.
+  // Also reject embedded credentials — `https://user:pass@host/...`
+  // parses cleanly but persists admin-pasted secrets into listings
+  // and backups outside the HMAC-secret flow.
   let parsed;
   try {
     parsed = new URL(trimmed);
@@ -76,7 +80,11 @@ function normalizeUrl(raw) {
       "URL must not include embedded user:password credentials."
     );
   }
-  return trimmed;
+  const canonical = parsed.toString();
+  if (canonical.length > URL_MAX_LENGTH) {
+    throw new WebhookStoreError("INVALID_URL", "URL must be 1–2048 characters.");
+  }
+  return canonical;
 }
 
 function normalizeEvents(raw) {
@@ -234,12 +242,16 @@ class WebhookStore {
     this.defaultMaxAttempts = Number.isInteger(options.defaultMaxAttempts) && options.defaultMaxAttempts > 0
       ? options.defaultMaxAttempts
       : 5;
-    // Pause writes while a backup/restore is in flight so a delivery
-    // landing mid-archive doesn't tear the snapshot, and a write that
-    // already passed the /api gate can't land on top of a restored
-    // file. Mirrors the LeaderboardStore/ClassesStore wiring.
-    this.waitForDataMutationLock = typeof options.waitForDataMutationLock === "function"
-      ? options.waitForDataMutationLock
+    // Atomic claim that BOTH waits for the data-mutation lock AND
+    // increments the direct-write counter so backup/restore's
+    // busy-check sees us. Without this, the previous pre-queue
+    // `await waitForDataMutationLock()` had a TOCTOU window: gate
+    // observed lock clear → backup set lock and started reading
+    // archive → this commit enqueued and renamed the JSON file
+    // underneath the read. The slot must be released after the
+    // write so the counter returns to zero.
+    this.claimDirectDataWriteSlot = typeof options.claimDirectDataWriteSlot === "function"
+      ? options.claimDirectDataWriteSlot
       : null;
     this.state = null;
     this.loadPromise = null;
@@ -302,23 +314,28 @@ class WebhookStore {
   }
 
   async #commit(updater) {
-    // Pause callers BEFORE they enter the queue. Awaiting the lock
-    // INSIDE the queued run would deadlock the backup drain path,
-    // which holds the lock and then awaits this same `commitQueue`:
-    // a queued run that re-checks the lock would block forever waiting
-    // for the lock to release, while backup waits forever for the
-    // queue to drain. Mirrors ClassesStore.#enqueueWrite.
-    if (this.waitForDataMutationLock) {
-      await this.waitForDataMutationLock();
+    // Atomically wait for the lock AND claim a direct-write slot.
+    // The slot must be claimed BEFORE we enqueue (so backup drain
+    // finds the queue empty and doesn't deadlock) AND released
+    // AFTER the write (so backup's busy-check observes we're still
+    // in flight). The slot is released in the `run`'s finally so
+    // we hold it for the smallest possible window.
+    let releaseSlot = null;
+    if (this.claimDirectDataWriteSlot) {
+      releaseSlot = await this.claimDirectDataWriteSlot();
     }
     const run = async () => {
-      const current = this.state ? cloneState(this.state) : await this.load();
-      const next = updater(current);
-      next.updatedAt = this.now().toISOString();
-      const finalState = normalizeStore(next);
-      await writeJsonAtomic(this.filePath, finalState);
-      this.state = finalState;
-      return cloneState(this.state);
+      try {
+        const current = this.state ? cloneState(this.state) : await this.load();
+        const next = updater(current);
+        next.updatedAt = this.now().toISOString();
+        const finalState = normalizeStore(next);
+        await writeJsonAtomic(this.filePath, finalState);
+        this.state = finalState;
+        return cloneState(this.state);
+      } finally {
+        if (releaseSlot) releaseSlot();
+      }
     };
     const next = this.commitQueue.then(run, run);
     this.commitQueue = next.then(() => undefined, () => undefined);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express-rate-limit": "^8.2.1",
         "helmet": "^8.1.0",
         "nspell": "^2.1.5",
+        "undici": "^7.25.0",
         "yauzl": "^3.3.0"
       },
       "devDependencies": {
@@ -6853,6 +6854,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "express-rate-limit": "^8.2.1",
     "helmet": "^8.1.0",
     "nspell": "^2.1.5",
+    "undici": "^7.25.0",
     "yauzl": "^3.3.0"
   },
   "devDependencies": {

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -159,7 +159,15 @@ const state = {
   // handler can route to PUT /entries/:date/:lang instead of
   // POST /entries (which would leave the original row behind if the
   // operator changed the date or lang of the entry they were editing).
-  scheduleEditingKey: null
+  scheduleEditingKey: null,
+  webhooksEnabled: true,
+  webhooksLoading: false,
+  webhooksRequestId: 0,
+  webhookSubscriptions: [],
+  webhookDefaultMaxAttempts: 5,
+  webhookDeliveriesLoading: false,
+  webhookDeliveriesSubscriptionId: null,
+  webhookDeliveries: []
 };
 
 let jobsRefreshTimer = null;
@@ -329,6 +337,9 @@ function activateTab(nextTab, focus = false) {
   }
   if (tabId === "schedule" && state.unlocked && !state.scheduleLoading) {
     loadSchedule({ announce: true }).catch(() => {});
+  }
+  if (tabId === "webhooks" && state.unlocked && !state.webhooksLoading) {
+    loadWebhooks({ announce: true }).catch(() => {});
   }
 }
 
@@ -2004,6 +2015,9 @@ async function unlockWorkspace() {
     if (state.unlocked && state.activeTab === "schedule") {
       loadSchedule({ announce: true }).catch(() => {});
     }
+    if (state.unlocked && state.activeTab === "webhooks") {
+      loadWebhooks({ announce: true }).catch(() => {});
+    }
   } finally {
     state.loading = false;
     renderWorkspace();
@@ -2341,6 +2355,11 @@ lockSessionBtnEl.addEventListener("click", () => {
   state.scheduleRequestId += 1;
   state.scheduleLoading = false;
   state.schedule = null;
+  state.webhooksRequestId += 1;
+  state.webhooksLoading = false;
+  state.webhookSubscriptions = [];
+  state.webhookDeliveries = [];
+  state.webhookDeliveriesSubscriptionId = null;
   destroyAllAnalyticsCharts();
   if (analyticsCardsEl) {
     analyticsCardsEl.querySelectorAll('[data-metric]').forEach((el) => {
@@ -3319,6 +3338,337 @@ if (scheduleReconcileBtnEl) {
     const detail = r?.action ? `(${r.action}, ${r.todayLocal || "unknown date"})` : "";
     setStatus(scheduleStatusEl, `Reconcile complete ${detail}`, "admin-status-ok");
     loadSchedule({ announce: false }).catch(() => {});
+  });
+}
+
+// ── Webhooks tab ───────────────────────────────────────────────────────
+const webhooksDisabledBannerEl = document.getElementById("webhooksDisabledBanner");
+const webhooksStatusEl = document.getElementById("webhooksStatus");
+const webhookCreateFormEl = document.getElementById("webhookCreateForm");
+const webhookUrlInputEl = document.getElementById("webhookUrlInput");
+const webhookEventsInputEl = document.getElementById("webhookEventsInput");
+const webhookLabelInputEl = document.getElementById("webhookLabelInput");
+const webhookMaxAttemptsInputEl = document.getElementById("webhookMaxAttemptsInput");
+const webhookEnabledInputEl = document.getElementById("webhookEnabledInput");
+const webhookCreatedSecretBoxEl = document.getElementById("webhookCreatedSecretBox");
+const webhookCreatedSecretValueEl = document.getElementById("webhookCreatedSecretValue");
+const webhooksTableBody = document.querySelector("#webhooksTable tbody");
+const webhookDeliveriesSubscriptionEl = document.getElementById("webhookDeliveriesSubscription");
+const webhookDeliveriesRefreshBtnEl = document.getElementById("webhookDeliveriesRefreshBtn");
+const webhookDeliveriesTableBody = document.querySelector("#webhookDeliveriesTable tbody");
+
+function parseEventsCsv(input) {
+  return String(input || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+async function loadWebhooks(options = {}) {
+  if (!state.unlocked) return;
+  if (state.webhooksLoading) return;
+  state.webhooksLoading = true;
+  const requestId = ++state.webhooksRequestId;
+  if (options.announce !== false) setStatus(webhooksStatusEl, "Loading webhooks…");
+  try {
+    const payload = await requestAdminJson("/api/admin/webhooks");
+    if (requestId !== state.webhooksRequestId) return;
+    state.webhooksEnabled = payload.enabled !== false;
+    state.webhookSubscriptions = Array.isArray(payload.subscriptions) ? payload.subscriptions : [];
+    state.webhookDefaultMaxAttempts = Number.isInteger(payload.defaultMaxAttempts)
+      ? payload.defaultMaxAttempts
+      : 5;
+    if (webhookMaxAttemptsInputEl && !webhookMaxAttemptsInputEl.value) {
+      webhookMaxAttemptsInputEl.placeholder = String(state.webhookDefaultMaxAttempts);
+    }
+    if (webhooksDisabledBannerEl) {
+      webhooksDisabledBannerEl.hidden = state.webhooksEnabled;
+    }
+    renderWebhooks();
+    if (options.announce !== false) setStatus(webhooksStatusEl, "Webhooks loaded.", "admin-status-ok");
+  } catch (err) {
+    if (requestId !== state.webhooksRequestId) return;
+    setStatus(webhooksStatusEl, `Load failed: ${err.message}`, "admin-status-missing");
+  } finally {
+    if (requestId === state.webhooksRequestId) {
+      state.webhooksLoading = false;
+    }
+  }
+}
+
+function renderWebhooks() {
+  if (!webhooksTableBody) return;
+  webhooksTableBody.innerHTML = "";
+  if (!state.webhookSubscriptions.length) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 7;
+    cell.textContent = "No webhook subscriptions configured yet.";
+    row.appendChild(cell);
+    webhooksTableBody.appendChild(row);
+  } else {
+    const fragment = document.createDocumentFragment();
+    for (const sub of state.webhookSubscriptions) {
+      const row = document.createElement("tr");
+      row.appendChild(buildCell(sub.label || "—"));
+      row.appendChild(buildCell(sub.url));
+      row.appendChild(buildCell((sub.events || []).join(", ")));
+      row.appendChild(buildCell(sub.enabled ? "yes" : "no"));
+      row.appendChild(buildCell(String(sub.maxAttempts ?? "—")));
+      row.appendChild(buildCell(formatTimestamp(sub.createdAt)));
+      const actions = document.createElement("td");
+      const toggleBtn = document.createElement("button");
+      toggleBtn.type = "button";
+      toggleBtn.className = "ghost";
+      toggleBtn.textContent = sub.enabled ? "Disable" : "Enable";
+      toggleBtn.addEventListener("click", () => toggleWebhook(sub.id, !sub.enabled));
+      actions.appendChild(toggleBtn);
+      const testBtn = document.createElement("button");
+      testBtn.type = "button";
+      testBtn.className = "ghost";
+      testBtn.textContent = "Test";
+      testBtn.addEventListener("click", () => sendWebhookTest(sub.id));
+      actions.appendChild(testBtn);
+      const rotateBtn = document.createElement("button");
+      rotateBtn.type = "button";
+      rotateBtn.className = "ghost";
+      rotateBtn.textContent = "Rotate secret";
+      rotateBtn.addEventListener("click", () => rotateWebhookSecret(sub.id));
+      actions.appendChild(rotateBtn);
+      const delBtn = document.createElement("button");
+      delBtn.type = "button";
+      delBtn.className = "ghost";
+      delBtn.textContent = "Delete";
+      delBtn.addEventListener("click", () => deleteWebhook(sub.id, sub.label || sub.url));
+      actions.appendChild(delBtn);
+      row.appendChild(actions);
+      fragment.appendChild(row);
+    }
+    webhooksTableBody.appendChild(fragment);
+  }
+  // Re-populate the deliveries subscription <select>.
+  if (webhookDeliveriesSubscriptionEl) {
+    const previousValue = state.webhookDeliveriesSubscriptionId
+      || webhookDeliveriesSubscriptionEl.value;
+    webhookDeliveriesSubscriptionEl.innerHTML = "";
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "— select subscription —";
+    webhookDeliveriesSubscriptionEl.appendChild(placeholder);
+    for (const sub of state.webhookSubscriptions) {
+      const opt = document.createElement("option");
+      opt.value = sub.id;
+      opt.textContent = sub.label ? `${sub.label} (${sub.url})` : sub.url;
+      webhookDeliveriesSubscriptionEl.appendChild(opt);
+    }
+    if (previousValue && state.webhookSubscriptions.some((s) => s.id === previousValue)) {
+      webhookDeliveriesSubscriptionEl.value = previousValue;
+    }
+  }
+}
+
+function buildCell(text) {
+  const td = document.createElement("td");
+  td.textContent = text === null || text === undefined ? "" : String(text);
+  return td;
+}
+
+async function toggleWebhook(id, nextEnabled) {
+  if (!state.unlocked) return;
+  try {
+    await requestAdminJson(`/api/admin/webhooks/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: nextEnabled })
+    });
+  } catch (err) {
+    setStatus(webhooksStatusEl, `Toggle failed: ${err.message}`, "admin-status-missing");
+    return;
+  }
+  setStatus(
+    webhooksStatusEl,
+    `Subscription ${nextEnabled ? "enabled" : "disabled"}.`,
+    "admin-status-ok"
+  );
+  loadWebhooks({ announce: false }).catch(() => {});
+}
+
+async function sendWebhookTest(id) {
+  if (!state.unlocked) return;
+  try {
+    const payload = await requestAdminJson(`/api/admin/webhooks/${encodeURIComponent(id)}/test`, {
+      method: "POST"
+    });
+    setStatus(
+      webhooksStatusEl,
+      `Test event queued (delivery ${payload.deliveryId}).`,
+      "admin-status-ok"
+    );
+  } catch (err) {
+    setStatus(webhooksStatusEl, `Test failed: ${err.message}`, "admin-status-missing");
+  }
+}
+
+async function rotateWebhookSecret(id) {
+  if (!state.unlocked) return;
+  if (!window.confirm("Rotate this subscription's secret? The old secret will stop being valid immediately.")) return;
+  try {
+    const payload = await requestAdminJson(`/api/admin/webhooks/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rotateSecret: true })
+    });
+    if (webhookCreatedSecretBoxEl && webhookCreatedSecretValueEl && payload?.subscription?.secret) {
+      webhookCreatedSecretValueEl.textContent = payload.subscription.secret;
+      webhookCreatedSecretBoxEl.hidden = false;
+    }
+    setStatus(webhooksStatusEl, "Secret rotated. Copy it now.", "admin-status-ok");
+    loadWebhooks({ announce: false }).catch(() => {});
+  } catch (err) {
+    setStatus(webhooksStatusEl, `Rotate failed: ${err.message}`, "admin-status-missing");
+  }
+}
+
+async function deleteWebhook(id, label) {
+  if (!state.unlocked) return;
+  if (!window.confirm(`Delete subscription "${label}"? Delivery history will also be removed.`)) return;
+  try {
+    await requestAdminJson(`/api/admin/webhooks/${encodeURIComponent(id)}`, { method: "DELETE" });
+  } catch (err) {
+    setStatus(webhooksStatusEl, `Delete failed: ${err.message}`, "admin-status-missing");
+    return;
+  }
+  setStatus(webhooksStatusEl, "Subscription deleted.", "admin-status-ok");
+  loadWebhooks({ announce: false }).catch(() => {});
+}
+
+if (webhookCreateFormEl) {
+  webhookCreateFormEl.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!state.unlocked) return;
+    const url = String(webhookUrlInputEl?.value || "").trim();
+    const events = parseEventsCsv(webhookEventsInputEl?.value);
+    const label = String(webhookLabelInputEl?.value || "").trim() || undefined;
+    const maxAttemptsRaw = String(webhookMaxAttemptsInputEl?.value || "").trim();
+    const maxAttempts = maxAttemptsRaw ? Number(maxAttemptsRaw) : undefined;
+    const enabled = Boolean(webhookEnabledInputEl?.checked);
+    if (!url) {
+      setStatus(webhooksStatusEl, "URL is required.", "admin-status-missing");
+      return;
+    }
+    if (events.length === 0) {
+      setStatus(webhooksStatusEl, "At least one event is required.", "admin-status-missing");
+      return;
+    }
+    let payload;
+    try {
+      payload = await requestAdminJson("/api/admin/webhooks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url, events, label, maxAttempts, enabled })
+      });
+    } catch (err) {
+      setStatus(webhooksStatusEl, `Create failed: ${err.message}`, "admin-status-missing");
+      return;
+    }
+    if (webhookCreatedSecretBoxEl && webhookCreatedSecretValueEl && payload?.subscription?.secret) {
+      webhookCreatedSecretValueEl.textContent = payload.subscription.secret;
+      webhookCreatedSecretBoxEl.hidden = false;
+    }
+    setStatus(webhooksStatusEl, "Subscription created. Copy the secret now.", "admin-status-ok");
+    webhookCreateFormEl.reset();
+    if (webhookEnabledInputEl) webhookEnabledInputEl.checked = true;
+    loadWebhooks({ announce: false }).catch(() => {});
+  });
+}
+
+async function loadWebhookDeliveries(subscriptionId) {
+  if (!state.unlocked || !subscriptionId) {
+    if (webhookDeliveriesTableBody) webhookDeliveriesTableBody.innerHTML = "";
+    state.webhookDeliveries = [];
+    return;
+  }
+  try {
+    const payload = await requestAdminJson(
+      `/api/admin/webhooks/${encodeURIComponent(subscriptionId)}/deliveries?limit=50`
+    );
+    state.webhookDeliveries = Array.isArray(payload.deliveries) ? payload.deliveries : [];
+    state.webhookDeliveriesSubscriptionId = subscriptionId;
+    renderWebhookDeliveries();
+  } catch (err) {
+    setStatus(webhooksStatusEl, `Deliveries fetch failed: ${err.message}`, "admin-status-missing");
+  }
+}
+
+function renderWebhookDeliveries() {
+  if (!webhookDeliveriesTableBody) return;
+  webhookDeliveriesTableBody.innerHTML = "";
+  if (!state.webhookDeliveries.length) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 7;
+    cell.textContent = "No deliveries yet.";
+    row.appendChild(cell);
+    webhookDeliveriesTableBody.appendChild(row);
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  for (const d of state.webhookDeliveries) {
+    const row = document.createElement("tr");
+    row.appendChild(buildCell(formatTimestamp(d.createdAt)));
+    row.appendChild(buildCell(d.event));
+    row.appendChild(buildCell(d.status));
+    row.appendChild(buildCell(String(d.attempts ?? 0)));
+    row.appendChild(buildCell(d.responseStatus !== null && d.responseStatus !== undefined ? String(d.responseStatus) : "—"));
+    row.appendChild(buildCell(d.lastError || ""));
+    const actions = document.createElement("td");
+    if (d.status === "failed") {
+      const retryBtn = document.createElement("button");
+      retryBtn.type = "button";
+      retryBtn.className = "ghost";
+      retryBtn.textContent = "Retry";
+      retryBtn.addEventListener("click", () => retryWebhookDelivery(d.subscriptionId, d.id));
+      actions.appendChild(retryBtn);
+    }
+    row.appendChild(actions);
+    fragment.appendChild(row);
+  }
+  webhookDeliveriesTableBody.appendChild(fragment);
+}
+
+async function retryWebhookDelivery(subscriptionId, deliveryId) {
+  if (!state.unlocked) return;
+  try {
+    await requestAdminJson(
+      `/api/admin/webhooks/${encodeURIComponent(subscriptionId)}/deliveries/${encodeURIComponent(deliveryId)}/retry`,
+      { method: "POST" }
+    );
+  } catch (err) {
+    setStatus(webhooksStatusEl, `Retry failed: ${err.message}`, "admin-status-missing");
+    return;
+  }
+  setStatus(webhooksStatusEl, "Delivery requeued.", "admin-status-ok");
+  loadWebhookDeliveries(subscriptionId).catch(() => {});
+}
+
+if (webhookDeliveriesSubscriptionEl) {
+  webhookDeliveriesSubscriptionEl.addEventListener("change", () => {
+    const id = webhookDeliveriesSubscriptionEl.value || null;
+    state.webhookDeliveriesSubscriptionId = id;
+    if (id) {
+      loadWebhookDeliveries(id).catch(() => {});
+    } else {
+      state.webhookDeliveries = [];
+      renderWebhookDeliveries();
+    }
+  });
+}
+
+if (webhookDeliveriesRefreshBtnEl) {
+  webhookDeliveriesRefreshBtnEl.addEventListener("click", () => {
+    const id = state.webhookDeliveriesSubscriptionId
+      || (webhookDeliveriesSubscriptionEl && webhookDeliveriesSubscriptionEl.value);
+    if (id) loadWebhookDeliveries(id).catch(() => {});
   });
 }
 

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -167,6 +167,10 @@ const state = {
   webhookDefaultMaxAttempts: 5,
   webhookDeliveriesLoading: false,
   webhookDeliveriesSubscriptionId: null,
+  // Bumped on every loadWebhookDeliveries() call so a slow response from
+  // an older subscription can't overwrite a fresh table when the
+  // operator switches the dropdown rapidly.
+  webhookDeliveriesRequestId: 0,
   webhookDeliveries: []
 };
 
@@ -2360,6 +2364,24 @@ lockSessionBtnEl.addEventListener("click", () => {
   state.webhookSubscriptions = [];
   state.webhookDeliveries = [];
   state.webhookDeliveriesSubscriptionId = null;
+  // Clear any one-time secret that's still on screen — without this,
+  // locking on the Webhooks tab and unlocking again would leave the
+  // previously revealed secret visible until loadWebhooks() finishes.
+  if (typeof webhookCreatedSecretBoxEl !== "undefined" && webhookCreatedSecretBoxEl) {
+    webhookCreatedSecretBoxEl.hidden = true;
+  }
+  if (typeof webhookCreatedSecretValueEl !== "undefined" && webhookCreatedSecretValueEl) {
+    webhookCreatedSecretValueEl.textContent = "";
+  }
+  if (typeof webhooksTableBody !== "undefined" && webhooksTableBody) {
+    webhooksTableBody.innerHTML = "";
+  }
+  if (typeof webhookDeliveriesTableBody !== "undefined" && webhookDeliveriesTableBody) {
+    webhookDeliveriesTableBody.innerHTML = "";
+  }
+  if (typeof webhookDeliveriesSubscriptionEl !== "undefined" && webhookDeliveriesSubscriptionEl) {
+    webhookDeliveriesSubscriptionEl.innerHTML = "";
+  }
   destroyAllAnalyticsCharts();
   if (analyticsCardsEl) {
     analyticsCardsEl.querySelectorAll('[data-metric]').forEach((el) => {
@@ -3588,14 +3610,21 @@ async function loadWebhookDeliveries(subscriptionId) {
     state.webhookDeliveries = [];
     return;
   }
+  const requestId = ++state.webhookDeliveriesRequestId;
   try {
     const payload = await requestAdminJson(
       `/api/admin/webhooks/${encodeURIComponent(subscriptionId)}/deliveries?limit=50`
     );
+    // Drop late responses — the operator may have switched
+    // subscriptions or locked the workspace before this fetch
+    // resolved, and the rendered table+retry buttons must reflect
+    // the most recent request.
+    if (requestId !== state.webhookDeliveriesRequestId) return;
     state.webhookDeliveries = Array.isArray(payload.deliveries) ? payload.deliveries : [];
     state.webhookDeliveriesSubscriptionId = subscriptionId;
     renderWebhookDeliveries();
   } catch (err) {
+    if (requestId !== state.webhookDeliveriesRequestId) return;
     setStatus(webhooksStatusEl, `Deliveries fetch failed: ${err.message}`, "admin-status-missing");
   }
 }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -168,6 +168,18 @@
             >
               Schedule
             </button>
+            <button
+              id="admin-tab-webhooks"
+              type="button"
+              class="ghost admin-tab"
+              data-tab="webhooks"
+              role="tab"
+              aria-controls="admin-panel-webhooks"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              Webhooks
+            </button>
           </nav>
 
           <section
@@ -975,6 +987,126 @@
                       <th scope="col">Lang</th>
                       <th scope="col">Word</th>
                       <th scope="col">Notes</th>
+                      <th scope="col">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </section>
+          </section>
+
+          <section
+            id="admin-panel-webhooks"
+            class="admin-slot"
+            data-panel="webhooks"
+            role="tabpanel"
+            aria-labelledby="admin-tab-webhooks"
+            tabindex="0"
+            hidden
+          >
+            <h3>Webhooks</h3>
+            <p class="note">
+              Outbound HTTP notifications for events like provider imports.
+              Subscribers receive a signed JSON POST whose body the recipient
+              should verify with HMAC-SHA-256 over the secret. See
+              <code>docs/webhooks.md</code> for the event catalog and verification
+              snippet.
+            </p>
+            <div id="webhooksDisabledBanner" class="message" role="status" aria-live="polite" hidden>
+              Webhooks are currently disabled at the server level
+              (<code>WEBHOOKS_ENABLED=false</code>). Subscriptions can still be
+              managed but no events will be delivered until the server is
+              restarted with webhooks enabled.
+            </div>
+            <div id="webhooksStatus" class="message" role="status" aria-live="polite"></div>
+
+            <section class="admin-subpanel">
+              <h4>Create a subscription</h4>
+              <form id="webhookCreateForm" class="form-inline">
+                <label class="form-inline">
+                  <span>URL</span>
+                  <input
+                    type="url"
+                    id="webhookUrlInput"
+                    placeholder="https://example.com/webhooks/wordle"
+                    required
+                    maxlength="2048"
+                    autocomplete="off"
+                    spellcheck="false"
+                  />
+                </label>
+                <label class="form-inline">
+                  <span>Events</span>
+                  <input
+                    type="text"
+                    id="webhookEventsInput"
+                    placeholder="provider.import.completed,provider.import.failed"
+                    required
+                    autocomplete="off"
+                    spellcheck="false"
+                  />
+                </label>
+                <label class="form-inline">
+                  <span>Label</span>
+                  <input type="text" id="webhookLabelInput" maxlength="80" autocomplete="off" />
+                </label>
+                <label class="form-inline">
+                  <span>Max attempts</span>
+                  <input type="number" id="webhookMaxAttemptsInput" min="1" max="20" step="1" />
+                </label>
+                <label class="checkbox-row">
+                  <input type="checkbox" id="webhookEnabledInput" checked />
+                  Enabled
+                </label>
+                <button type="submit">Create subscription</button>
+              </form>
+              <div id="webhookCreatedSecretBox" class="message" role="status" aria-live="polite" hidden>
+                <strong>Secret (one-time view):</strong>
+                <code id="webhookCreatedSecretValue"></code>
+                <p class="note">Copy this now — the secret will be redacted on every subsequent read. Rotate the secret to issue a new one.</p>
+              </div>
+            </section>
+
+            <section class="admin-subpanel">
+              <h4>Subscriptions</h4>
+              <div class="admin-table-wrap">
+                <table id="webhooksTable" class="admin-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Label</th>
+                      <th scope="col">URL</th>
+                      <th scope="col">Events</th>
+                      <th scope="col">Enabled</th>
+                      <th scope="col">Max attempts</th>
+                      <th scope="col">Created</th>
+                      <th scope="col">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="admin-subpanel">
+              <h4>Recent deliveries</h4>
+              <div class="form-inline">
+                <label class="form-inline">
+                  <span>Subscription</span>
+                  <select id="webhookDeliveriesSubscription"></select>
+                </label>
+                <button type="button" id="webhookDeliveriesRefreshBtn">Refresh</button>
+              </div>
+              <div class="admin-table-wrap">
+                <table id="webhookDeliveriesTable" class="admin-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Created</th>
+                      <th scope="col">Event</th>
+                      <th scope="col">Status</th>
+                      <th scope="col">Attempts</th>
+                      <th scope="col">HTTP</th>
+                      <th scope="col">Last error</th>
                       <th scope="col">Actions</th>
                     </tr>
                   </thead>

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -807,8 +807,13 @@ function createAdminRouter(deps) {
         // Best-effort cascade: delivery rows for the removed
         // subscription have no admin UI to inspect anyway.
         await webhookDeliveryStore.deleteForSubscription(req.params.id).catch((cascadeErr) => {
+          // Pass id as a separate arg (not interpolated) so a hostile
+          // path param can't inject %s-style format placeholders into
+          // the format string. The store's pattern check rejects ids
+          // outside [A-Za-z0-9_-], but defense in depth.
           console.warn(
-            `[webhook] could not cascade-delete deliveries for ${req.params.id}:`,
+            "[webhook] could not cascade-delete deliveries for %s:",
+            req.params.id,
             cascadeErr.message
           );
         });
@@ -831,6 +836,12 @@ function createAdminRouter(deps) {
   });
 
   router.post("/api/admin/webhooks/:id/test", async (req, res) => {
+    if (!webhooksEnabled) {
+      return res.status(409).json({
+        error: "Webhooks are disabled at the server level (WEBHOOKS_ENABLED=false). Cannot fire test events.",
+        code: "WEBHOOKS_DISABLED"
+      });
+    }
     try {
       const sub = await webhookStore.findById(req.params.id);
       if (!sub) {
@@ -844,18 +855,22 @@ function createAdminRouter(deps) {
       // what a real provider event would look like — operators
       // verifying their endpoint should see exactly what production
       // payloads will send.
-      const delivery = await webhookDeliveryStore.enqueue({
+      const testPayload = {
+        message: "Test event from local-hosted-wordle admin.",
         subscriptionId: sub.id,
-        event: "webhook.test",
-        url: sub.url
+        requestedAt: new Date().toISOString()
+      };
+      const delivery = await withSlot(async () => {
+        return webhookDeliveryStore.enqueue({
+          subscriptionId: sub.id,
+          event: "webhook.test",
+          url: sub.url,
+          payload: testPayload
+        });
       });
       webhookService.scheduleDelivery(delivery.id, 0, {
         event: "webhook.test",
-        payload: {
-          message: "Test event from local-hosted-wordle admin.",
-          subscriptionId: sub.id,
-          requestedAt: new Date().toISOString()
-        },
+        payload: testPayload,
         subscription: sub
       });
       webhookAudit("subscription.test", {
@@ -916,6 +931,12 @@ function createAdminRouter(deps) {
   });
 
   router.post("/api/admin/webhooks/:id/deliveries/:deliveryId/retry", async (req, res) => {
+    if (!webhooksEnabled) {
+      return res.status(409).json({
+        error: "Webhooks are disabled at the server level (WEBHOOKS_ENABLED=false). Cannot retry deliveries.",
+        code: "WEBHOOKS_DISABLED"
+      });
+    }
     try {
       const sub = await webhookStore.findById(req.params.id);
       if (!sub) {
@@ -937,7 +958,9 @@ function createAdminRouter(deps) {
           code: "INVALID_REQUEST"
         });
       }
-      const retried = await webhookService.retryDelivery(delivery.id);
+      const retried = await withSlot(async () => {
+        return webhookService.retryDelivery(delivery.id);
+      });
       webhookAudit("delivery.retry", {
         actor: actorFingerprint(req),
         id: sub.id,

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -130,7 +130,15 @@ function createAdminRouter(deps) {
     analyticsTimezone,
     scheduleStore,
     runSchedulerReconcile,
-    ScheduleStoreError
+    ScheduleStoreError,
+    webhookStore,
+    webhookDeliveryStore,
+    webhookService,
+    WebhookStoreError,
+    WebhookDeliveryStoreError,
+    redactWebhookSecret,
+    webhooksEnabled,
+    webhookDefaultMaxAttempts
   } = deps;
 
   // Required dep — the toggle and runtime-config handlers depend on
@@ -637,6 +645,317 @@ function createAdminRouter(deps) {
     }
   });
 
+  // ── Webhooks ────────────────────────────────────────────────────────
+  // Map a WebhookStoreError code to an HTTP status. 400 covers shape /
+  // validation failures, 404 for not-found, 503 for store I/O failures.
+  function webhookErrorStatus(err) {
+    if (err instanceof WebhookStoreError || err instanceof WebhookDeliveryStoreError) {
+      switch (err.code) {
+        case "INVALID_REQUEST":
+        case "INVALID_URL":
+        case "INVALID_EVENTS":
+        case "INVALID_LABEL":
+        case "INVALID_MAX_ATTEMPTS":
+        case "INVALID_SUBSCRIPTION":
+        case "INVALID_DELIVERY":
+        case "INVALID_STORE":
+        case "VERSION_UNSUPPORTED":
+          return 400;
+        case "SUBSCRIPTION_NOT_FOUND":
+        case "DELIVERY_NOT_FOUND":
+          return 404;
+        case "STORE_READ_FAILED":
+        case "STORE_WRITE_FAILED":
+        case "STORE_PARSE_FAILED":
+          return 503;
+        default:
+          return 500;
+      }
+    }
+    return 500;
+  }
+  function webhookErrorBody(err) {
+    const STORE_LEVEL = new Set([
+      "STORE_READ_FAILED",
+      "STORE_WRITE_FAILED",
+      "STORE_PARSE_FAILED"
+    ]);
+    const code = err?.code || "INTERNAL";
+    const message = STORE_LEVEL.has(code)
+      ? "Webhook store unavailable. See server logs."
+      : err?.message || "Webhook operation failed.";
+    return { error: message, code };
+  }
+  function webhookAudit(action, fields) {
+    try {
+      console.log(JSON.stringify({
+        event: `[webhook] ${action}`,
+        ts: new Date().toISOString(),
+        ...fields
+      }));
+    } catch (_err) {
+      // best-effort
+    }
+  }
+  function ensureWebhookDeps() {
+    if (!webhookStore || typeof webhookStore.load !== "function") {
+      throw new TypeError("createAdminRouter: webhookStore dep is required.");
+    }
+    if (!webhookDeliveryStore || typeof webhookDeliveryStore.load !== "function") {
+      throw new TypeError("createAdminRouter: webhookDeliveryStore dep is required.");
+    }
+    if (!webhookService) {
+      throw new TypeError("createAdminRouter: webhookService dep is required.");
+    }
+    if (!WebhookStoreError) {
+      throw new TypeError("createAdminRouter: WebhookStoreError dep is required.");
+    }
+    if (!WebhookDeliveryStoreError) {
+      throw new TypeError("createAdminRouter: WebhookDeliveryStoreError dep is required.");
+    }
+    if (typeof redactWebhookSecret !== "function") {
+      throw new TypeError("createAdminRouter: redactWebhookSecret dep is required.");
+    }
+  }
+  ensureWebhookDeps();
+
+  router.get("/api/admin/webhooks", async (req, res) => {
+    try {
+      const snapshot = await webhookStore.getSnapshot();
+      const subscriptions = snapshot.subscriptions.map((sub) => redactWebhookSecret(sub));
+      return res.json({
+        ok: true,
+        enabled: webhooksEnabled !== false,
+        subscriptions,
+        defaultMaxAttempts: webhookDefaultMaxAttempts
+      });
+    } catch (err) {
+      if (err instanceof WebhookStoreError) {
+        return res.status(webhookErrorStatus(err)).json(webhookErrorBody(err));
+      }
+      console.error("[webhook] list failed:", err);
+      return res.status(503).json({
+        error: "Webhook list failed.",
+        code: "STORE_READ_FAILED"
+      });
+    }
+  });
+
+  router.post("/api/admin/webhooks", async (req, res) => {
+    try {
+      const created = await withSlot(async () => {
+        return webhookStore.create({
+          url: req.body?.url,
+          events: req.body?.events,
+          enabled: req.body?.enabled !== false,
+          maxAttempts: req.body?.maxAttempts,
+          label: req.body?.label
+        });
+      });
+      webhookAudit("subscription.create", {
+        actor: actorFingerprint(req),
+        id: created.id,
+        events: created.events,
+        url: created.url
+      });
+      // Return the secret ONCE on creation. Subsequent reads redact it
+      // so the operator must rotate-and-fetch to retrieve it again.
+      return res.status(201).json({ ok: true, subscription: created });
+    } catch (err) {
+      if (err instanceof WebhookStoreError) {
+        return res.status(webhookErrorStatus(err)).json(webhookErrorBody(err));
+      }
+      console.error("[webhook] create failed:", err);
+      return res.status(503).json({
+        error: "Webhook create failed.",
+        code: "STORE_WRITE_FAILED"
+      });
+    }
+  });
+
+  router.patch("/api/admin/webhooks/:id", async (req, res) => {
+    try {
+      const result = await withSlot(async () => {
+        return webhookStore.update(req.params.id, req.body || {});
+      });
+      const rotated = req.body?.rotateSecret === true;
+      webhookAudit("subscription.update", {
+        actor: actorFingerprint(req),
+        id: result.id,
+        rotated
+      });
+      // If rotateSecret was requested, reveal the new secret in the
+      // response (one-time view); otherwise redact.
+      const payload = rotated ? result : redactWebhookSecret(result);
+      return res.json({ ok: true, subscription: payload });
+    } catch (err) {
+      if (err instanceof WebhookStoreError) {
+        return res.status(webhookErrorStatus(err)).json(webhookErrorBody(err));
+      }
+      console.error("[webhook] update failed:", err);
+      return res.status(503).json({
+        error: "Webhook update failed.",
+        code: "STORE_WRITE_FAILED"
+      });
+    }
+  });
+
+  router.delete("/api/admin/webhooks/:id", async (req, res) => {
+    try {
+      await withSlot(async () => {
+        await webhookStore.remove(req.params.id);
+        // Best-effort cascade: delivery rows for the removed
+        // subscription have no admin UI to inspect anyway.
+        await webhookDeliveryStore.deleteForSubscription(req.params.id).catch((cascadeErr) => {
+          console.warn(
+            `[webhook] could not cascade-delete deliveries for ${req.params.id}:`,
+            cascadeErr.message
+          );
+        });
+      });
+      webhookAudit("subscription.delete", {
+        actor: actorFingerprint(req),
+        id: req.params.id
+      });
+      return res.status(204).send();
+    } catch (err) {
+      if (err instanceof WebhookStoreError) {
+        return res.status(webhookErrorStatus(err)).json(webhookErrorBody(err));
+      }
+      console.error("[webhook] delete failed:", err);
+      return res.status(503).json({
+        error: "Webhook delete failed.",
+        code: "STORE_WRITE_FAILED"
+      });
+    }
+  });
+
+  router.post("/api/admin/webhooks/:id/test", async (req, res) => {
+    try {
+      const sub = await webhookStore.findById(req.params.id);
+      if (!sub) {
+        return res.status(404).json({
+          error: `No subscription with id ${req.params.id}.`,
+          code: "SUBSCRIPTION_NOT_FOUND"
+        });
+      }
+      // Synthesize a queued delivery for the test event. We use the
+      // same emit() path so signature, headers, and store rows match
+      // what a real provider event would look like — operators
+      // verifying their endpoint should see exactly what production
+      // payloads will send.
+      const delivery = await webhookDeliveryStore.enqueue({
+        subscriptionId: sub.id,
+        event: "webhook.test",
+        url: sub.url
+      });
+      webhookService.scheduleDelivery(delivery.id, 0, {
+        event: "webhook.test",
+        payload: {
+          message: "Test event from local-hosted-wordle admin.",
+          subscriptionId: sub.id,
+          requestedAt: new Date().toISOString()
+        },
+        subscription: sub
+      });
+      webhookAudit("subscription.test", {
+        actor: actorFingerprint(req),
+        id: sub.id,
+        deliveryId: delivery.id
+      });
+      return res.status(202).json({ ok: true, deliveryId: delivery.id });
+    } catch (err) {
+      if (err instanceof WebhookStoreError || err instanceof WebhookDeliveryStoreError) {
+        return res.status(webhookErrorStatus(err)).json(webhookErrorBody(err));
+      }
+      console.error("[webhook] test failed:", err);
+      return res.status(503).json({
+        error: "Webhook test failed.",
+        code: "STORE_WRITE_FAILED"
+      });
+    }
+  });
+
+  router.get("/api/admin/webhooks/:id/deliveries", async (req, res) => {
+    try {
+      const limitRaw = req.query.limit;
+      let limit = 50;
+      if (limitRaw !== undefined) {
+        const n = Number(limitRaw);
+        if (!Number.isInteger(n) || n < 1 || n > 500) {
+          return res.status(400).json({ error: "limit must be between 1 and 500.", code: "INVALID_REQUEST" });
+        }
+        limit = n;
+      }
+      const sub = await webhookStore.findById(req.params.id);
+      if (!sub) {
+        return res.status(404).json({
+          error: `No subscription with id ${req.params.id}.`,
+          code: "SUBSCRIPTION_NOT_FOUND"
+        });
+      }
+      const status = req.query.status ? String(req.query.status) : undefined;
+      const event = req.query.event ? String(req.query.event) : undefined;
+      const deliveries = await webhookDeliveryStore.findRecent({
+        subscriptionId: sub.id,
+        status,
+        event,
+        limit
+      });
+      return res.json({ ok: true, deliveries });
+    } catch (err) {
+      if (err instanceof WebhookDeliveryStoreError) {
+        return res.status(webhookErrorStatus(err)).json(webhookErrorBody(err));
+      }
+      console.error("[webhook] deliveries list failed:", err);
+      return res.status(503).json({
+        error: "Webhook deliveries fetch failed.",
+        code: "STORE_READ_FAILED"
+      });
+    }
+  });
+
+  router.post("/api/admin/webhooks/:id/deliveries/:deliveryId/retry", async (req, res) => {
+    try {
+      const sub = await webhookStore.findById(req.params.id);
+      if (!sub) {
+        return res.status(404).json({
+          error: `No subscription with id ${req.params.id}.`,
+          code: "SUBSCRIPTION_NOT_FOUND"
+        });
+      }
+      const delivery = await webhookDeliveryStore.findById(req.params.deliveryId);
+      if (!delivery || delivery.subscriptionId !== sub.id) {
+        return res.status(404).json({
+          error: `No delivery with id ${req.params.deliveryId} for this subscription.`,
+          code: "DELIVERY_NOT_FOUND"
+        });
+      }
+      if (delivery.status !== "failed") {
+        return res.status(409).json({
+          error: `Delivery is in ${delivery.status} state and cannot be retried.`,
+          code: "INVALID_REQUEST"
+        });
+      }
+      const retried = await webhookService.retryDelivery(delivery.id);
+      webhookAudit("delivery.retry", {
+        actor: actorFingerprint(req),
+        id: sub.id,
+        deliveryId: delivery.id
+      });
+      return res.json({ ok: true, delivery: retried });
+    } catch (err) {
+      if (err instanceof WebhookStoreError || err instanceof WebhookDeliveryStoreError) {
+        return res.status(webhookErrorStatus(err)).json(webhookErrorBody(err));
+      }
+      console.error("[webhook] retry failed:", err);
+      return res.status(503).json({
+        error: "Webhook retry failed.",
+        code: "STORE_WRITE_FAILED"
+      });
+    }
+  });
+
   router.delete("/api/admin/stats/profile/:id", async (req, res) => {
     const profileId = String(req.params.id || "").trim();
     if (!profileId) {
@@ -998,8 +1317,10 @@ function createAdminRouter(deps) {
       }
 
       providerImportSyncActiveRef.value = true;
+      let syncResult = null;
+      let syncError = null;
       try {
-        const result = await runProviderImportPipeline({
+        syncResult = await runProviderImportPipeline({
           sourceType,
           variant,
           commit: commitInput || null,
@@ -1008,13 +1329,44 @@ function createAdminRouter(deps) {
           manualFiles: req.body?.manualFiles
         });
         return res.json({
-          ...result,
+          ...syncResult,
           providers: buildProviderStatusRows()
         });
       } catch (err) {
+        syncError = err;
         return providerAdminError(res, mapProviderPipelineError(err));
       } finally {
         providerImportSyncActiveRef.value = false;
+        // Fire-and-forget emit so the response isn't held up by webhook
+        // delivery. Errors are logged but never bubble to the client.
+        if (webhookService) {
+          if (syncResult) {
+            webhookService
+              .emit("provider.import.completed", {
+                jobId: null,
+                variant: syncResult.variant,
+                commit: syncResult.commit,
+                sourceType: syncResult.sourceType,
+                filterMode: syncResult.filterMode,
+                counts: syncResult.counts,
+                artifacts: syncResult.artifacts
+              })
+              .catch((emitErr) => {
+                console.error("[webhook] emit failed for sync import:", emitErr);
+              });
+          } else if (syncError) {
+            webhookService
+              .emit("provider.import.failed", {
+                jobId: null,
+                variant,
+                sourceType,
+                error: { message: syncError?.message || String(syncError) }
+              })
+              .catch((emitErr) => {
+                console.error("[webhook] emit failed for sync import:", emitErr);
+              });
+          }
+        }
         startProviderImportQueueIfNeeded().catch((queueErr) => {
           console.error("Provider import queue processing failed.", queueErr);
         });

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -214,6 +214,8 @@ function createBackupRouter(deps) {
     appConfigStore,
     classesStore,
     scheduleStore,
+    webhookStore,
+    webhookDeliveryStore,
     rebuildLanguageRuntimeCatalog,
     reloadWordData,
     providerImportQueueActiveRef,
@@ -238,6 +240,8 @@ function createBackupRouter(deps) {
     if (adminJobsStore?.load) await adminJobsStore.load();
     if (classesStore?.load) await classesStore.load();
     if (scheduleStore?.load) await scheduleStore.load();
+    if (webhookStore?.load) await webhookStore.load();
+    if (webhookDeliveryStore?.load) await webhookDeliveryStore.load();
     if (appConfigStore?.loadSync) appConfigStore.loadSync();
     if (languageRegistryStore?.loadSync) languageRegistryStore.loadSync();
   }
@@ -254,7 +258,9 @@ function createBackupRouter(deps) {
       leaderboardStore?.writeQueue,
       adminJobsStore?.writeQueue,
       classesStore?.writeQueue,
-      scheduleStore?.commitQueue
+      scheduleStore?.commitQueue,
+      webhookStore?.commitQueue,
+      webhookDeliveryStore?.commitQueue
     ].filter(Boolean);
     if (queues.length === 0) return;
     await Promise.allSettled(queues);
@@ -616,6 +622,8 @@ function createBackupRouter(deps) {
         ["adminJobsStore", () => adminJobsStore?.reload?.()],
         ["classesStore", () => classesStore?.reload?.()],
         ["scheduleStore", () => scheduleStore?.reload?.()],
+        ["webhookStore", () => webhookStore?.reload?.()],
+        ["webhookDeliveryStore", () => webhookDeliveryStore?.reload?.()],
         ["appConfigStore", () => appConfigStore?.reloadSync?.()],
         ["languageRegistryStore", () => languageRegistryStore?.reloadSync?.()],
         ["languageRuntimeCatalog", () => rebuildLanguageRuntimeCatalog?.()],

--- a/scripts/validate-schemas.js
+++ b/scripts/validate-schemas.js
@@ -33,6 +33,10 @@ const backupManifestSchemaPath = path.join(projectRoot, "data", "backup-manifest
 const backupManifestExamplePath = path.join(projectRoot, "data", "backup-manifest.example.json");
 const scheduleSchemaPath = path.join(projectRoot, "data", "schedule.schema.json");
 const scheduleExamplePath = path.join(projectRoot, "data", "schedule.example.json");
+const webhooksSchemaPath = path.join(projectRoot, "data", "webhooks.schema.json");
+const webhooksExamplePath = path.join(projectRoot, "data", "webhooks.example.json");
+const webhookDeliveriesSchemaPath = path.join(projectRoot, "data", "webhook-deliveries.schema.json");
+const webhookDeliveriesExamplePath = path.join(projectRoot, "data", "webhook-deliveries.example.json");
 
 function readJson(filePath, kind) {
   let raw;
@@ -110,6 +114,16 @@ function runSchemaChecks() {
       schemaPath: scheduleSchemaPath,
       dataPath: scheduleExamplePath,
       schemaLabel: "schedule schema"
+    },
+    {
+      schemaPath: webhooksSchemaPath,
+      dataPath: webhooksExamplePath,
+      schemaLabel: "webhooks schema"
+    },
+    {
+      schemaPath: webhookDeliveriesSchemaPath,
+      dataPath: webhookDeliveriesExamplePath,
+      schemaLabel: "webhook deliveries schema"
     }
   ];
 

--- a/server.js
+++ b/server.js
@@ -20,6 +20,9 @@ const { AppConfigStore, AppConfigStoreError } = require("./lib/app-config-store"
 const { aggregate: aggregateAnalytics } = require("./lib/analytics-aggregator");
 const { ScheduleStore } = require("./lib/schedule-store");
 const { reconcileDailyWord } = require("./lib/scheduler-tick");
+const { WebhookStore, WebhookStoreError, redactSecret } = require("./lib/webhook-store");
+const { WebhookDeliveryStore, WebhookDeliveryStoreError } = require("./lib/webhook-delivery-store");
+const { WebhookService } = require("./lib/webhook-service");
 const { LanguageRegistryError, LanguageRegistryStore } = require("./lib/language-registry");
 const { SUPPORTED_VARIANT_IDS } = require("./lib/provider-artifact-shared");
 const { fetchAndPersistProviderSource, computeSha256 } = require("./lib/provider-fetch");
@@ -151,6 +154,12 @@ const CLASSES_DATA_PATH = process.env.CLASSES_STORE_PATH
 const SCHEDULE_DATA_PATH = process.env.SCHEDULE_STORE_PATH
   ? path.resolve(process.env.SCHEDULE_STORE_PATH)
   : path.join(__dirname, "data", "schedule.json");
+const WEBHOOKS_DATA_PATH = process.env.WEBHOOKS_STORE_PATH
+  ? path.resolve(process.env.WEBHOOKS_STORE_PATH)
+  : path.join(__dirname, "data", "webhooks.json");
+const WEBHOOK_DELIVERIES_DATA_PATH = process.env.WEBHOOK_DELIVERIES_STORE_PATH
+  ? path.resolve(process.env.WEBHOOK_DELIVERIES_STORE_PATH)
+  : path.join(__dirname, "data", "webhook-deliveries.json");
 const ENV_CLASSES_MAX_MEMBERS_PER_CLASS = clampEnvBounded(
   process.env.CLASSES_MAX_MEMBERS_PER_CLASS,
   1000,
@@ -244,6 +253,48 @@ const ENV_SCHEDULE_RETENTION_DAYS = clampEnvBounded(
   0,
   36500,
   "SCHEDULE_RETENTION_DAYS"
+);
+
+// Webhooks env vars — outbound notifications for events such as
+// provider.import.completed. Kept off by default so a fresh boot is
+// silent until an operator explicitly opts in via the admin UI.
+const ENV_WEBHOOKS_ENABLED = String(process.env.WEBHOOKS_ENABLED || "").toLowerCase() === "true";
+const ENV_WEBHOOK_REQUEST_TIMEOUT_MS = clampEnvBounded(
+  process.env.WEBHOOK_REQUEST_TIMEOUT_MS,
+  10_000,
+  1000,
+  60_000,
+  "WEBHOOK_REQUEST_TIMEOUT_MS"
+);
+const ENV_WEBHOOK_MAX_BODY_BYTES = clampEnvBounded(
+  process.env.WEBHOOK_MAX_BODY_BYTES,
+  64 * 1024,
+  1024,
+  1024 * 1024,
+  "WEBHOOK_MAX_BODY_BYTES"
+);
+const ENV_WEBHOOK_ALLOW_PRIVATE_NETWORKS =
+  String(process.env.WEBHOOK_ALLOW_PRIVATE_NETWORKS || "").toLowerCase() === "true";
+const ENV_WEBHOOK_DELIVERY_HISTORY_MAX = clampEnvBounded(
+  process.env.WEBHOOK_DELIVERY_HISTORY_MAX,
+  200,
+  10,
+  10_000,
+  "WEBHOOK_DELIVERY_HISTORY_MAX"
+);
+const ENV_WEBHOOK_MAX_ATTEMPTS_DEFAULT = clampEnvBounded(
+  process.env.WEBHOOK_MAX_ATTEMPTS_DEFAULT,
+  5,
+  1,
+  20,
+  "WEBHOOK_MAX_ATTEMPTS_DEFAULT"
+);
+const ENV_WEBHOOK_GLOBAL_INFLIGHT_LIMIT = clampEnvBounded(
+  process.env.WEBHOOK_GLOBAL_INFLIGHT_LIMIT,
+  4,
+  1,
+  64,
+  "WEBHOOK_GLOBAL_INFLIGHT_LIMIT"
 );
 
 const MIN_LEN = 3;
@@ -1248,6 +1299,26 @@ const scheduleStore = new ScheduleStore({
   filePath: SCHEDULE_DATA_PATH,
   defaultTimezone: ENV_SCHEDULE_TIMEZONE_DEFAULT,
   defaultRetentionDays: ENV_SCHEDULE_RETENTION_DAYS,
+  logger: console
+});
+const webhookStore = new WebhookStore({
+  filePath: WEBHOOKS_DATA_PATH,
+  defaultMaxAttempts: ENV_WEBHOOK_MAX_ATTEMPTS_DEFAULT,
+  logger: console
+});
+const webhookDeliveryStore = new WebhookDeliveryStore({
+  filePath: WEBHOOK_DELIVERIES_DATA_PATH,
+  historyMax: ENV_WEBHOOK_DELIVERY_HISTORY_MAX,
+  logger: console
+});
+const webhookService = new WebhookService({
+  subscriptionStore: webhookStore,
+  deliveryStore: webhookDeliveryStore,
+  enabled: ENV_WEBHOOKS_ENABLED,
+  allowPrivateNetworks: ENV_WEBHOOK_ALLOW_PRIVATE_NETWORKS,
+  timeoutMs: ENV_WEBHOOK_REQUEST_TIMEOUT_MS,
+  maxBodyBytes: ENV_WEBHOOK_MAX_BODY_BYTES,
+  globalInflight: ENV_WEBHOOK_GLOBAL_INFLIGHT_LIMIT,
   logger: console
 });
 let schedulerIntervalRef = null;
@@ -2537,16 +2608,42 @@ async function startProviderImportQueueIfNeeded() {
         break;
       }
 
+      let result = null;
+      let failure = null;
       try {
-        const result = await runProviderImportPipeline(job.request);
+        result = await runProviderImportPipeline(job.request);
         await adminJobsStore.markSucceeded(job.id, {
           artifacts: result.artifacts
         });
       } catch (err) {
-        const failure = formatProviderJobError(err);
+        failure = formatProviderJobError(err);
         await adminJobsStore.markFailed(job.id, failure);
       } finally {
         await cleanupManualUploadStaging(job.request?.manualUpload).catch(() => {});
+        // Best-effort emit. Failures here are logged but never block the
+        // queue — the job's persisted status is the source of truth.
+        try {
+          if (result) {
+            await webhookService.emit("provider.import.completed", {
+              jobId: job.id,
+              variant: result.variant,
+              commit: result.commit,
+              sourceType: result.sourceType,
+              filterMode: result.filterMode,
+              counts: result.counts,
+              artifacts: result.artifacts
+            });
+          } else if (failure) {
+            await webhookService.emit("provider.import.failed", {
+              jobId: job.id,
+              variant: job.request?.variant || null,
+              sourceType: job.request?.sourceType || null,
+              error: failure
+            });
+          }
+        } catch (emitErr) {
+          console.error("[webhook] emit failed for provider import:", emitErr);
+        }
       }
     }
   } finally {
@@ -2834,6 +2931,8 @@ app.use(
     appConfigStore,
     classesStore,
     scheduleStore,
+    webhookStore,
+    webhookDeliveryStore,
     rebuildLanguageRuntimeCatalog,
     reloadWordData: () => {
       // Re-read data/word.json from disk and refresh the in-memory cache
@@ -2932,7 +3031,15 @@ app.use(
     analyticsTimezone: ENV_ANALYTICS_TIMEZONE,
     scheduleStore,
     runSchedulerReconcile,
-    ScheduleStoreError: require("./lib/schedule-store").ScheduleStoreError
+    ScheduleStoreError: require("./lib/schedule-store").ScheduleStoreError,
+    webhookStore,
+    webhookDeliveryStore,
+    webhookService,
+    WebhookStoreError,
+    WebhookDeliveryStoreError,
+    redactWebhookSecret: redactSecret,
+    webhooksEnabled: ENV_WEBHOOKS_ENABLED,
+    webhookDefaultMaxAttempts: ENV_WEBHOOK_MAX_ATTEMPTS_DEFAULT
   })
 );
 
@@ -3188,6 +3295,21 @@ async function startServer(listener = app.listen.bind(app)) {
     console.error("[scheduler] boot reconcile error:", err);
   }
   startSchedulerInterval();
+  // Restart recovery: any delivery left in `running` (process died
+  // mid-flight) or `queued` (timer was lost across restart) gets
+  // requeued so a crash doesn't permanently strand a notification.
+  // Errors are logged-and-swallowed because webhooks are a soft layer
+  // and shouldn't block the listener from coming up.
+  if (ENV_WEBHOOKS_ENABLED) {
+    try {
+      const recovered = await webhookService.recoverOnBoot();
+      if (recovered > 0) {
+        console.log(`[webhook] recovered ${recovered} delivery(ies) after restart.`);
+      }
+    } catch (err) {
+      console.error("[webhook] recovery failed:", err);
+    }
+  }
   return listener(PORT, HOST, () => {
     console.log(`local-hosted-wordle server running at http://localhost:${PORT}`);
     console.log(`Definitions mode: ${getDefinitionsMode()}`);
@@ -3224,3 +3346,6 @@ module.exports.startServer = startServer;
 module.exports.runSchedulerReconcile = runSchedulerReconcile;
 module.exports.stopSchedulerInterval = stopSchedulerInterval;
 module.exports.scheduleStore = scheduleStore;
+module.exports.webhookStore = webhookStore;
+module.exports.webhookDeliveryStore = webhookDeliveryStore;
+module.exports.webhookService = webhookService;

--- a/server.js
+++ b/server.js
@@ -1304,12 +1304,14 @@ const scheduleStore = new ScheduleStore({
 const webhookStore = new WebhookStore({
   filePath: WEBHOOKS_DATA_PATH,
   defaultMaxAttempts: ENV_WEBHOOK_MAX_ATTEMPTS_DEFAULT,
-  logger: console
+  logger: console,
+  waitForDataMutationLock
 });
 const webhookDeliveryStore = new WebhookDeliveryStore({
   filePath: WEBHOOK_DELIVERIES_DATA_PATH,
   historyMax: ENV_WEBHOOK_DELIVERY_HISTORY_MAX,
-  logger: console
+  logger: console,
+  waitForDataMutationLock
 });
 const webhookService = new WebhookService({
   subscriptionStore: webhookStore,

--- a/server.js
+++ b/server.js
@@ -1305,13 +1305,18 @@ const webhookStore = new WebhookStore({
   filePath: WEBHOOKS_DATA_PATH,
   defaultMaxAttempts: ENV_WEBHOOK_MAX_ATTEMPTS_DEFAULT,
   logger: console,
-  waitForDataMutationLock
+  // Atomic check-and-claim: waits for the data-mutation lock AND
+  // increments directDataWriteActiveRef so backup/restore's busy
+  // check observes us. Background delivery attempts (executeOnce)
+  // bypass the admin /api gate, so this is the only thing keeping
+  // them from racing a backup that just observed the queue empty.
+  claimDirectDataWriteSlot
 });
 const webhookDeliveryStore = new WebhookDeliveryStore({
   filePath: WEBHOOK_DELIVERIES_DATA_PATH,
   historyMax: ENV_WEBHOOK_DELIVERY_HISTORY_MAX,
   logger: console,
-  waitForDataMutationLock
+  claimDirectDataWriteSlot
 });
 const webhookService = new WebhookService({
   subscriptionStore: webhookStore,

--- a/tests/admin-webhook-routes.test.js
+++ b/tests/admin-webhook-routes.test.js
@@ -47,8 +47,23 @@ function loadApp({ adminKey, dir, env = {} } = {}) {
   return require("../server");
 }
 
+// Stub global.fetch so test deliveries never make a real outbound HTTP
+// call. Real fetch would either time out (CI without egress) or worse,
+// hit https://example.com/x for real. The stub returns 200 OK so the
+// delivery row can be inspected as `succeeded` without the test
+// depending on network.
+const originalFetch = globalThis.fetch;
+beforeEach(() => {
+  globalThis.fetch = async () => ({
+    status: 200,
+    headers: { get: () => null },
+    body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+  });
+});
+
 afterEach(() => {
   resetEnv();
+  globalThis.fetch = originalFetch;
 });
 
 describe("GET /api/admin/webhooks", () => {
@@ -209,6 +224,18 @@ describe("POST /api/admin/webhooks/:id/test", () => {
     const app = loadApp({ dir });
     const res = await supertest(app).post("/api/admin/webhooks/nonexistent/test");
     expect(res.status).toBe(404);
+  });
+
+  test("409 with WEBHOOKS_DISABLED when WEBHOOKS_ENABLED=false", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir, env: { WEBHOOKS_ENABLED: "false" } });
+    const created = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "https://example.com/x", events: ["webhook.test"] });
+    const id = created.body.subscription.id;
+    const res = await supertest(app).post(`/api/admin/webhooks/${encodeURIComponent(id)}/test`);
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("WEBHOOKS_DISABLED");
   });
 });
 

--- a/tests/admin-webhook-routes.test.js
+++ b/tests/admin-webhook-routes.test.js
@@ -1,0 +1,243 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const supertest = require("supertest");
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv() {
+  Object.keys(process.env).forEach((key) => {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  });
+  Object.entries(ORIGINAL_ENV).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+}
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "lhw-webhook-int-"));
+}
+
+function loadApp({ adminKey, dir, env = {} } = {}) {
+  jest.resetModules();
+  resetEnv();
+  if (adminKey) {
+    process.env.ADMIN_KEY = adminKey;
+  } else {
+    delete process.env.ADMIN_KEY;
+  }
+  process.env.NODE_ENV = "test";
+  process.env.SCHEDULER_CHECK_INTERVAL_MS = String(60 * 60 * 1000);
+  if (dir) {
+    process.env.WEBHOOKS_STORE_PATH = path.join(dir, "webhooks.json");
+    process.env.WEBHOOK_DELIVERIES_STORE_PATH = path.join(dir, "webhook-deliveries.json");
+    process.env.SCHEDULE_STORE_PATH = path.join(dir, "schedule.json");
+    process.env.STATS_STORE_PATH = path.join(dir, "leaderboard.json");
+    process.env.CLASSES_STORE_PATH = path.join(dir, "classes.json");
+    process.env.ADMIN_JOBS_STORE_PATH = path.join(dir, "admin-jobs.json");
+    process.env.APP_CONFIG_PATH = path.join(dir, "app-config.json");
+  }
+  process.env.WEBHOOKS_ENABLED = "true";
+  process.env.WEBHOOK_ALLOW_PRIVATE_NETWORKS = "true";
+  for (const [k, v] of Object.entries(env)) {
+    process.env[k] = v;
+  }
+  return require("../server");
+}
+
+afterEach(() => {
+  resetEnv();
+});
+
+describe("GET /api/admin/webhooks", () => {
+  test("returns an empty subscription list on first call", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app).get("/api/admin/webhooks");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.subscriptions).toEqual([]);
+    expect(res.body.enabled).toBe(true);
+  });
+
+  test("requires admin key when configured", async () => {
+    const dir = tempDir();
+    const app = loadApp({ adminKey: "test-key", dir });
+    const noKey = await supertest(app).get("/api/admin/webhooks");
+    expect(noKey.status).toBe(401);
+    const withKey = await supertest(app)
+      .get("/api/admin/webhooks")
+      .set("x-admin-key", "test-key");
+    expect(withKey.status).toBe(200);
+  });
+
+  test("redacts secrets in list", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const create = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "https://example.com/x", events: ["a.b"] });
+    expect(create.status).toBe(201);
+    expect(create.body.subscription.secret).toMatch(/^[a-f0-9]{64}$/);
+    const list = await supertest(app).get("/api/admin/webhooks");
+    expect(list.body.subscriptions).toHaveLength(1);
+    expect(list.body.subscriptions[0].secret).toBeUndefined();
+  });
+});
+
+describe("POST /api/admin/webhooks", () => {
+  test("returns the secret one-time on creation", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({
+        url: "https://example.com/x",
+        events: ["provider.import.completed"],
+        label: "My ops bot",
+        maxAttempts: 3
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.subscription.secret).toMatch(/^[a-f0-9]{64}$/);
+    expect(res.body.subscription.label).toBe("My ops bot");
+    expect(res.body.subscription.maxAttempts).toBe(3);
+  });
+
+  test("400 on invalid URL", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "not-a-url", events: ["a.b"] });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_URL");
+  });
+
+  test("400 on empty events array", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "https://example.com", events: [] });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_EVENTS");
+  });
+});
+
+describe("PATCH /api/admin/webhooks/:id", () => {
+  test("toggling enabled does not return the secret", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const created = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "https://example.com/x", events: ["a.b"] });
+    const id = created.body.subscription.id;
+    const res = await supertest(app)
+      .patch(`/api/admin/webhooks/${encodeURIComponent(id)}`)
+      .send({ enabled: false });
+    expect(res.status).toBe(200);
+    expect(res.body.subscription.enabled).toBe(false);
+    expect(res.body.subscription.secret).toBeUndefined();
+  });
+
+  test("rotateSecret reveals the new secret in the response", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const created = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "https://example.com/x", events: ["a.b"] });
+    const original = created.body.subscription.secret;
+    const id = created.body.subscription.id;
+    const res = await supertest(app)
+      .patch(`/api/admin/webhooks/${encodeURIComponent(id)}`)
+      .send({ rotateSecret: true });
+    expect(res.status).toBe(200);
+    expect(res.body.subscription.secret).toMatch(/^[a-f0-9]{64}$/);
+    expect(res.body.subscription.secret).not.toBe(original);
+  });
+
+  test("404 on missing subscription", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app)
+      .patch("/api/admin/webhooks/nonexistent")
+      .send({ enabled: false });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("SUBSCRIPTION_NOT_FOUND");
+  });
+});
+
+describe("DELETE /api/admin/webhooks/:id", () => {
+  test("204 and cascades delivery rows", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const created = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "https://example.com/x", events: ["a.b"] });
+    const id = created.body.subscription.id;
+    const del = await supertest(app).delete(`/api/admin/webhooks/${encodeURIComponent(id)}`);
+    expect(del.status).toBe(204);
+    const list = await supertest(app).get("/api/admin/webhooks");
+    expect(list.body.subscriptions).toEqual([]);
+  });
+
+  test("404 on missing subscription", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app).delete("/api/admin/webhooks/nonexistent");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/admin/webhooks/:id/test", () => {
+  test("queues a webhook.test delivery", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const created = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "https://example.com/x", events: ["webhook.test"] });
+    const id = created.body.subscription.id;
+    const res = await supertest(app).post(`/api/admin/webhooks/${encodeURIComponent(id)}/test`);
+    expect(res.status).toBe(202);
+    expect(res.body.deliveryId).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("404 on missing subscription", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app).post("/api/admin/webhooks/nonexistent/test");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/admin/webhooks/:id/deliveries", () => {
+  test("returns deliveries filtered to the subscription", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const created = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "https://example.com/x", events: ["webhook.test"] });
+    const id = created.body.subscription.id;
+    // Trigger a test delivery so there's something in the store. The
+    // actual fetch will fail (we don't have a server listening at
+    // example.com/x in tests), but the delivery row will exist.
+    await supertest(app).post(`/api/admin/webhooks/${encodeURIComponent(id)}/test`);
+    const res = await supertest(app).get(`/api/admin/webhooks/${encodeURIComponent(id)}/deliveries`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.deliveries)).toBe(true);
+    expect(res.body.deliveries.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("400 on invalid limit", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const created = await supertest(app)
+      .post("/api/admin/webhooks")
+      .send({ url: "https://example.com/x", events: ["a.b"] });
+    const id = created.body.subscription.id;
+    const res = await supertest(app).get(`/api/admin/webhooks/${encodeURIComponent(id)}/deliveries?limit=abc`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/backup-restore.integration.test.js
+++ b/tests/backup-restore.integration.test.js
@@ -118,7 +118,30 @@ function makeTempState() {
     }, null, 2)}\n`,
     "utf8"
   );
-  return { statsPath, classesPath, adminJobsPath, appConfigPath, schedulePath, projectRoot };
+  const webhooksPath = path.join(dir, "webhooks.json");
+  fs.writeFileSync(
+    webhooksPath,
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: new Date(0).toISOString(),
+      subscriptions: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  const webhookDeliveriesPath = path.join(dir, "webhook-deliveries.json");
+  fs.writeFileSync(
+    webhookDeliveriesPath,
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: new Date(0).toISOString(),
+      deliveries: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  return {
+    statsPath, classesPath, adminJobsPath, appConfigPath, schedulePath,
+    webhooksPath, webhookDeliveriesPath, projectRoot
+  };
 }
 
 function loadFreshApp(adminKey, paths, extraEnv = {}) {
@@ -129,6 +152,9 @@ function loadFreshApp(adminKey, paths, extraEnv = {}) {
   process.env.CLASSES_STORE_PATH = paths.classesPath;
   process.env.ADMIN_JOBS_STORE_PATH = paths.adminJobsPath;
   process.env.APP_CONFIG_PATH = paths.appConfigPath;
+  if (paths.schedulePath) process.env.SCHEDULE_STORE_PATH = paths.schedulePath;
+  if (paths.webhooksPath) process.env.WEBHOOKS_STORE_PATH = paths.webhooksPath;
+  if (paths.webhookDeliveriesPath) process.env.WEBHOOK_DELIVERIES_STORE_PATH = paths.webhookDeliveriesPath;
   process.env.RATE_LIMIT_MAX = "1000";
   process.env.ADMIN_RATE_LIMIT_MAX = "1000";
   process.env.ADMIN_WRITE_RATE_LIMIT_MAX = "1000";

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -41,6 +41,8 @@ async function makeProjectRoot() {
     "data/app-config.schema.json",
     "data/classes.schema.json",
     "data/schedule.schema.json",
+    "data/webhooks.schema.json",
+    "data/webhook-deliveries.schema.json",
     "data/backup-manifest.schema.json"
   ]) {
     await copyFileFromRepo(rel, dir);
@@ -100,6 +102,24 @@ async function makeProjectRoot() {
       auto_rotate: false,
       retention_days: 90,
       scheduled_words: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  await fsp.writeFile(
+    path.join(dir, "data", "webhooks.json"),
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      subscriptions: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  await fsp.writeFile(
+    path.join(dir, "data", "webhook-deliveries.json"),
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      deliveries: []
     }, null, 2)}\n`,
     "utf8"
   );

--- a/tests/webhook-delivery-store.test.js
+++ b/tests/webhook-delivery-store.test.js
@@ -193,6 +193,32 @@ describe("WebhookDeliveryStore", () => {
     expect(snap.deliveries[0].subscriptionId).toBe("sub2");
   });
 
+  test("payload cap measured in UTF-8 bytes, not UTF-16 code units", async () => {
+    // 5000 4-byte UTF-8 chars ("\u{1F4A9}") = 20000 bytes, but
+    // String.length is only 10000 (each char = 2 UTF-16 surrogates).
+    // 8 KiB cap — 20000 bytes exceeds it; old `length` check would
+    // have undercounted and let it through.
+    const massivePayload = { repeat: "\u{1F4A9}".repeat(5000) };
+    const d = await store.enqueue({
+      subscriptionId: "sub1",
+      event: "a.b",
+      payload: massivePayload
+    });
+    expect(d.payload).toBeUndefined();
+  });
+
+  test("payload at cap boundary is preserved", async () => {
+    // 1000 ASCII chars (1 byte each) → 1000 bytes serialized
+    // (plus the JSON object framing of a couple bytes), well under 8 KiB.
+    const small = { msg: "x".repeat(1000) };
+    const d = await store.enqueue({
+      subscriptionId: "sub1",
+      event: "a.b",
+      payload: small
+    });
+    expect(d.payload).toEqual(small);
+  });
+
   test("update clears lastError when patch is empty string", async () => {
     const d = await store.enqueue({ subscriptionId: "sub1", event: "a.b" });
     const e1 = await store.update(d.id, { lastError: "Boom" });

--- a/tests/webhook-delivery-store.test.js
+++ b/tests/webhook-delivery-store.test.js
@@ -97,18 +97,52 @@ describe("WebhookDeliveryStore", () => {
     expect(updated.nextAttemptAt).toBeUndefined();
   });
 
-  test("retention cap evicts oldest deliveries when count exceeds max", async () => {
+  test("retention cap evicts oldest TERMINAL deliveries when count exceeds max", async () => {
     let now = new Date("2026-05-08T00:00:00.000Z");
     store.now = () => now;
+    const ids = [];
     for (let i = 0; i < 8; i++) {
       now = new Date(now.getTime() + 1000);
-      await store.enqueue({ subscriptionId: "sub1", event: `evt.${i}` });
+      const d = await store.enqueue({ subscriptionId: "sub1", event: `evt.${i}` });
+      ids.push(d.id);
+    }
+    // Mark all as terminal so retention can evict freely.
+    for (const id of ids) {
+      await store.update(id, { status: "succeeded" });
     }
     const snap = await store.load();
     expect(snap.deliveries).toHaveLength(5); // historyMax
     // The oldest 3 (evt.0, evt.1, evt.2) should be evicted.
     const remainingEvents = snap.deliveries.map((d) => d.event);
     expect(remainingEvents).toEqual(["evt.3", "evt.4", "evt.5", "evt.6", "evt.7"]);
+  });
+
+  test("retention preserves queued/running rows even when over cap", async () => {
+    let now = new Date("2026-05-08T00:00:00.000Z");
+    store.now = () => now;
+    // 6 succeeded (terminal) plus 4 queued (active) → total 10, cap is 5.
+    // Eviction must touch ONLY succeeded rows; queued rows must survive
+    // because their timer is still pending in-process.
+    const succeededIds = [];
+    const queuedIds = [];
+    for (let i = 0; i < 6; i++) {
+      now = new Date(now.getTime() + 1000);
+      const d = await store.enqueue({ subscriptionId: "sub1", event: `done.${i}` });
+      await store.update(d.id, { status: "succeeded" });
+      succeededIds.push(d.id);
+    }
+    for (let i = 0; i < 4; i++) {
+      now = new Date(now.getTime() + 1000);
+      const d = await store.enqueue({ subscriptionId: "sub1", event: `pend.${i}` });
+      queuedIds.push(d.id);
+    }
+    const snap = await store.load();
+    const ids = snap.deliveries.map((d) => d.id);
+    // All 4 queued rows must still be present.
+    for (const qid of queuedIds) expect(ids).toContain(qid);
+    // The file holds queued (4) + at least 1 surviving succeeded
+    // (5 total = historyMax). Some succeeded rows are evicted.
+    expect(snap.deliveries.length).toBeGreaterThanOrEqual(5);
   });
 
   test("findRecent reverses order so newest comes first", async () => {

--- a/tests/webhook-delivery-store.test.js
+++ b/tests/webhook-delivery-store.test.js
@@ -1,0 +1,169 @@
+"use strict";
+
+const fs = require("fs");
+const fsp = require("fs/promises");
+const os = require("os");
+const path = require("path");
+
+const {
+  WebhookDeliveryStore,
+  generateDeliveryId,
+  normalizeDelivery,
+  STATUSES
+} = require("../lib/webhook-delivery-store");
+
+function tempPath(name = "webhook-deliveries.json") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-deliv-"));
+  return path.join(dir, name);
+}
+
+function frozenNow(iso = "2026-05-08T00:00:00.000Z") {
+  return () => new Date(iso);
+}
+
+describe("webhook-delivery-store helpers", () => {
+  test("generateDeliveryId returns a base64url id", () => {
+    const id = generateDeliveryId();
+    expect(id).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(id.length).toBeGreaterThanOrEqual(20);
+  });
+
+  test("STATUSES contains all expected values", () => {
+    expect(STATUSES).toEqual(["queued", "running", "succeeded", "failed", "canceled"]);
+  });
+
+  test("normalizeDelivery rejects invalid status", () => {
+    expect(() => normalizeDelivery({
+      id: "abc",
+      subscriptionId: "sub1",
+      event: "a.b",
+      status: "weird",
+      attempts: 0,
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z"
+    })).toThrow(expect.objectContaining({ code: "INVALID_DELIVERY" }));
+  });
+
+  test("normalizeDelivery clamps responseSnippet", () => {
+    const out = normalizeDelivery({
+      id: "abc",
+      subscriptionId: "sub1",
+      event: "a.b",
+      status: "succeeded",
+      attempts: 1,
+      responseSnippet: "x".repeat(8000),
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z"
+    });
+    expect(out.responseSnippet.length).toBe(4096);
+  });
+});
+
+describe("WebhookDeliveryStore", () => {
+  let store;
+  let filePath;
+
+  beforeEach(() => {
+    filePath = tempPath();
+    store = new WebhookDeliveryStore({ filePath, now: frozenNow(), historyMax: 5 });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(path.dirname(filePath), { recursive: true, force: true });
+  });
+
+  test("enqueue creates a queued row", async () => {
+    const delivery = await store.enqueue({
+      subscriptionId: "sub1",
+      event: "a.b",
+      url: "https://example.com"
+    });
+    expect(delivery.status).toBe("queued");
+    expect(delivery.attempts).toBe(0);
+    expect(delivery.subscriptionId).toBe("sub1");
+    expect(delivery.event).toBe("a.b");
+    expect(delivery.url).toBe("https://example.com");
+  });
+
+  test("update moves to running with attempts and clears nextAttemptAt", async () => {
+    const d = await store.enqueue({ subscriptionId: "sub1", event: "a.b" });
+    const updated = await store.update(d.id, {
+      status: "running",
+      attempts: 1,
+      nextAttemptAt: null
+    });
+    expect(updated.status).toBe("running");
+    expect(updated.attempts).toBe(1);
+    expect(updated.nextAttemptAt).toBeUndefined();
+  });
+
+  test("retention cap evicts oldest deliveries when count exceeds max", async () => {
+    let now = new Date("2026-05-08T00:00:00.000Z");
+    store.now = () => now;
+    for (let i = 0; i < 8; i++) {
+      now = new Date(now.getTime() + 1000);
+      await store.enqueue({ subscriptionId: "sub1", event: `evt.${i}` });
+    }
+    const snap = await store.load();
+    expect(snap.deliveries).toHaveLength(5); // historyMax
+    // The oldest 3 (evt.0, evt.1, evt.2) should be evicted.
+    const remainingEvents = snap.deliveries.map((d) => d.event);
+    expect(remainingEvents).toEqual(["evt.3", "evt.4", "evt.5", "evt.6", "evt.7"]);
+  });
+
+  test("findRecent reverses order so newest comes first", async () => {
+    let now = new Date("2026-05-08T00:00:00.000Z");
+    store.now = () => now;
+    for (let i = 0; i < 3; i++) {
+      now = new Date(now.getTime() + 1000);
+      await store.enqueue({ subscriptionId: "sub1", event: `evt.${i}` });
+    }
+    const recent = await store.findRecent({ subscriptionId: "sub1", limit: 2 });
+    expect(recent).toHaveLength(2);
+    expect(recent[0].event).toBe("evt.2");
+    expect(recent[1].event).toBe("evt.1");
+  });
+
+  test("findRecent filters by status and event", async () => {
+    const d1 = await store.enqueue({ subscriptionId: "sub1", event: "a.b" });
+    const d2 = await store.enqueue({ subscriptionId: "sub1", event: "c.d" });
+    await store.update(d1.id, { status: "succeeded" });
+    await store.update(d2.id, { status: "failed" });
+    const succeeded = await store.findRecent({ subscriptionId: "sub1", status: "succeeded" });
+    expect(succeeded).toHaveLength(1);
+    expect(succeeded[0].id).toBe(d1.id);
+    const cd = await store.findRecent({ subscriptionId: "sub1", event: "c.d" });
+    expect(cd).toHaveLength(1);
+    expect(cd[0].id).toBe(d2.id);
+  });
+
+  test("findRecoverable returns running and queued only", async () => {
+    const queued = await store.enqueue({ subscriptionId: "sub1", event: "a.b" });
+    const running = await store.enqueue({ subscriptionId: "sub1", event: "c.d" });
+    const succeeded = await store.enqueue({ subscriptionId: "sub1", event: "e.f" });
+    await store.update(running.id, { status: "running" });
+    await store.update(succeeded.id, { status: "succeeded" });
+    const recoverable = await store.findRecoverable();
+    const ids = recoverable.map((d) => d.id).sort();
+    expect(ids).toEqual([queued.id, running.id].sort());
+  });
+
+  test("deleteForSubscription removes only that subscription's rows", async () => {
+    await store.enqueue({ subscriptionId: "sub1", event: "a.b" });
+    await store.enqueue({ subscriptionId: "sub1", event: "c.d" });
+    await store.enqueue({ subscriptionId: "sub2", event: "a.b" });
+    const removed = await store.deleteForSubscription("sub1");
+    expect(removed).toBe(2);
+    const snap = await store.load();
+    expect(snap.deliveries).toHaveLength(1);
+    expect(snap.deliveries[0].subscriptionId).toBe("sub2");
+  });
+
+  test("update clears lastError when patch is empty string", async () => {
+    const d = await store.enqueue({ subscriptionId: "sub1", event: "a.b" });
+    const e1 = await store.update(d.id, { lastError: "Boom" });
+    expect(e1.lastError).toBe("Boom");
+    const e2 = await store.update(d.id, { lastError: "" });
+    expect(e2.lastError).toBeUndefined();
+  });
+});

--- a/tests/webhook-service.test.js
+++ b/tests/webhook-service.test.js
@@ -154,12 +154,14 @@ describe("SSRF guard (isPrivateIPv4 / isPrivateIPv6 / assertOutboundUrlAllowed)"
 
   test("assertOutboundUrlAllowed permits any address when allowPrivateNetworks=true", async () => {
     const out = await assertOutboundUrlAllowed("http://10.0.0.1/webhook", { allowPrivateNetworks: true });
-    expect(out.hostname).toBe("10.0.0.1");
+    expect(out.url.hostname).toBe("10.0.0.1");
+    expect(out.addresses).toBe(null);
   });
 
   test("assertOutboundUrlAllowed accepts public IP literal", async () => {
     const out = await assertOutboundUrlAllowed("https://1.1.1.1/x");
-    expect(out.hostname).toBe("1.1.1.1");
+    expect(out.url.hostname).toBe("1.1.1.1");
+    expect(out.addresses).toEqual([{ address: "1.1.1.1", family: 4 }]);
   });
 });
 
@@ -340,6 +342,122 @@ describe("WebhookService.emit + executeOnce", () => {
       return d && d.status === "failed";
     }, { timeoutMs: 5000 });
     expect(calls).toBe(2);
+  });
+});
+
+describe("Subscription edits between attempts", () => {
+  test("retry honors a fresh URL after the operator edited the subscription mid-flight", async () => {
+    const calls = [];
+    const fetchImpl = async (url) => {
+      calls.push(url);
+      if (calls.length === 1) {
+        return {
+          status: 500,
+          headers: { get: () => null },
+          body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+        };
+      }
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({
+      fetchImpl,
+      // Bigger backoff so the update lands deterministically between
+      // attempts instead of racing the timer.
+      backoffSchedule: [200, 200, 200]
+    });
+    const sub = await subs.create({
+      url: "https://old.example/",
+      events: ["a.b"],
+      maxAttempts: 3
+    });
+    await svc.emit("a.b", { foo: 1 });
+    // Wait until the delivery row reaches `queued` with a scheduled
+    // next-attempt — that's the retry timer phase, when an admin edit
+    // is meant to be observed by the next executeOnce.
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && d.status === "queued" && d.nextAttemptAt;
+    });
+    await subs.update(sub.id, { url: "https://new.example/" });
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && d.status === "succeeded";
+    }, { timeoutMs: 5000 });
+    expect(calls).toEqual(["https://old.example/", "https://new.example/"]);
+  });
+
+  test("rotated secret is used for retries, not the original", async () => {
+    const sigs = [];
+    const fetchImpl = async (url, init) => {
+      sigs.push(init.headers["x-webhook-signature"]);
+      if (sigs.length === 1) {
+        return {
+          status: 500,
+          headers: { get: () => null },
+          body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+        };
+      }
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({
+      fetchImpl,
+      backoffSchedule: [200, 200, 200]
+    });
+    const sub = await subs.create({
+      url: "https://example.com/",
+      events: ["a.b"],
+      maxAttempts: 3
+    });
+    await svc.emit("a.b", {});
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && d.status === "queued" && d.nextAttemptAt;
+    });
+    await subs.update(sub.id, { rotateSecret: true });
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && d.status === "succeeded";
+    }, { timeoutMs: 5000 });
+    expect(sigs[0]).not.toBe(sigs[1]);
+  });
+});
+
+describe("Persisted payload survives recovery", () => {
+  test("recoverOnBoot uses the persisted payload, not an empty object", async () => {
+    const bodies = [];
+    const fetchImpl = async (url, init) => {
+      bodies.push(init.body);
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({ fetchImpl });
+    const sub = await subs.create({ url: "https://example.com/", events: ["a.b"] });
+    // Manually persist a row that mimics what emit() writes pre-restart.
+    const stuck = await deliveries.enqueue({
+      subscriptionId: sub.id,
+      event: "a.b",
+      url: sub.url,
+      payload: { reconstructed: true, n: 42 }
+    });
+    await deliveries.update(stuck.id, { status: "running", attempts: 1 });
+    await svc.recoverOnBoot();
+    await waitForCondition(async () => {
+      const d = await deliveries.findById(stuck.id);
+      return d && d.status === "succeeded";
+    });
+    const sent = JSON.parse(bodies[0]);
+    expect(sent.payload).toEqual({ reconstructed: true, n: 42 });
   });
 });
 

--- a/tests/webhook-service.test.js
+++ b/tests/webhook-service.test.js
@@ -1,0 +1,451 @@
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const nodeCrypto = require("node:crypto");
+
+const {
+  WebhookService,
+  signPayload,
+  parseRetryAfterHeader,
+  classifyHttpStatus,
+  isPrivateIPv4,
+  isPrivateIPv6,
+  assertOutboundUrlAllowed,
+  nextBackoffMs,
+  DEFAULT_BACKOFF_MS
+} = require("../lib/webhook-service");
+
+const { WebhookStore } = require("../lib/webhook-store");
+const { WebhookDeliveryStore } = require("../lib/webhook-delivery-store");
+
+function tempPaths() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-svc-"));
+  return {
+    dir,
+    subs: path.join(dir, "webhooks.json"),
+    deliveries: path.join(dir, "webhook-deliveries.json")
+  };
+}
+
+async function buildService(extra = {}) {
+  const paths = tempPaths();
+  const subs = new WebhookStore({ filePath: paths.subs });
+  const deliveries = new WebhookDeliveryStore({ filePath: paths.deliveries });
+  const svc = new WebhookService({
+    subscriptionStore: subs,
+    deliveryStore: deliveries,
+    enabled: true,
+    backoffSchedule: [10, 20, 30],
+    timeoutMs: 500,
+    fetchImpl: extra.fetchImpl,
+    allowPrivateNetworks: true,
+    logger: { warn: () => {}, error: () => {}, log: () => {} },
+    ...extra
+  });
+  return { svc, subs, deliveries, dir: paths.dir };
+}
+
+async function waitForCondition(predicate, { timeoutMs = 1500, intervalMs = 10 } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error("waitForCondition timed out");
+}
+
+describe("signature + helper functions", () => {
+  test("signPayload produces deterministic HMAC-SHA-256", () => {
+    const sig = signPayload("hello", "secret");
+    const expected = nodeCrypto.createHmac("sha256", "secret").update("hello").digest("hex");
+    expect(sig).toBe(`sha256=${expected}`);
+  });
+
+  test("parseRetryAfterHeader parses numeric seconds", () => {
+    expect(parseRetryAfterHeader("30", new Date())).toBe(30000);
+    expect(parseRetryAfterHeader("0", new Date())).toBe(0);
+  });
+
+  test("parseRetryAfterHeader parses HTTP-date and clamps negatives to 0", () => {
+    const now = new Date("2026-05-08T00:00:00.000Z");
+    const future = new Date("2026-05-08T00:00:30.000Z").toUTCString();
+    expect(parseRetryAfterHeader(future, now)).toBe(30000);
+    const past = new Date("2026-05-07T00:00:00.000Z").toUTCString();
+    expect(parseRetryAfterHeader(past, now)).toBe(0);
+  });
+
+  test("parseRetryAfterHeader returns null for unparseable values", () => {
+    expect(parseRetryAfterHeader("not-a-date", new Date())).toBe(null);
+    expect(parseRetryAfterHeader("", new Date())).toBe(null);
+    expect(parseRetryAfterHeader(null, new Date())).toBe(null);
+  });
+
+  test("classifyHttpStatus categorises 2xx success, 4xx non-retriable, 5xx retriable", () => {
+    expect(classifyHttpStatus(200)).toEqual({ ok: true, retriable: false });
+    expect(classifyHttpStatus(204)).toEqual({ ok: true, retriable: false });
+    expect(classifyHttpStatus(400)).toEqual({ ok: false, retriable: false });
+    expect(classifyHttpStatus(404)).toEqual({ ok: false, retriable: false });
+    expect(classifyHttpStatus(408)).toEqual({ ok: false, retriable: true });
+    expect(classifyHttpStatus(429)).toEqual({ ok: false, retriable: true });
+    expect(classifyHttpStatus(500)).toEqual({ ok: false, retriable: true });
+    expect(classifyHttpStatus(502)).toEqual({ ok: false, retriable: true });
+  });
+
+  test("nextBackoffMs uses schedule index and caps at last slot", () => {
+    expect(nextBackoffMs(1)).toBe(DEFAULT_BACKOFF_MS[0]);
+    expect(nextBackoffMs(5)).toBe(DEFAULT_BACKOFF_MS[4]);
+    expect(nextBackoffMs(99)).toBe(DEFAULT_BACKOFF_MS[4]);
+  });
+});
+
+describe("SSRF guard (isPrivateIPv4 / isPrivateIPv6 / assertOutboundUrlAllowed)", () => {
+  test.each([
+    "10.0.0.1",
+    "172.16.0.1",
+    "172.31.255.255",
+    "192.168.1.1",
+    "127.0.0.1",
+    "169.254.169.254",
+    "0.0.0.0"
+  ])("isPrivateIPv4 flags %s as private", (ip) => {
+    expect(isPrivateIPv4(ip)).toBe(true);
+  });
+
+  test.each([
+    "8.8.8.8",
+    "1.1.1.1",
+    "172.32.0.1",
+    "172.15.0.1",
+    "11.0.0.0"
+  ])("isPrivateIPv4 accepts %s as public", (ip) => {
+    expect(isPrivateIPv4(ip)).toBe(false);
+  });
+
+  test.each([
+    "::1",
+    "fe80::1",
+    "fc00::1",
+    "fd00::1",
+    "::ffff:127.0.0.1"
+  ])("isPrivateIPv6 flags %s as private", (ip) => {
+    expect(isPrivateIPv6(ip)).toBe(true);
+  });
+
+  test.each([
+    "2606:4700::1",
+    "2001:4860:4860::8888"
+  ])("isPrivateIPv6 accepts %s as public", (ip) => {
+    expect(isPrivateIPv6(ip)).toBe(false);
+  });
+
+  test("assertOutboundUrlAllowed rejects ftp://", async () => {
+    await expect(assertOutboundUrlAllowed("ftp://example.com")).rejects.toThrow(
+      expect.objectContaining({ code: "INVALID_URL" })
+    );
+  });
+
+  test("assertOutboundUrlAllowed rejects literal private IPv4 by default", async () => {
+    await expect(assertOutboundUrlAllowed("http://10.0.0.1/webhook")).rejects.toThrow(
+      expect.objectContaining({ code: "PRIVATE_ADDRESS_BLOCKED" })
+    );
+  });
+
+  test("assertOutboundUrlAllowed permits any address when allowPrivateNetworks=true", async () => {
+    const out = await assertOutboundUrlAllowed("http://10.0.0.1/webhook", { allowPrivateNetworks: true });
+    expect(out.hostname).toBe("10.0.0.1");
+  });
+
+  test("assertOutboundUrlAllowed accepts public IP literal", async () => {
+    const out = await assertOutboundUrlAllowed("https://1.1.1.1/x");
+    expect(out.hostname).toBe("1.1.1.1");
+  });
+});
+
+describe("WebhookService.emit + executeOnce", () => {
+  test("emit signs the payload and POSTs to the subscription URL", async () => {
+    const calls = [];
+    const fetchImpl = async (url, init) => {
+      calls.push({ url, init });
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({ fetchImpl });
+    const sub = await subs.create({
+      url: "https://example.com/webhook",
+      events: ["test.event"]
+    });
+    await svc.emit("test.event", { foo: "bar" });
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && d.status === "succeeded";
+    });
+    expect(calls).toHaveLength(1);
+    const headers = calls[0].init.headers;
+    expect(headers["x-webhook-signature"]).toMatch(/^sha256=[a-f0-9]{64}$/);
+    expect(headers["x-webhook-event"]).toBe("test.event");
+    expect(headers["x-webhook-attempt"]).toBe("1");
+    const body = JSON.parse(calls[0].init.body);
+    expect(body.event).toBe("test.event");
+    expect(body.payload).toEqual({ foo: "bar" });
+    // Verify signature
+    const expectedSig = signPayload(calls[0].init.body, sub.secret);
+    expect(headers["x-webhook-signature"]).toBe(expectedSig);
+  });
+
+  test("emit only delivers to subscriptions enabled for this event", async () => {
+    const calls = [];
+    const fetchImpl = async (url) => {
+      calls.push(url);
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({ fetchImpl });
+    await subs.create({ url: "https://a.example/", events: ["test.event"] });
+    await subs.create({ url: "https://b.example/", events: ["other.event"] });
+    await subs.create({ url: "https://c.example/", events: ["test.event"], enabled: false });
+    await svc.emit("test.event", {});
+    await waitForCondition(async () => {
+      const all = (await deliveries.load()).deliveries;
+      return all.length === 1 && all[0].status === "succeeded";
+    });
+    expect(calls).toEqual(["https://a.example/"]);
+  });
+
+  test("retriable HTTP 500 schedules a retry, then succeeds on the second attempt", async () => {
+    let attempts = 0;
+    const fetchImpl = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return {
+          status: 500,
+          headers: { get: () => null },
+          body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+        };
+      }
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({ fetchImpl });
+    const sub = await subs.create({
+      url: "https://example.com/webhook",
+      events: ["test.event"],
+      maxAttempts: 3
+    });
+    await svc.emit("test.event", {});
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && d.status === "succeeded";
+    });
+    expect(attempts).toBe(2);
+  });
+
+  test("non-retriable HTTP 400 marks delivery as failed without retrying", async () => {
+    let attempts = 0;
+    const fetchImpl = async () => {
+      attempts += 1;
+      return {
+        status: 400,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({ fetchImpl });
+    const sub = await subs.create({
+      url: "https://example.com/webhook",
+      events: ["test.event"],
+      maxAttempts: 3
+    });
+    await svc.emit("test.event", {});
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && d.status === "failed";
+    });
+    expect(attempts).toBe(1);
+  });
+
+  test("hitting maxAttempts marks delivery as failed", async () => {
+    const fetchImpl = async () => ({
+      status: 500,
+      headers: { get: () => null },
+      body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+    });
+    const { svc, subs, deliveries } = await buildService({ fetchImpl });
+    const sub = await subs.create({
+      url: "https://example.com/webhook",
+      events: ["test.event"],
+      maxAttempts: 2
+    });
+    await svc.emit("test.event", {});
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && d.status === "failed";
+    });
+    const final = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+    expect(final.attempts).toBe(2);
+    expect(final.lastError).toMatch(/HTTP 500/);
+  });
+
+  test("disabled service does not enqueue any deliveries", async () => {
+    const fetchImpl = async () => ({
+      status: 200,
+      headers: { get: () => null },
+      body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+    });
+    const { svc, subs, deliveries } = await buildService({ fetchImpl, enabled: false });
+    await subs.create({ url: "https://example.com/", events: ["test.event"] });
+    const out = await svc.emit("test.event", {});
+    expect(out).toEqual([]);
+    const all = (await deliveries.load()).deliveries;
+    expect(all).toEqual([]);
+  });
+
+  test("Retry-After header inflates the backoff", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return {
+        status: 429,
+        headers: {
+          get: (name) => (name.toLowerCase() === "retry-after" ? "1" : null)
+        },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({
+      fetchImpl,
+      backoffSchedule: [10, 10, 10] // small, but Retry-After=1 (1000ms) should win
+    });
+    const sub = await subs.create({
+      url: "https://example.com/webhook",
+      events: ["test.event"],
+      maxAttempts: 2
+    });
+    await svc.emit("test.event", {});
+    // First attempt is immediate; second is delayed by ~1000ms (Retry-After).
+    // After both fail (429 → 429), status should be `failed`. We just check
+    // that the delivery eventually fails AND that calls reached maxAttempts.
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && d.status === "failed";
+    }, { timeoutMs: 5000 });
+    expect(calls).toBe(2);
+  });
+});
+
+describe("WebhookService.recoverOnBoot", () => {
+  test("requeues `running` deliveries left over from a crash", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({ fetchImpl });
+    const sub = await subs.create({ url: "https://example.com/", events: ["a.b"] });
+    // Manually create a stuck `running` delivery.
+    const stuck = await deliveries.enqueue({ subscriptionId: sub.id, event: "a.b" });
+    await deliveries.update(stuck.id, { status: "running", attempts: 1 });
+    const recovered = await svc.recoverOnBoot();
+    expect(recovered).toBe(1);
+    await waitForCondition(async () => {
+      const d = await deliveries.findById(stuck.id);
+      return d && d.status === "succeeded";
+    });
+    expect(calls).toBe(1);
+  });
+
+  test("schedules `queued` deliveries with persisted nextAttemptAt", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({ fetchImpl });
+    const sub = await subs.create({ url: "https://example.com/", events: ["a.b"] });
+    const queued = await deliveries.enqueue({
+      subscriptionId: sub.id,
+      event: "a.b",
+      nextAttemptAt: new Date(Date.now() - 1000).toISOString() // already due
+    });
+    const recovered = await svc.recoverOnBoot();
+    expect(recovered).toBe(1);
+    await waitForCondition(async () => {
+      const d = await deliveries.findById(queued.id);
+      return d && d.status === "succeeded";
+    });
+    expect(calls).toBe(1);
+  });
+
+  test("disabled service skips recovery", async () => {
+    const { svc } = await buildService({ enabled: false });
+    expect(await svc.recoverOnBoot()).toBe(0);
+  });
+});
+
+describe("WebhookService.retryDelivery", () => {
+  test("requeues a failed delivery and marks it queued before send", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({ fetchImpl });
+    const sub = await subs.create({ url: "https://example.com/", events: ["a.b"] });
+    const d = await deliveries.enqueue({ subscriptionId: sub.id, event: "a.b" });
+    await deliveries.update(d.id, { status: "failed", lastError: "Boom" });
+    const retried = await svc.retryDelivery(d.id);
+    expect(retried.status).toBe("queued");
+    await waitForCondition(async () => {
+      const x = await deliveries.findById(d.id);
+      return x && x.status === "succeeded";
+    });
+    expect(calls).toBe(1);
+  });
+
+  test("non-failed delivery is returned unchanged", async () => {
+    const { svc, subs, deliveries } = await buildService();
+    const sub = await subs.create({ url: "https://example.com/", events: ["a.b"] });
+    const d = await deliveries.enqueue({ subscriptionId: sub.id, event: "a.b" });
+    await deliveries.update(d.id, { status: "succeeded" });
+    const retried = await svc.retryDelivery(d.id);
+    expect(retried.status).toBe("succeeded");
+  });
+});
+
+describe("WebhookService.shutdown", () => {
+  test("clears scheduled timers and prevents further work", async () => {
+    const fetchImpl = async () => {
+      throw new Error("should not have been called");
+    };
+    const { svc, subs } = await buildService({ fetchImpl, backoffSchedule: [60_000] });
+    await subs.create({ url: "https://example.com/", events: ["a.b"] });
+    // Schedule a delivery far enough out that it won't fire before shutdown.
+    svc.scheduleDelivery("nonexistent-id", 60_000, { event: "a.b", payload: {} });
+    expect(svc.scheduledTimers.size).toBeGreaterThan(0);
+    svc.shutdown();
+    expect(svc.scheduledTimers.size).toBe(0);
+    expect(svc.shutdownRequested).toBe(true);
+  });
+});

--- a/tests/webhook-service.test.js
+++ b/tests/webhook-service.test.js
@@ -125,6 +125,7 @@ describe("SSRF guard (isPrivateIPv4 / isPrivateIPv6 / assertOutboundUrlAllowed)"
 
   test.each([
     "::1",
+    "::",
     "fe80::1",
     "fc00::1",
     "fd00::1",

--- a/tests/webhook-store.test.js
+++ b/tests/webhook-store.test.js
@@ -1,0 +1,275 @@
+"use strict";
+
+const fs = require("fs");
+const fsp = require("fs/promises");
+const os = require("os");
+const path = require("path");
+
+const {
+  WebhookStore,
+  generateSubscriptionId,
+  generateSecret,
+  redactSecret,
+  normalizeSubscription,
+  normalizeStore
+} = require("../lib/webhook-store");
+
+function tempPath(name = "webhooks.json") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-webhooks-"));
+  return path.join(dir, name);
+}
+
+function frozenNow(iso = "2026-05-08T00:00:00.000Z") {
+  return () => new Date(iso);
+}
+
+describe("webhook-store helpers", () => {
+  test("generateSubscriptionId returns a 22-char base64url string", () => {
+    const id = generateSubscriptionId();
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThanOrEqual(20);
+    expect(id).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("generateSecret returns a 64-char hex string", () => {
+    const secret = generateSecret();
+    expect(secret).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("redactSecret strips the secret field", () => {
+    const sub = {
+      id: "abc",
+      url: "https://example.com",
+      events: ["x.y"],
+      enabled: true,
+      secret: "deadbeef",
+      maxAttempts: 5,
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z"
+    };
+    const out = redactSecret(sub);
+    expect(out.secret).toBeUndefined();
+    expect(out.id).toBe("abc");
+    // Original is not mutated
+    expect(sub.secret).toBe("deadbeef");
+  });
+
+  test("normalizeSubscription rejects invalid URL scheme", () => {
+    expect(() => normalizeSubscription({
+      id: "abc",
+      url: "ftp://bad.example.com",
+      events: ["x.y"],
+      enabled: true,
+      secret: "a".repeat(32),
+      maxAttempts: 5,
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z"
+    })).toThrow(expect.objectContaining({ code: "INVALID_URL" }));
+  });
+
+  test("normalizeSubscription rejects empty events array", () => {
+    expect(() => normalizeSubscription({
+      id: "abc",
+      url: "https://example.com",
+      events: [],
+      enabled: true,
+      secret: "a".repeat(32),
+      maxAttempts: 5,
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z"
+    })).toThrow(expect.objectContaining({ code: "INVALID_EVENTS" }));
+  });
+
+  test("normalizeSubscription rejects events that don't match the pattern", () => {
+    expect(() => normalizeSubscription({
+      id: "abc",
+      url: "https://example.com",
+      events: ["UPPERCASE"],
+      enabled: true,
+      secret: "a".repeat(32),
+      maxAttempts: 5,
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z"
+    })).toThrow(expect.objectContaining({ code: "INVALID_EVENTS" }));
+  });
+
+  test("normalizeSubscription deduplicates events", () => {
+    const out = normalizeSubscription({
+      id: "abc",
+      url: "https://example.com",
+      events: ["a.b", "a.b", "c.d"],
+      enabled: true,
+      secret: "a".repeat(32),
+      maxAttempts: 5,
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z"
+    });
+    expect(out.events).toEqual(["a.b", "c.d"]);
+  });
+
+  test("normalizeSubscription rejects out-of-range maxAttempts", () => {
+    expect(() => normalizeSubscription({
+      id: "abc",
+      url: "https://example.com",
+      events: ["x.y"],
+      enabled: true,
+      secret: "a".repeat(32),
+      maxAttempts: 0,
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z"
+    })).toThrow(expect.objectContaining({ code: "INVALID_MAX_ATTEMPTS" }));
+    expect(() => normalizeSubscription({
+      id: "abc",
+      url: "https://example.com",
+      events: ["x.y"],
+      enabled: true,
+      secret: "a".repeat(32),
+      maxAttempts: 25,
+      createdAt: "2026-05-08T00:00:00.000Z",
+      updatedAt: "2026-05-08T00:00:00.000Z"
+    })).toThrow(expect.objectContaining({ code: "INVALID_MAX_ATTEMPTS" }));
+  });
+
+  test("normalizeStore drops duplicate ids and sorts by createdAt", () => {
+    const out = normalizeStore({
+      version: 1,
+      updatedAt: "2026-05-08T00:00:00.000Z",
+      subscriptions: [
+        {
+          id: "second",
+          url: "https://b.example.com",
+          events: ["x.y"],
+          enabled: true,
+          secret: "a".repeat(32),
+          maxAttempts: 5,
+          createdAt: "2026-05-08T00:00:00.000Z",
+          updatedAt: "2026-05-08T00:00:00.000Z"
+        },
+        {
+          id: "first",
+          url: "https://a.example.com",
+          events: ["x.y"],
+          enabled: true,
+          secret: "a".repeat(32),
+          maxAttempts: 5,
+          createdAt: "2026-05-07T00:00:00.000Z",
+          updatedAt: "2026-05-07T00:00:00.000Z"
+        },
+        {
+          id: "first",
+          url: "https://duplicate.example.com",
+          events: ["x.y"],
+          enabled: true,
+          secret: "a".repeat(32),
+          maxAttempts: 5,
+          createdAt: "2026-05-06T00:00:00.000Z",
+          updatedAt: "2026-05-06T00:00:00.000Z"
+        }
+      ]
+    });
+    expect(out.subscriptions.map((s) => s.id)).toEqual(["first", "second"]);
+    // first dedup-by-id wins (insertion order)
+    expect(out.subscriptions[0].url).toBe("https://a.example.com");
+  });
+});
+
+describe("WebhookStore CRUD", () => {
+  let store;
+  let filePath;
+
+  beforeEach(() => {
+    filePath = tempPath();
+    store = new WebhookStore({ filePath, now: frozenNow(), defaultMaxAttempts: 5 });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(path.dirname(filePath), { recursive: true, force: true });
+  });
+
+  test("first load creates an empty store on disk", async () => {
+    const snap = await store.load();
+    expect(snap.subscriptions).toEqual([]);
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  test("create persists a new subscription with secret", async () => {
+    const created = await store.create({
+      url: "https://example.com/webhook",
+      events: ["provider.import.completed"]
+    });
+    expect(created.id).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(created.secret).toMatch(/^[a-f0-9]{64}$/);
+    expect(created.maxAttempts).toBe(5);
+    expect(created.enabled).toBe(true);
+    const reloaded = new WebhookStore({ filePath });
+    const snap = await reloaded.load();
+    expect(snap.subscriptions).toHaveLength(1);
+    expect(snap.subscriptions[0].id).toBe(created.id);
+  });
+
+  test("create rejects invalid URL", async () => {
+    await expect(store.create({
+      url: "not-a-url",
+      events: ["a.b"]
+    })).rejects.toThrow(expect.objectContaining({ code: "INVALID_URL" }));
+  });
+
+  test("update merges fields and bumps updatedAt", async () => {
+    const created = await store.create({ url: "https://example.com", events: ["a.b"] });
+    store.now = () => new Date("2026-05-09T00:00:00.000Z");
+    const updated = await store.update(created.id, { enabled: false, label: "Test" });
+    expect(updated.enabled).toBe(false);
+    expect(updated.label).toBe("Test");
+    expect(updated.updatedAt).toBe("2026-05-09T00:00:00.000Z");
+    expect(updated.secret).toBe(created.secret); // unchanged
+  });
+
+  test("update with rotateSecret issues a fresh secret", async () => {
+    const created = await store.create({ url: "https://example.com", events: ["a.b"] });
+    const rotated = await store.update(created.id, { rotateSecret: true });
+    expect(rotated.secret).not.toBe(created.secret);
+    expect(rotated.secret).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("update on missing id throws SUBSCRIPTION_NOT_FOUND", async () => {
+    await expect(store.update("nonexistent", { enabled: false })).rejects.toThrow(
+      expect.objectContaining({ code: "SUBSCRIPTION_NOT_FOUND" })
+    );
+  });
+
+  test("remove drops the subscription", async () => {
+    const a = await store.create({ url: "https://a.example", events: ["a.b"] });
+    const b = await store.create({ url: "https://b.example", events: ["a.b"] });
+    await store.remove(a.id);
+    const snap = await store.load();
+    expect(snap.subscriptions.map((s) => s.id)).toEqual([b.id]);
+  });
+
+  test("findEnabledForEvent filters by event and enabled flag", async () => {
+    await store.create({ url: "https://a.example", events: ["a.b"] });
+    await store.create({ url: "https://b.example", events: ["a.b", "c.d"], enabled: false });
+    await store.create({ url: "https://c.example", events: ["c.d"] });
+    const subs = await store.findEnabledForEvent("a.b");
+    expect(subs).toHaveLength(1);
+    expect(subs[0].url).toBe("https://a.example");
+  });
+
+  test("concurrent create + remove are serialized via commitQueue", async () => {
+    const first = await store.create({ url: "https://a.example", events: ["a.b"] });
+    const op1 = store.create({ url: "https://b.example", events: ["a.b"] });
+    const op2 = store.remove(first.id);
+    await Promise.all([op1, op2]);
+    const snap = await store.load();
+    expect(snap.subscriptions).toHaveLength(1);
+    expect(snap.subscriptions[0].url).toBe("https://b.example");
+  });
+
+  test("reload picks up an out-of-band file edit", async () => {
+    await store.create({ url: "https://a.example", events: ["a.b"] });
+    const raw = JSON.parse(await fsp.readFile(filePath, "utf8"));
+    raw.subscriptions[0].url = "https://changed.example";
+    await fsp.writeFile(filePath, JSON.stringify(raw, null, 2), "utf8");
+    const snap = await store.reload();
+    expect(snap.subscriptions[0].url).toBe("https://changed.example");
+  });
+});

--- a/tests/webhook-store.test.js
+++ b/tests/webhook-store.test.js
@@ -214,6 +214,19 @@ describe("WebhookStore CRUD", () => {
     })).rejects.toThrow(expect.objectContaining({ code: "INVALID_URL" }));
   });
 
+  test("create rejects URLs with embedded credentials", async () => {
+    await expect(store.create({
+      url: "https://user:pass@example.com/webhook",
+      events: ["a.b"]
+    })).rejects.toThrow(expect.objectContaining({ code: "INVALID_URL" }));
+    // user-only (no password) should also reject — the URL-parser
+    // treats this as an embedded credential.
+    await expect(store.create({
+      url: "https://user@example.com/webhook",
+      events: ["a.b"]
+    })).rejects.toThrow(expect.objectContaining({ code: "INVALID_URL" }));
+  });
+
   test("update merges fields and bumps updatedAt", async () => {
     const created = await store.create({ url: "https://example.com", events: ["a.b"] });
     store.now = () => new Date("2026-05-09T00:00:00.000Z");

--- a/tests/webhook-store.test.js
+++ b/tests/webhook-store.test.js
@@ -277,6 +277,40 @@ describe("WebhookStore CRUD", () => {
     expect(snap.subscriptions[0].url).toBe("https://b.example");
   });
 
+  test("commit blocks BEFORE entering the commitQueue when the data lock is held (deadlock guard)", async () => {
+    let releaseLock;
+    const lockHeld = new Promise((resolve) => { releaseLock = resolve; });
+    const waitFn = async () => { await lockHeld; };
+    const store2 = new WebhookStore({
+      filePath: tempPath(),
+      waitForDataMutationLock: waitFn,
+      now: frozenNow()
+    });
+    await store2.load();
+    // Start a create() while the "lock" is held. It must NOT enqueue
+    // to commitQueue until the lock releases — otherwise the backup
+    // drain path (which awaits commitQueue while holding the lock)
+    // would deadlock.
+    const createPromise = store2.create({
+      url: "https://example.com",
+      events: ["a.b"]
+    });
+    // Yield microtasks; create should be parked at waitForDataMutationLock.
+    await new Promise((r) => setImmediate(r));
+    // Drain the commitQueue — it must resolve immediately because no
+    // run was enqueued (the await blocked first).
+    const drainResult = await Promise.race([
+      store2.commitQueue,
+      new Promise((r) => setTimeout(() => r("TIMEOUT"), 100))
+    ]);
+    expect(drainResult).toBe(undefined);
+    // Now release the lock and let the commit proceed.
+    releaseLock();
+    await createPromise;
+    const snap = await store2.load();
+    expect(snap.subscriptions).toHaveLength(1);
+  });
+
   test("reload picks up an out-of-band file edit", async () => {
     await store.create({ url: "https://a.example", events: ["a.b"] });
     const raw = JSON.parse(await fsp.readFile(filePath, "utf8"));

--- a/tests/webhook-store.test.js
+++ b/tests/webhook-store.test.js
@@ -168,8 +168,10 @@ describe("webhook-store helpers", () => {
       ]
     });
     expect(out.subscriptions.map((s) => s.id)).toEqual(["first", "second"]);
-    // first dedup-by-id wins (insertion order)
-    expect(out.subscriptions[0].url).toBe("https://a.example.com");
+    // first dedup-by-id wins (insertion order). URL is canonicalized
+    // by `new URL(...).toString()` which adds a trailing slash for
+    // bare-host URLs (no path).
+    expect(out.subscriptions[0].url).toBe("https://a.example.com/");
   });
 });
 
@@ -212,6 +214,15 @@ describe("WebhookStore CRUD", () => {
       url: "not-a-url",
       events: ["a.b"]
     })).rejects.toThrow(expect.objectContaining({ code: "INVALID_URL" }));
+  });
+
+  test("create canonicalizes URL (lowercases scheme so persisted form matches schema regex)", async () => {
+    const created = await store.create({
+      url: "HTTPS://Example.COM/Webhook",
+      events: ["a.b"]
+    });
+    // Scheme + host lowercased by URL serialization; path case preserved.
+    expect(created.url).toBe("https://example.com/Webhook");
   });
 
   test("create rejects URLs with embedded credentials", async () => {
@@ -264,7 +275,7 @@ describe("WebhookStore CRUD", () => {
     await store.create({ url: "https://c.example", events: ["c.d"] });
     const subs = await store.findEnabledForEvent("a.b");
     expect(subs).toHaveLength(1);
-    expect(subs[0].url).toBe("https://a.example");
+    expect(subs[0].url).toBe("https://a.example/");
   });
 
   test("concurrent create + remove are serialized via commitQueue", async () => {
@@ -274,7 +285,7 @@ describe("WebhookStore CRUD", () => {
     await Promise.all([op1, op2]);
     const snap = await store.load();
     expect(snap.subscriptions).toHaveLength(1);
-    expect(snap.subscriptions[0].url).toBe("https://b.example");
+    expect(snap.subscriptions[0].url).toBe("https://b.example/");
   });
 
   test("commit blocks BEFORE entering the commitQueue when the data lock is held (deadlock guard)", async () => {
@@ -314,9 +325,12 @@ describe("WebhookStore CRUD", () => {
   test("reload picks up an out-of-band file edit", async () => {
     await store.create({ url: "https://a.example", events: ["a.b"] });
     const raw = JSON.parse(await fsp.readFile(filePath, "utf8"));
-    raw.subscriptions[0].url = "https://changed.example";
+    // Use a fully-canonical URL here because normalizeUrl runs on
+    // every load — a hand-edited bare-host form would get a trailing
+    // slash appended on reload, hiding the assertion's intent.
+    raw.subscriptions[0].url = "https://changed.example/";
     await fsp.writeFile(filePath, JSON.stringify(raw, null, 2), "utf8");
     const snap = await store.reload();
-    expect(snap.subscriptions[0].url).toBe("https://changed.example");
+    expect(snap.subscriptions[0].url).toBe("https://changed.example/");
   });
 });


### PR DESCRIPTION
## Summary
- Opt-in webhook dispatcher that fires HMAC-SHA-256 signed POSTs on admin events: `provider.import.completed`, `provider.import.failed`, and `webhook.test`
- New stores (`data/webhooks.json`, `data/webhook-deliveries.json`) with schemas, atomic writes, retention cap, and backup/restore integration
- Admin Webhooks tab: create / enable / disable / rotate secret / test / per-subscription delivery history with manual retry of failed deliveries
- SSRF guard (RFC1918 / loopback / link-local on both v4 and v6, including IPv4-mapped IPv6) — opt-out only via `WEBHOOK_ALLOW_PRIVATE_NETWORKS=true` for local dev
- Exponential backoff (1s → 10m, 5 attempts default), `Retry-After` honoring (capped at 10m), restart recovery, and concurrency semaphore
- Disabled by default — `WEBHOOKS_ENABLED=true` to start delivering

Closes #95

## Test plan
- [x] `npm run check` (lint + schema:check + nit-guardrails + 523 jest tests, all green)
- [x] `tests/webhook-store.test.js` (19 cases)
- [x] `tests/webhook-delivery-store.test.js` (12 cases)
- [x] `tests/webhook-service.test.js` (42 cases — signature, SSRF accept/reject table, backoff, retry, recovery, shutdown)
- [x] `tests/admin-webhook-routes.test.js` (15 cases — list/create/patch/delete/test/deliveries/retry, secret redaction, 401/404/400 paths)
- [x] Backup + restore tests cover the new files end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added outbound webhooks functionality, including subscription management, event-based delivery, automatic retry with backoff, and delivery history tracking in the admin panel.
  * Test webhook deliveries and monitor delivery attempts with detailed status and error information.

* **Documentation**
  * Added comprehensive webhook system documentation covering configuration, supported events, verification, retry behavior, and API endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->