### PR TITLE
feat(player): daily-puzzle web-push notifications with admin broadcast

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,15 @@ PERF_LOGGING=false
 # production the SSRF guard rejects RFC1918, loopback, and link-local
 # addresses to prevent metadata-service exfil.
 # WEBHOOK_ALLOW_PRIVATE_NETWORKS=false
+
+# Web Push notifications. VAPID keys are auto-generated and persisted
+# in data/app-config.json on first boot — never delete that file
+# unless you intend to invalidate every existing subscription. The
+# notifications.enabled / .localFireTime / .gracePeriodMinutes
+# overrides under data/app-config.json shadow these seeds at runtime;
+# admin UI edits take effect without a restart.
+# PUSH_NOTIFICATIONS_ENABLED=true
+# PUSH_DAILY_FIRE_LOCAL_TIME=00:00
+# PUSH_GRACE_PERIOD_MINUTES=60
+# RFC 8292 subject for VAPID JWT — must be mailto: or https:.
+# PUSH_VAPID_SUBJECT=mailto:admin@localhost

--- a/.env.example
+++ b/.env.example
@@ -51,8 +51,10 @@ PERF_LOGGING=false
 # WEBHOOK_ALLOW_PRIVATE_NETWORKS=false
 
 # Web Push notifications. VAPID keys are auto-generated and persisted
-# in data/app-config.json on first boot — never delete that file
-# unless you intend to invalidate every existing subscription. The
+# in data/vapid-keys.json on first boot — never delete that file
+# unless you intend to invalidate every existing subscription. VAPID
+# is stored separately from data/app-config.json so the private key
+# stays out of backup archives. The
 # notifications.enabled / .localFireTime / .gracePeriodMinutes
 # overrides under data/app-config.json shadow these seeds at runtime;
 # admin UI edits take effect without a restart.

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ data/app-config.json
 data/schedule.json
 data/webhooks.json
 data/webhook-deliveries.json
+data/push-subscriptions.json

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ data/schedule.json
 data/webhooks.json
 data/webhook-deliveries.json
 data/push-subscriptions.json
+data/vapid-keys.json

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -19,3 +19,14 @@ text is checked in next to the bundle at
 
 - Project: https://www.chartjs.org/
 - License: MIT (Copyright (c) 2014-2024 Chart.js Contributors)
+
+## web-push
+
+Daily-puzzle Web Push notifications use the `web-push` Node package
+to sign VAPID JWTs (RFC 8292) and encrypt RFC 8291 push messages.
+Required because Node ships VAPID-capable transport but does not
+expose the lower-level `aes128gcm` content encoding helpers needed
+for RFC 8291 message bodies.
+
+- Project: https://github.com/web-push-libs/web-push
+- License: MIT

--- a/data/app-config.schema.json
+++ b/data/app-config.schema.json
@@ -18,6 +18,33 @@
       "type": "string",
       "format": "date-time"
     },
+    "pushKeys": {
+      "description": "VAPID keypair for Web Push, generated on first boot and persisted forever. Private key never exposed to clients or via runtime-config; absence indicates push notifications are disabled.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["publicKey", "privateKey", "subject"],
+      "properties": {
+        "publicKey": {
+          "description": "URL-safe base64 (87 chars from generateVAPIDKeys).",
+          "type": "string",
+          "minLength": 80,
+          "maxLength": 200
+        },
+        "privateKey": {
+          "description": "URL-safe base64 (43 chars from generateVAPIDKeys).",
+          "type": "string",
+          "minLength": 40,
+          "maxLength": 100
+        },
+        "subject": {
+          "description": "RFC 8292 jws_t identifier; must be mailto: or https: URL.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "^(mailto:|https:)"
+        }
+      }
+    },
     "overrides": {
       "type": "object",
       "additionalProperties": false,
@@ -78,6 +105,25 @@
           "properties": {
             "perfLogging": {
               "type": "boolean"
+            }
+          }
+        },
+        "notifications": {
+          "description": "Web Push notifications config. Operator-controlled at runtime; the dispatcher reads these on every fire so admin edits take effect without restart.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "localFireTime": {
+              "description": "Daily fire time in 24h HH:MM, server-local timezone.",
+              "type": "string",
+              "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$"
+            },
+            "gracePeriodMinutes": {
+              "description": "If the daily fire window was missed by more than this many minutes (e.g. server was down), skip the missed fire instead of firing late.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1440
             }
           }
         }

--- a/data/app-config.schema.json
+++ b/data/app-config.schema.json
@@ -93,10 +93,10 @@
               "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$"
             },
             "gracePeriodMinutes": {
-              "description": "If the daily fire window was missed by more than this many minutes (e.g. server was down), skip the missed fire instead of firing late.",
+              "description": "If the daily fire window was missed by more than this many minutes (e.g. server was down), skip the missed fire instead of firing late. Capped at 60 so a long downtime can't blur day boundaries.",
               "type": "integer",
               "minimum": 0,
-              "maximum": 1440
+              "maximum": 60
             }
           }
         }

--- a/data/app-config.schema.json
+++ b/data/app-config.schema.json
@@ -18,33 +18,6 @@
       "type": "string",
       "format": "date-time"
     },
-    "pushKeys": {
-      "description": "VAPID keypair for Web Push, generated on first boot and persisted forever. Private key never exposed to clients or via runtime-config; absence indicates push notifications are disabled.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["publicKey", "privateKey", "subject"],
-      "properties": {
-        "publicKey": {
-          "description": "URL-safe base64 (87 chars from generateVAPIDKeys).",
-          "type": "string",
-          "minLength": 80,
-          "maxLength": 200
-        },
-        "privateKey": {
-          "description": "URL-safe base64 (43 chars from generateVAPIDKeys).",
-          "type": "string",
-          "minLength": 40,
-          "maxLength": 100
-        },
-        "subject": {
-          "description": "RFC 8292 jws_t identifier; must be mailto: or https: URL.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256,
-          "pattern": "^(mailto:|https:)"
-        }
-      }
-    },
     "overrides": {
       "type": "object",
       "additionalProperties": false,

--- a/data/push-subscriptions.example.json
+++ b/data/push-subscriptions.example.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "updatedAt": "2026-05-09T20:00:00.000Z",
+  "lastBroadcastAt": null,
+  "lastDailyFireAt": null,
+  "subscriptions": []
+}

--- a/data/push-subscriptions.schema.json
+++ b/data/push-subscriptions.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wordle-local/push-subscriptions.schema.json",
+  "title": "Web Push subscriptions",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "updatedAt", "subscriptions"],
+  "properties": {
+    "version": { "type": "integer", "const": 1 },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "lastBroadcastAt": { "type": ["string", "null"], "format": "date-time" },
+    "lastDailyFireAt": { "type": ["string", "null"], "format": "date-time" },
+    "subscriptions": {
+      "type": "array",
+      "uniqueItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "endpointHash",
+          "endpoint",
+          "keys",
+          "createdAt"
+        ],
+        "properties": {
+          "endpointHash": {
+            "description": "First 16 hex chars of sha256(endpoint). Used as opaque ID in URLs; never the raw endpoint.",
+            "type": "string",
+            "pattern": "^[a-f0-9]{16}$"
+          },
+          "endpoint": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096,
+            "pattern": "^https://"
+          },
+          "keys": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["p256dh", "auth"],
+            "properties": {
+              "p256dh": { "type": "string", "minLength": 1, "maxLength": 256 },
+              "auth": { "type": "string", "minLength": 1, "maxLength": 64 }
+            }
+          },
+          "ua": { "type": "string", "maxLength": 256 },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "lastSuccessAt": { "type": ["string", "null"], "format": "date-time" },
+          "lastFailureAt": { "type": ["string", "null"], "format": "date-time" },
+          "failureStreak": { "type": "integer", "minimum": 0, "maximum": 1000 },
+          "firstFailureAt": { "type": ["string", "null"], "format": "date-time" }
+        }
+      }
+    }
+  }
+}

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -36,9 +36,9 @@ The admin Notifications tab surfaces:
 | Item | Behavior |
 | --- | --- |
 | **Generation** | Once on first boot via `web-push.generateVAPIDKeys()`. |
-| **Persistence** | `data/app-config.json` under `pushKeys`. |
-| **Rotation** | Not currently supported in the admin UI. Manual rotation requires deleting `pushKeys` from `data/app-config.json` (server restart will regenerate); ALL existing subscriptions become invalid and need to re-register. |
-| **Server-only** | `privateKey` is never exposed via `/api/meta`, runtime config, or any admin endpoint. The integration test `tests/notification-routes.test.js` enforces this. |
+| **Persistence** | `data/vapid-keys.json` (server-only file, **NOT** included in the backup `IN_SCOPE_FILES` set). |
+| **Rotation** | Not currently supported in the admin UI. Manual rotation requires deleting `data/vapid-keys.json` (server restart will regenerate); ALL existing subscriptions become invalid and need to re-register. |
+| **Server-only** | `privateKey` is never exposed via `/api/meta`, runtime config, any admin endpoint, OR the backup archive. Splitting VAPID into its own file (rather than nesting under `app-config.json`) keeps the secret pinned to the host that generated it — admin-key-holders downloading a backup can't extract the private half from offline copies. |
 | **Subject** | `mailto:` or `https:` per RFC 8292. Defaults to `mailto:admin@localhost`; override with `PUSH_VAPID_SUBJECT`. |
 
 ## Browser support
@@ -87,9 +87,10 @@ need HTTPS or localhost." in this case.
 | --- | --- | --- | --- |
 | `PUSH_NOTIFICATIONS_ENABLED` | `true` | bool | Seed for the runtime `notifications.enabled` flag. After first boot, the admin UI override wins. |
 | `PUSH_DAILY_FIRE_LOCAL_TIME` | `00:00` | HH:MM 24h | Server-local time of the daily fire. Seed only; the runtime override wins. |
-| `PUSH_GRACE_PERIOD_MINUTES` | `60` | 0–1440 | Fire-late grace window on boot. |
+| `PUSH_GRACE_PERIOD_MINUTES` | `60` | 0–60 | Fire-late grace window on boot. Capped at 60 so a long downtime doesn't blur day boundaries. |
 | `PUSH_VAPID_SUBJECT` | `mailto:admin@localhost` | mailto: or https: | RFC 8292 subject for VAPID JWT. |
 | `PUSH_SUBSCRIPTIONS_STORE_PATH` | `data/push-subscriptions.json` | path | Override the subscription store location. |
+| `VAPID_KEYS_STORE_PATH` | `data/vapid-keys.json` | path | Override the VAPID keypair location (server-only; not backed up). |
 
 The `notifications.{enabled,localFireTime,gracePeriodMinutes}` keys
 under `overrides` in `data/app-config.json` shadow the env vars at

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,152 @@
+# Web Push notifications
+
+Self-hosted, family-scale Web Push for the daily Wordle puzzle. No FCM,
+APNs, or third-party push relays — every notification flows through the
+local node using a VAPID keypair generated at first boot.
+
+## Player flow
+
+1. Player opens the site (HTTPS or `localhost`; secure context required).
+2. Player toggles **Get notified when daily puzzle is ready** in the
+   header settings strip. The browser's permission prompt appears
+   only on this user gesture — never automatically.
+3. Browser issues a `PushManager.subscribe()` against the
+   server-supplied VAPID public key.
+4. Browser sends the subscription record (endpoint, p256dh, auth) to
+   `POST /api/notifications/subscribe`. Server returns an opaque
+   `endpointHash`.
+5. At the configured local time each day, the server's
+   `DailyNotificationScheduler` broadcasts a payload to every
+   registered subscription.
+
+## Admin flow
+
+The admin Notifications tab surfaces:
+
+- **Subscription count** — how many devices are registered (raw
+  endpoints are never echoed).
+- **Last broadcast** / **Last daily fire** timestamps.
+- **Broadcast** form: title (≤ 80 chars), body (≤ 200 chars),
+  site-relative URL. Click **Preview** for a `dryRun` that returns the
+  recipient count without sending; click **Send to all** to dispatch
+  (with a confirmation modal).
+
+## VAPID
+
+| Item | Behavior |
+| --- | --- |
+| **Generation** | Once on first boot via `web-push.generateVAPIDKeys()`. |
+| **Persistence** | `data/app-config.json` under `pushKeys`. |
+| **Rotation** | Not currently supported in the admin UI. Manual rotation requires deleting `pushKeys` from `data/app-config.json` (server restart will regenerate); ALL existing subscriptions become invalid and need to re-register. |
+| **Server-only** | `privateKey` is never exposed via `/api/meta`, runtime config, or any admin endpoint. The integration test `tests/notification-routes.test.js` enforces this. |
+| **Subject** | `mailto:` or `https:` per RFC 8292. Defaults to `mailto:admin@localhost`; override with `PUSH_VAPID_SUBJECT`. |
+
+## Browser support
+
+| Browser | Status |
+| --- | --- |
+| Chrome / Chromium / Edge | Fully supported. |
+| Firefox | Fully supported. |
+| Safari (macOS 16+) | Supported in regular browser context. |
+| **Safari (iOS / iPadOS 16.4+)** | **Requires PWA install** — the player must add the site to Home Screen first. The opt-in toggle is shown but `PushManager.subscribe()` will fail without the install. The page surfaces this via the toggle's status line. |
+| Older mobile browsers | Toggle is hidden (no `PushManager` global). |
+
+## HTTPS requirement
+
+Service Workers and the Push API require a **secure context**. The
+toggle is hidden on plain HTTP (except `localhost` / `127.0.0.1`,
+which browsers treat as secure). The status line reads "Notifications
+need HTTPS or localhost." in this case.
+
+## Daily fire scheduler
+
+- The scheduler computes the next absolute fire-time from wall clock
+  (`Date.now()`) on every re-arm — never additive `+24h` — so DST
+  transitions and clock skew can't drift the schedule.
+- On boot, if the configured fire time has already passed today AND no
+  fire happened in the window, the scheduler fires late if it's
+  within `gracePeriodMinutes` (default 60). Beyond that, the missed
+  fire is skipped and the schedule re-arms for tomorrow.
+- The scheduler honors the runtime `notifications.enabled` flag:
+  toggling it off in the admin UI suspends fires without restart;
+  toggling on resumes within ~60 s.
+
+## Retention
+
+| Outcome | Action |
+| --- | --- |
+| HTTP 2xx | `lastSuccessAt` updated; failure tracking cleared. |
+| HTTP 410 (Gone) / 404 | Subscription pruned immediately. |
+| HTTP 408 / 429 / 5xx | Treated as transient; `failureStreak` incremented; no retry on this fire (next daily fire will try again). |
+| Other 4xx | `failureStreak` incremented; the row is not pruned automatically — the operator can inspect via the admin tab. |
+| First failure older than 7 days | Pruned by the next `pruneStale` pass. |
+
+## Environment variables
+
+| Var | Default | Range | Purpose |
+| --- | --- | --- | --- |
+| `PUSH_NOTIFICATIONS_ENABLED` | `true` | bool | Seed for the runtime `notifications.enabled` flag. After first boot, the admin UI override wins. |
+| `PUSH_DAILY_FIRE_LOCAL_TIME` | `00:00` | HH:MM 24h | Server-local time of the daily fire. Seed only; the runtime override wins. |
+| `PUSH_GRACE_PERIOD_MINUTES` | `60` | 0–1440 | Fire-late grace window on boot. |
+| `PUSH_VAPID_SUBJECT` | `mailto:admin@localhost` | mailto: or https: | RFC 8292 subject for VAPID JWT. |
+| `PUSH_SUBSCRIPTIONS_STORE_PATH` | `data/push-subscriptions.json` | path | Override the subscription store location. |
+
+The `notifications.{enabled,localFireTime,gracePeriodMinutes}` keys
+under `overrides` in `data/app-config.json` shadow the env vars at
+runtime.
+
+## Admin API
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| GET | `/api/admin/notifications/subscriptions` | Count + timestamps + opaque per-row hashes. Never raw endpoints/keys. |
+| POST | `/api/admin/notifications/broadcast` | `{title, body, url, dryRun?}`. `dryRun:true` returns recipient count + rendered preview without sending. |
+
+## Player API
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| GET | `/api/notifications/vapid-public-key` | Returns the public VAPID key (URL-safe base64). 503 with `code: VAPID_MISSING` until the boot path provisions keys. |
+| POST | `/api/notifications/subscribe` | Body: `{endpoint, keys:{p256dh,auth}}`. Returns `{endpointHash}`. |
+| DELETE | `/api/notifications/subscribe/:endpointHash` | 204 (idempotent). |
+
+## Service worker
+
+`public/sw.js` v3 adds two listeners:
+
+- `push` — parses the JSON payload (`{title, body, url, tag}`) and
+  calls `self.registration.showNotification`. Falls back to a generic
+  daily-puzzle copy on empty payloads.
+- `notificationclick` — focuses an existing tab at the URL if open,
+  else opens a new window. The `tag` collapses repeat notifications so
+  a daily fire that arrives before a previous one was dismissed
+  doesn't pile up.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Toggle hidden | Browser lacks `PushManager` / Service Worker, or the site is HTTP (not HTTPS or localhost). |
+| Toggle disabled, "Notifications blocked" | Browser permission denied. Open browser settings → site permissions → reload. |
+| Subscribe returns 503 `VAPID_MISSING` | Boot path hasn't run `ensurePushKeysSync` yet — wait a few seconds and retry. |
+| No notification at midnight | Check `notifications.enabled` in admin Runtime Settings, server-local timezone of the host, and the `lastDailyFireAt` timestamp on the admin Notifications tab. |
+| Notification body shows wrong word length | The scheduler reads `wordDataCache` at fire time. If admin set a new word AFTER the daily reconcile, the new word reflects on the next fire. |
+
+## Dependencies
+
+- `web-push@^3.6.0` — runtime dependency for VAPID JWT signing and
+  RFC 8291 message encryption.
+
+## Test coverage
+
+- Unit: `tests/push-subscription-store.test.js` — atomic write,
+  dedupe-by-endpoint, prune-on-410, `pruneStale` cutoff.
+- Unit: `tests/notification-service.test.js` — `buildPayload` clamps,
+  `classifyResponse` decision table, sendOne mocking, broadcast
+  aggregate counts.
+- Unit: `tests/daily-notification-scheduler.test.js` — `computeNextFireAt`
+  across DST, `decideBootAction` grace window, scheduler integration
+  with mocked store + service.
+- Integration: `tests/notification-routes.test.js` — subscribe, unsubscribe,
+  vapid-public-key, admin subscriptions/broadcast, VAPID-private-key
+  leak check across `/api/meta` + `/api/admin/notifications/*`.

--- a/lib/app-config-store.js
+++ b/lib/app-config-store.js
@@ -157,8 +157,11 @@ function normalizeNotificationsOverrides(raw, errors) {
   }
   if (raw.gracePeriodMinutes !== undefined) {
     const minutes = toInteger(raw.gracePeriodMinutes);
-    if (minutes === null || minutes < 0 || minutes > 1440) {
-      errors.push("overrides.notifications.gracePeriodMinutes must be an integer between 0 and 1440.");
+    // Cap at 60 minutes per the design contract: a missed daily fire
+    // beyond an hour stale should be dropped rather than blurring
+    // day boundaries after a long restart or DST transition.
+    if (minutes === null || minutes < 0 || minutes > 60) {
+      errors.push("overrides.notifications.gracePeriodMinutes must be an integer between 0 and 60.");
     } else {
       next.gracePeriodMinutes = minutes;
     }
@@ -166,32 +169,6 @@ function normalizeNotificationsOverrides(raw, errors) {
   return Object.keys(next).length ? next : undefined;
 }
 
-const VAPID_SUBJECT_PATTERN = /^(mailto:|https:)/;
-
-function normalizePushKeys(raw, errors) {
-  if (raw === undefined || raw === null) return undefined;
-  if (!isObject(raw)) {
-    errors.push("pushKeys must be an object when provided.");
-    return undefined;
-  }
-  const out = {};
-  if (typeof raw.publicKey !== "string" || raw.publicKey.length < 80 || raw.publicKey.length > 200) {
-    errors.push("pushKeys.publicKey must be the URL-safe base64 string from generateVAPIDKeys().");
-    return undefined;
-  }
-  out.publicKey = raw.publicKey;
-  if (typeof raw.privateKey !== "string" || raw.privateKey.length < 40 || raw.privateKey.length > 100) {
-    errors.push("pushKeys.privateKey must be the URL-safe base64 string from generateVAPIDKeys().");
-    return undefined;
-  }
-  out.privateKey = raw.privateKey;
-  if (typeof raw.subject !== "string" || !VAPID_SUBJECT_PATTERN.test(raw.subject) || raw.subject.length > 256) {
-    errors.push("pushKeys.subject must be a mailto: or https: identifier (RFC 8292).");
-    return undefined;
-  }
-  out.subject = raw.subject;
-  return out;
-}
 
 function normalizeOverrides(rawOverrides, options = {}) {
   const errors = [];
@@ -292,16 +269,11 @@ function normalizeState(rawState, options = {}) {
     errors.push(`unsupported version ${String(rawState.version)}; expected ${SCHEMA_VERSION}.`);
   }
 
-  const pushKeysErrors = [];
-  const pushKeys = normalizePushKeys(rawState.pushKeys, pushKeysErrors);
-  errors.push(...pushKeysErrors);
-
   const state = {
     version: SCHEMA_VERSION,
     updatedAt,
     overrides
   };
-  if (pushKeys) state.pushKeys = pushKeys;
   return { state, errors };
 }
 
@@ -370,71 +342,31 @@ class AppConfigStore {
 
   replaceOverridesSync(rawOverrides) {
     this.loadSync();
-    const { overrides, errors } = normalizeOverrides(rawOverrides, { allowUnknown: false });
+    const { overrides: incoming, errors } = normalizeOverrides(rawOverrides, { allowUnknown: false });
     if (errors.length > 0) {
       throw new AppConfigStoreError("INVALID_OVERRIDES", errors.join(" "));
     }
 
+    // PRESERVE notification overrides across runtime-config saves. The
+    // existing Runtime Settings UI submits `{definitions, limits,
+    // diagnostics}` and never sends `notifications` — without this
+    // merge, an unrelated Settings save silently drops a previously
+    // persisted notifications.{enabled,localFireTime,gracePeriodMinutes}
+    // and reverts to env-default values.
+    const merged = { ...incoming };
+    const previousNotifications = this.state?.overrides?.notifications;
+    if (previousNotifications && incoming.notifications === undefined) {
+      merged.notifications = clone(previousNotifications);
+    }
+
     const nextState = {
       version: SCHEMA_VERSION,
       updatedAt: new Date().toISOString(),
-      overrides,
-      // Preserve pushKeys across overrides updates — the runtime-config
-      // PUT path replaces only the overrides block.
-      ...(this.state?.pushKeys ? { pushKeys: clone(this.state.pushKeys) } : {})
+      overrides: merged
     };
     writeJsonAtomicSync(this.filePath, nextState);
     this.state = nextState;
     return clone(this.state);
-  }
-
-  // Returns the persisted VAPID keypair or null if none exists yet.
-  // Includes the private key — server-only callers; never echo this
-  // back to clients or include it in runtime-config responses.
-  getPushKeysSync() {
-    const snapshot = this.getSnapshotSync();
-    return snapshot.pushKeys ? clone(snapshot.pushKeys) : null;
-  }
-
-  // Generate-on-missing: if no VAPID keypair exists, calls `generate`
-  // (typically `web-push.generateVAPIDKeys`) and persists the result.
-  // Idempotent: subsequent calls return the existing keys without
-  // regenerating, so VAPID stays stable across restarts even though
-  // we read on every boot. The subject defaults to the operator's
-  // PUSH_VAPID_SUBJECT env var if provided, else mailto:admin@localhost.
-  ensurePushKeysSync({ generate, subject } = {}) {
-    if (typeof generate !== "function") {
-      throw new AppConfigStoreError(
-        "INVALID_REQUEST",
-        "ensurePushKeysSync requires a generate function (e.g. web-push.generateVAPIDKeys)."
-      );
-    }
-    this.loadSync();
-    if (this.state?.pushKeys) return clone(this.state.pushKeys);
-    const fresh = generate();
-    const resolvedSubject = (typeof subject === "string" && VAPID_SUBJECT_PATTERN.test(subject))
-      ? subject
-      : "mailto:admin@localhost";
-    const errors = [];
-    const normalized = normalizePushKeys(
-      { ...fresh, subject: resolvedSubject },
-      errors
-    );
-    if (!normalized) {
-      throw new AppConfigStoreError(
-        "INVALID_PUSH_KEYS",
-        `Generated VAPID keys did not validate: ${errors.join(" ")}`
-      );
-    }
-    const nextState = {
-      ...this.state,
-      version: SCHEMA_VERSION,
-      updatedAt: new Date().toISOString(),
-      pushKeys: normalized
-    };
-    writeJsonAtomicSync(this.filePath, nextState);
-    this.state = nextState;
-    return clone(normalized);
   }
 }
 

--- a/lib/app-config-store.js
+++ b/lib/app-config-store.js
@@ -134,6 +134,65 @@ function normalizeDiagnosticsOverrides(raw, errors) {
   return Object.keys(next).length ? next : undefined;
 }
 
+const HHMM_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function normalizeNotificationsOverrides(raw, errors) {
+  if (!isObject(raw)) {
+    return undefined;
+  }
+  const next = {};
+  if (raw.enabled !== undefined) {
+    if (typeof raw.enabled !== "boolean") {
+      errors.push("overrides.notifications.enabled must be true or false.");
+    } else {
+      next.enabled = raw.enabled;
+    }
+  }
+  if (raw.localFireTime !== undefined) {
+    if (typeof raw.localFireTime !== "string" || !HHMM_PATTERN.test(raw.localFireTime)) {
+      errors.push("overrides.notifications.localFireTime must be a 24-hour HH:MM string.");
+    } else {
+      next.localFireTime = raw.localFireTime;
+    }
+  }
+  if (raw.gracePeriodMinutes !== undefined) {
+    const minutes = toInteger(raw.gracePeriodMinutes);
+    if (minutes === null || minutes < 0 || minutes > 1440) {
+      errors.push("overrides.notifications.gracePeriodMinutes must be an integer between 0 and 1440.");
+    } else {
+      next.gracePeriodMinutes = minutes;
+    }
+  }
+  return Object.keys(next).length ? next : undefined;
+}
+
+const VAPID_SUBJECT_PATTERN = /^(mailto:|https:)/;
+
+function normalizePushKeys(raw, errors) {
+  if (raw === undefined || raw === null) return undefined;
+  if (!isObject(raw)) {
+    errors.push("pushKeys must be an object when provided.");
+    return undefined;
+  }
+  const out = {};
+  if (typeof raw.publicKey !== "string" || raw.publicKey.length < 80 || raw.publicKey.length > 200) {
+    errors.push("pushKeys.publicKey must be the URL-safe base64 string from generateVAPIDKeys().");
+    return undefined;
+  }
+  out.publicKey = raw.publicKey;
+  if (typeof raw.privateKey !== "string" || raw.privateKey.length < 40 || raw.privateKey.length > 100) {
+    errors.push("pushKeys.privateKey must be the URL-safe base64 string from generateVAPIDKeys().");
+    return undefined;
+  }
+  out.privateKey = raw.privateKey;
+  if (typeof raw.subject !== "string" || !VAPID_SUBJECT_PATTERN.test(raw.subject) || raw.subject.length > 256) {
+    errors.push("pushKeys.subject must be a mailto: or https: identifier (RFC 8292).");
+    return undefined;
+  }
+  out.subject = raw.subject;
+  return out;
+}
+
 function normalizeOverrides(rawOverrides, options = {}) {
   const errors = [];
   const allowUnknown = options.allowUnknown === true;
@@ -149,7 +208,7 @@ function normalizeOverrides(rawOverrides, options = {}) {
     };
   }
 
-  const knownKeys = new Set(["definitions", "limits", "diagnostics"]);
+  const knownKeys = new Set(["definitions", "limits", "diagnostics", "notifications"]);
   for (const key of Object.keys(rawOverrides)) {
     if (!knownKeys.has(key) && !allowUnknown) {
       errors.push(`overrides.${key} is not supported for runtime updates.`);
@@ -169,6 +228,11 @@ function normalizeOverrides(rawOverrides, options = {}) {
   const diagnostics = normalizeDiagnosticsOverrides(rawOverrides.diagnostics, errors);
   if (diagnostics) {
     overrides.diagnostics = diagnostics;
+  }
+
+  const notifications = normalizeNotificationsOverrides(rawOverrides.notifications, errors);
+  if (notifications) {
+    overrides.notifications = notifications;
   }
 
   return { overrides, errors };
@@ -228,14 +292,17 @@ function normalizeState(rawState, options = {}) {
     errors.push(`unsupported version ${String(rawState.version)}; expected ${SCHEMA_VERSION}.`);
   }
 
-  return {
-    state: {
-      version: SCHEMA_VERSION,
-      updatedAt,
-      overrides
-    },
-    errors
+  const pushKeysErrors = [];
+  const pushKeys = normalizePushKeys(rawState.pushKeys, pushKeysErrors);
+  errors.push(...pushKeysErrors);
+
+  const state = {
+    version: SCHEMA_VERSION,
+    updatedAt,
+    overrides
   };
+  if (pushKeys) state.pushKeys = pushKeys;
+  return { state, errors };
 }
 
 class AppConfigStore {
@@ -311,11 +378,63 @@ class AppConfigStore {
     const nextState = {
       version: SCHEMA_VERSION,
       updatedAt: new Date().toISOString(),
-      overrides
+      overrides,
+      // Preserve pushKeys across overrides updates — the runtime-config
+      // PUT path replaces only the overrides block.
+      ...(this.state?.pushKeys ? { pushKeys: clone(this.state.pushKeys) } : {})
     };
     writeJsonAtomicSync(this.filePath, nextState);
     this.state = nextState;
     return clone(this.state);
+  }
+
+  // Returns the persisted VAPID keypair or null if none exists yet.
+  // Includes the private key — server-only callers; never echo this
+  // back to clients or include it in runtime-config responses.
+  getPushKeysSync() {
+    const snapshot = this.getSnapshotSync();
+    return snapshot.pushKeys ? clone(snapshot.pushKeys) : null;
+  }
+
+  // Generate-on-missing: if no VAPID keypair exists, calls `generate`
+  // (typically `web-push.generateVAPIDKeys`) and persists the result.
+  // Idempotent: subsequent calls return the existing keys without
+  // regenerating, so VAPID stays stable across restarts even though
+  // we read on every boot. The subject defaults to the operator's
+  // PUSH_VAPID_SUBJECT env var if provided, else mailto:admin@localhost.
+  ensurePushKeysSync({ generate, subject } = {}) {
+    if (typeof generate !== "function") {
+      throw new AppConfigStoreError(
+        "INVALID_REQUEST",
+        "ensurePushKeysSync requires a generate function (e.g. web-push.generateVAPIDKeys)."
+      );
+    }
+    this.loadSync();
+    if (this.state?.pushKeys) return clone(this.state.pushKeys);
+    const fresh = generate();
+    const resolvedSubject = (typeof subject === "string" && VAPID_SUBJECT_PATTERN.test(subject))
+      ? subject
+      : "mailto:admin@localhost";
+    const errors = [];
+    const normalized = normalizePushKeys(
+      { ...fresh, subject: resolvedSubject },
+      errors
+    );
+    if (!normalized) {
+      throw new AppConfigStoreError(
+        "INVALID_PUSH_KEYS",
+        `Generated VAPID keys did not validate: ${errors.join(" ")}`
+      );
+    }
+    const nextState = {
+      ...this.state,
+      version: SCHEMA_VERSION,
+      updatedAt: new Date().toISOString(),
+      pushKeys: normalized
+    };
+    writeJsonAtomicSync(this.filePath, nextState);
+    this.state = nextState;
+    return clone(normalized);
   }
 }
 

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -21,6 +21,7 @@ const IN_SCOPE_FILES = Object.freeze([
   "data/schedule.json",
   "data/webhooks.json",
   "data/webhook-deliveries.json",
+  "data/push-subscriptions.json",
   "data/word.json"
 ]);
 
@@ -32,7 +33,8 @@ const IN_SCOPE_SCHEMAS = Object.freeze({
   "data/classes.json": "data/classes.schema.json",
   "data/schedule.json": "data/schedule.schema.json",
   "data/webhooks.json": "data/webhooks.schema.json",
-  "data/webhook-deliveries.json": "data/webhook-deliveries.schema.json"
+  "data/webhook-deliveries.json": "data/webhook-deliveries.schema.json",
+  "data/push-subscriptions.json": "data/push-subscriptions.schema.json"
 });
 
 const DIAGNOSTIC_SCHEMAS = Object.freeze([
@@ -44,6 +46,7 @@ const DIAGNOSTIC_SCHEMAS = Object.freeze([
   "data/schedule.schema.json",
   "data/webhooks.schema.json",
   "data/webhook-deliveries.schema.json",
+  "data/push-subscriptions.schema.json",
   "data/backup-manifest.schema.json",
   "data/providers/provider-import-manifest.schema.json"
 ]);

--- a/lib/daily-notification-scheduler.js
+++ b/lib/daily-notification-scheduler.js
@@ -1,0 +1,193 @@
+"use strict";
+
+// Daily web-push fire scheduler. Computes the next midnight (or
+// configured local time) using server-local timezone, fires once,
+// then re-arms from wall-clock — never additive `+24h` so DST
+// transitions and clock skew don't drift the schedule.
+
+class DailyNotificationSchedulerError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "DailyNotificationSchedulerError";
+    this.code = code;
+  }
+}
+
+const HHMM_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function parseHhMm(localFireTime) {
+  if (typeof localFireTime !== "string" || !HHMM_PATTERN.test(localFireTime)) {
+    throw new DailyNotificationSchedulerError(
+      "INVALID_REQUEST",
+      `localFireTime must be HH:MM 24h; got ${localFireTime}.`
+    );
+  }
+  const [hh, mm] = localFireTime.split(":").map(Number);
+  return { hh, mm };
+}
+
+// Returns the next absolute wall-clock Date the scheduler should fire.
+// If the configured time has already passed today, schedule for
+// tomorrow. Pure function; tests pass a fixed `now` to verify.
+function computeNextFireAt(now, localFireTime) {
+  const { hh, mm } = parseHhMm(localFireTime);
+  const next = new Date(now);
+  next.setHours(hh, mm, 0, 0);
+  if (next.getTime() <= now.getTime()) {
+    next.setDate(next.getDate() + 1);
+  }
+  return next;
+}
+
+// Decides whether a missed fire (e.g. server was down at the
+// configured time and is just coming back up) should fire late or be
+// skipped. Returns:
+//   { action: "fire-now", missedAt }   — within grace; fire late
+//   { action: "skip", missedAt }       — outside grace; skip
+//   { action: "no-recent-miss" }       — nothing missed, schedule next
+// `lastDailyFireAt` is the persisted timestamp of the most recent
+// successful fire (null on a fresh install).
+function decideBootAction({
+  now,
+  localFireTime,
+  lastDailyFireAt,
+  gracePeriodMinutes = 60
+}) {
+  const { hh, mm } = parseHhMm(localFireTime);
+  const todayFire = new Date(now);
+  todayFire.setHours(hh, mm, 0, 0);
+  // If today's fire window hasn't arrived yet, nothing was missed.
+  if (todayFire.getTime() > now.getTime()) {
+    return { action: "no-recent-miss" };
+  }
+  // Today's fire window has passed. Was it already fired?
+  if (lastDailyFireAt) {
+    const lastMs = new Date(lastDailyFireAt).getTime();
+    if (Number.isFinite(lastMs) && lastMs >= todayFire.getTime()) {
+      return { action: "no-recent-miss" };
+    }
+  }
+  // Window passed and we haven't fired since today's window. Decide
+  // by the grace period: if we're within grace, fire late.
+  const minutesSinceWindow = (now.getTime() - todayFire.getTime()) / 60000;
+  if (minutesSinceWindow <= gracePeriodMinutes) {
+    return { action: "fire-now", missedAt: todayFire.toISOString() };
+  }
+  return { action: "skip", missedAt: todayFire.toISOString() };
+}
+
+class DailyNotificationScheduler {
+  constructor(options = {}) {
+    if (!options.notificationService) {
+      throw new DailyNotificationSchedulerError(
+        "INVALID_REQUEST",
+        "notificationService is required."
+      );
+    }
+    if (!options.subscriptionStore) {
+      throw new DailyNotificationSchedulerError(
+        "INVALID_REQUEST",
+        "subscriptionStore is required."
+      );
+    }
+    this.notificationService = options.notificationService;
+    this.subscriptionStore = options.subscriptionStore;
+    this.logger = options.logger || console;
+    this.now = typeof options.now === "function" ? options.now : () => new Date();
+    // Operator-facing config accessors so admin-edits at runtime take
+    // effect on the next re-arm without a restart.
+    this.getConfig = typeof options.getConfig === "function"
+      ? options.getConfig
+      : () => ({ enabled: true, localFireTime: "00:00", gracePeriodMinutes: 60 });
+    // Payload builder so the scheduler doesn't hard-code copy. The
+    // server passes a builder that pulls the active daily word.
+    this.buildPayload = typeof options.buildPayload === "function"
+      ? options.buildPayload
+      : () => ({
+        title: "Today's Wordle is ready",
+        body: "Open the app to play today's puzzle.",
+        url: "/"
+      });
+    this.timer = null;
+    this.nextFireAt = null;
+    this.shutdownRequested = false;
+  }
+
+  async start() {
+    this.shutdownRequested = false;
+    const cfg = this.getConfig() || {};
+    if (cfg.enabled === false) {
+      this.logger.log?.("[notify] scheduler not started: notifications disabled in config.");
+      return;
+    }
+    // On boot: check if a recent fire was missed. If it was within
+    // grace, fire now. Otherwise skip and re-arm to tomorrow.
+    const lastDailyFireAt = (await this.subscriptionStore.getSnapshot()).lastDailyFireAt;
+    const decision = decideBootAction({
+      now: this.now(),
+      localFireTime: cfg.localFireTime || "00:00",
+      lastDailyFireAt,
+      gracePeriodMinutes: cfg.gracePeriodMinutes ?? 60
+    });
+    if (decision.action === "fire-now") {
+      this.logger.log?.(`[notify] firing missed window from ${decision.missedAt}.`);
+      await this.fireOnce();
+    } else if (decision.action === "skip") {
+      this.logger.log?.(`[notify] skipping missed window from ${decision.missedAt} (outside ${cfg.gracePeriodMinutes ?? 60}-minute grace).`);
+    }
+    this.armNext();
+  }
+
+  armNext() {
+    if (this.shutdownRequested) return;
+    const cfg = this.getConfig() || {};
+    if (cfg.enabled === false) {
+      // Re-check periodically so toggling on doesn't require a restart.
+      this.timer = setTimeout(() => this.armNext(), 60_000);
+      if (typeof this.timer.unref === "function") this.timer.unref();
+      return;
+    }
+    const nowDate = this.now();
+    const next = computeNextFireAt(nowDate, cfg.localFireTime || "00:00");
+    this.nextFireAt = next;
+    const delay = Math.max(0, next.getTime() - nowDate.getTime());
+    this.timer = setTimeout(async () => {
+      this.timer = null;
+      try {
+        await this.fireOnce();
+      } catch (err) {
+        this.logger.error?.("[notify] daily fire failed:", err);
+      }
+      // Always re-arm — next-fire is recomputed from wall clock so a
+      // long-running process can never drift.
+      this.armNext();
+    }, delay);
+    if (typeof this.timer.unref === "function") this.timer.unref();
+  }
+
+  async fireOnce() {
+    const cfg = this.getConfig() || {};
+    if (cfg.enabled === false) return { skipped: true, reason: "disabled" };
+    const payload = await Promise.resolve(this.buildPayload());
+    const result = await this.notificationService.broadcast(payload);
+    await this.subscriptionStore.stampLastDailyFire().catch((err) => {
+      this.logger.warn?.("[notify] could not stamp lastDailyFireAt:", err.message);
+    });
+    return result;
+  }
+
+  shutdown() {
+    this.shutdownRequested = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+module.exports = {
+  DailyNotificationScheduler,
+  DailyNotificationSchedulerError,
+  computeNextFireAt,
+  decideBootAction
+};

--- a/lib/daily-notification-scheduler.js
+++ b/lib/daily-notification-scheduler.js
@@ -117,7 +117,12 @@ class DailyNotificationScheduler {
     this.shutdownRequested = false;
     const cfg = this.getConfig() || {};
     if (cfg.enabled === false) {
-      this.logger.log?.("[notify] scheduler not started: notifications disabled in config.");
+      this.logger.log?.("[notify] scheduler started in disabled mode — polling for re-enable.");
+      // Still arm the disabled-state poll so toggling notifications
+      // on at runtime resumes daily fires within ~60s. Without this
+      // re-arm, the scheduler would stay dormant until a process
+      // restart, breaking the "takes effect without restart" promise.
+      this.armNext();
       return;
     }
     // On boot: check if a recent fire was missed. If it was within

--- a/lib/daily-notification-scheduler.js
+++ b/lib/daily-notification-scheduler.js
@@ -47,6 +47,11 @@ function computeNextFireAt(now, localFireTime) {
 //   { action: "no-recent-miss" }       — nothing missed, schedule next
 // `lastDailyFireAt` is the persisted timestamp of the most recent
 // successful fire (null on a fresh install).
+//
+// Cross-midnight handling: if `localFireTime` is late in the day
+// (e.g. 23:30) and the server reboots shortly after midnight, today's
+// 23:30 hasn't arrived yet, but YESTERDAY's 23:30 may still be within
+// the grace window. We check yesterday's fire window too.
 function decideBootAction({
   now,
   localFireTime,
@@ -56,24 +61,39 @@ function decideBootAction({
   const { hh, mm } = parseHhMm(localFireTime);
   const todayFire = new Date(now);
   todayFire.setHours(hh, mm, 0, 0);
-  // If today's fire window hasn't arrived yet, nothing was missed.
-  if (todayFire.getTime() > now.getTime()) {
-    return { action: "no-recent-miss" };
-  }
-  // Today's fire window has passed. Was it already fired?
-  if (lastDailyFireAt) {
-    const lastMs = new Date(lastDailyFireAt).getTime();
-    if (Number.isFinite(lastMs) && lastMs >= todayFire.getTime()) {
+  const lastMs = lastDailyFireAt ? new Date(lastDailyFireAt).getTime() : null;
+  const lastFireMs = Number.isFinite(lastMs) ? lastMs : null;
+
+  // Case 1: today's fire window has already passed.
+  if (todayFire.getTime() <= now.getTime()) {
+    if (lastFireMs !== null && lastFireMs >= todayFire.getTime()) {
       return { action: "no-recent-miss" };
     }
+    const minutesSinceWindow = (now.getTime() - todayFire.getTime()) / 60000;
+    if (minutesSinceWindow <= gracePeriodMinutes) {
+      return { action: "fire-now", missedAt: todayFire.toISOString() };
+    }
+    return { action: "skip", missedAt: todayFire.toISOString() };
   }
-  // Window passed and we haven't fired since today's window. Decide
-  // by the grace period: if we're within grace, fire late.
-  const minutesSinceWindow = (now.getTime() - todayFire.getTime()) / 60000;
-  if (minutesSinceWindow <= gracePeriodMinutes) {
-    return { action: "fire-now", missedAt: todayFire.toISOString() };
+
+  // Case 2: today's window hasn't arrived yet. Check yesterday's same
+  // wall-clock time — a 23:30 fire missed during a brief downtime
+  // that crossed midnight is still within the grace window from a
+  // few minutes ago.
+  const yesterdayFire = new Date(todayFire);
+  yesterdayFire.setDate(yesterdayFire.getDate() - 1);
+  // If yesterday's window already fired (lastFireMs >= yesterdayFire),
+  // there's nothing to catch up on.
+  if (lastFireMs !== null && lastFireMs >= yesterdayFire.getTime()) {
+    return { action: "no-recent-miss" };
   }
-  return { action: "skip", missedAt: todayFire.toISOString() };
+  // Yesterday's window passed without a fire (or no record). Within
+  // grace?
+  const minutesSinceYesterday = (now.getTime() - yesterdayFire.getTime()) / 60000;
+  if (minutesSinceYesterday >= 0 && minutesSinceYesterday <= gracePeriodMinutes) {
+    return { action: "fire-now", missedAt: yesterdayFire.toISOString() };
+  }
+  return { action: "no-recent-miss" };
 }
 
 class DailyNotificationScheduler {
@@ -178,6 +198,21 @@ class DailyNotificationScheduler {
     await this.subscriptionStore.stampLastDailyFire().catch((err) => {
       this.logger.warn?.("[notify] could not stamp lastDailyFireAt:", err.message);
     });
+    // Prune stale rows whose first failure is older than the retention
+    // cutoff. Done after the broadcast so any newly-failing rows from
+    // this fire have their `firstFailureAt` stamped before pruneStale
+    // walks them. Best-effort: pruning failures don't abort the fire
+    // result we return.
+    if (typeof this.subscriptionStore.pruneStale === "function") {
+      try {
+        const removed = await this.subscriptionStore.pruneStale();
+        if (Array.isArray(removed) && removed.length > 0) {
+          this.logger.log?.(`[notify] pruned ${removed.length} stale subscription(s).`);
+        }
+      } catch (err) {
+        this.logger.warn?.("[notify] pruneStale failed:", err.message || err);
+      }
+    }
     return result;
   }
 

--- a/lib/notification-service.js
+++ b/lib/notification-service.js
@@ -71,7 +71,16 @@ class NotificationService {
     // Web Push sender. Defaults to `require('web-push')`; injected in
     // tests so we don't hit a real push service.
     this.webPush = options.webPush || require("web-push");
-    this.enabled = options.enabled !== false;
+    // Live `enabled` getter — called on every send so admin toggling
+    // the runtime `notifications.enabled` flag stops both the daily
+    // scheduler AND admin broadcasts. The boot-time boolean fallback
+    // is kept for tests + simple wirings.
+    if (typeof options.isEnabled === "function") {
+      this.isEnabled = options.isEnabled;
+    } else {
+      const enabledFlag = options.enabled !== false;
+      this.isEnabled = () => enabledFlag;
+    }
     // VAPID accessor — called every send so admin-rotated keys take
     // effect without restart. Returns `{publicKey, privateKey, subject}`
     // or null if VAPID isn't provisioned.
@@ -98,7 +107,7 @@ class NotificationService {
   // `{ok, status, gone}`. Caller is expected to update the subscription
   // store based on the result.
   async sendOne(subscription, payload, { ttlSeconds = this.ttlSeconds } = {}) {
-    if (!this.enabled) return { ok: false, status: null, skipped: true, reason: "disabled" };
+    if (!this.isEnabled()) return { ok: false, status: null, skipped: true, reason: "disabled" };
     const keys = this.getPushKeys();
     if (!keys || !keys.publicKey || !keys.privateKey) {
       throw new NotificationServiceError(
@@ -136,7 +145,7 @@ class NotificationService {
   // lastSuccessAt; gone deletes; non-gone failures increment streak.
   // Returns aggregate counts.
   async broadcast(payload, { dryRun = false } = {}) {
-    if (!this.enabled) return { sent: 0, failed: 0, gone: 0, skipped: true, reason: "disabled" };
+    if (!this.isEnabled()) return { sent: 0, failed: 0, gone: 0, skipped: true, reason: "disabled" };
     const subs = await this.subscriptionStore.list();
     if (dryRun) {
       return {

--- a/lib/notification-service.js
+++ b/lib/notification-service.js
@@ -1,0 +1,182 @@
+"use strict";
+
+// Web Push dispatcher. Wraps the `web-push` npm package so the rest of
+// the codebase can ignore VAPID + RFC 8291/8292 details and just call
+// `service.broadcast({title, body, url})`.
+
+class NotificationServiceError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = "NotificationServiceError";
+    this.code = code;
+    if (options.cause) this.cause = options.cause;
+  }
+}
+
+// Web Push payload size cap is ~4 KiB encrypted; we keep ours far below
+// so headers + cipher overhead don't push us over.
+const PAYLOAD_MAX_BYTES = 1024;
+const TITLE_MAX_LENGTH = 80;
+const BODY_MAX_LENGTH = 200;
+const URL_MAX_LENGTH = 256;
+
+function clampString(value, max) {
+  if (typeof value !== "string") return "";
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+function buildPayload({ title, body, url, tag } = {}) {
+  const cleaned = {
+    title: clampString(title, TITLE_MAX_LENGTH),
+    body: clampString(body, BODY_MAX_LENGTH),
+    url: clampString(url, URL_MAX_LENGTH)
+  };
+  if (typeof tag === "string" && tag.length > 0) {
+    cleaned.tag = tag.length > 64 ? tag.slice(0, 64) : tag;
+  }
+  return cleaned;
+}
+
+// Map web-push send errors to a stable shape so the store can decide
+// whether to retain or prune. statusCode comes straight from the push
+// service's response.
+function classifyResponse(err) {
+  if (!err) return { ok: true, retriable: false, gone: false };
+  const status = err.statusCode ?? err.status ?? null;
+  // 410 Gone: subscription is permanently invalid; the store should
+  // delete the row immediately rather than waiting for the prune cycle.
+  if (status === 410 || status === 404) {
+    return { ok: false, retriable: false, gone: true, status };
+  }
+  // 4xx (other than 408/429) means the request was malformed —
+  // not retriable, but the subscription itself isn't gone.
+  if (status === 408 || status === 429) {
+    return { ok: false, retriable: true, gone: false, status };
+  }
+  if (status >= 400 && status < 500) {
+    return { ok: false, retriable: false, gone: false, status };
+  }
+  // 5xx + network error → retriable.
+  return { ok: false, retriable: true, gone: false, status };
+}
+
+class NotificationService {
+  constructor(options = {}) {
+    if (!options.subscriptionStore) {
+      throw new NotificationServiceError("INVALID_REQUEST", "subscriptionStore is required.");
+    }
+    this.subscriptionStore = options.subscriptionStore;
+    this.logger = options.logger || console;
+    this.now = typeof options.now === "function" ? options.now : () => new Date();
+    // Web Push sender. Defaults to `require('web-push')`; injected in
+    // tests so we don't hit a real push service.
+    this.webPush = options.webPush || require("web-push");
+    this.enabled = options.enabled !== false;
+    // VAPID accessor — called every send so admin-rotated keys take
+    // effect without restart. Returns `{publicKey, privateKey, subject}`
+    // or null if VAPID isn't provisioned.
+    this.getPushKeys = typeof options.getPushKeys === "function" ? options.getPushKeys : null;
+    if (!this.getPushKeys) {
+      throw new NotificationServiceError(
+        "INVALID_REQUEST",
+        "getPushKeys callback is required (must return {publicKey, privateKey, subject})."
+      );
+    }
+    // Concurrency cap so a thundering herd of sends doesn't saturate
+    // the event loop. Default conservatively low — push services are
+    // happy to receive 100s of req/s from one source, but our retry
+    // semaphore should match the dispatcher's polite-default ethos.
+    this.maxConcurrent = Number.isInteger(options.maxConcurrent) && options.maxConcurrent > 0
+      ? options.maxConcurrent
+      : 8;
+    this.ttlSeconds = Number.isInteger(options.ttlSeconds) && options.ttlSeconds > 0
+      ? options.ttlSeconds
+      : 24 * 60 * 60;
+  }
+
+  // Send a single push notification to a single subscription. Returns
+  // `{ok, status, gone}`. Caller is expected to update the subscription
+  // store based on the result.
+  async sendOne(subscription, payload, { ttlSeconds = this.ttlSeconds } = {}) {
+    if (!this.enabled) return { ok: false, status: null, skipped: true, reason: "disabled" };
+    const keys = this.getPushKeys();
+    if (!keys || !keys.publicKey || !keys.privateKey) {
+      throw new NotificationServiceError(
+        "VAPID_MISSING",
+        "Cannot send: VAPID keypair not provisioned."
+      );
+    }
+    const body = JSON.stringify(buildPayload(payload));
+    if (Buffer.byteLength(body, "utf8") > PAYLOAD_MAX_BYTES) {
+      throw new NotificationServiceError(
+        "PAYLOAD_TOO_LARGE",
+        `Notification payload is ${Buffer.byteLength(body, "utf8")} bytes; cap is ${PAYLOAD_MAX_BYTES}.`
+      );
+    }
+    try {
+      this.webPush.setVapidDetails(keys.subject, keys.publicKey, keys.privateKey);
+      await this.webPush.sendNotification(
+        {
+          endpoint: subscription.endpoint,
+          keys: subscription.keys
+        },
+        body,
+        { TTL: ttlSeconds }
+      );
+      return { ok: true, status: 200, gone: false };
+    } catch (err) {
+      const classification = classifyResponse(err);
+      this.logger.warn?.(`[notify] send failed for ${subscription.endpointHash}:`, err.message || err);
+      return { ...classification, error: err.message || String(err) };
+    }
+  }
+
+  // Broadcast to every active subscription. Settles all sends with a
+  // small concurrency cap. Updates the store: success bumps
+  // lastSuccessAt; gone deletes; non-gone failures increment streak.
+  // Returns aggregate counts.
+  async broadcast(payload, { dryRun = false } = {}) {
+    if (!this.enabled) return { sent: 0, failed: 0, gone: 0, skipped: true, reason: "disabled" };
+    const subs = await this.subscriptionStore.list();
+    if (dryRun) {
+      return {
+        recipients: subs.length,
+        preview: buildPayload(payload),
+        dryRun: true
+      };
+    }
+    let sent = 0;
+    let failed = 0;
+    let gone = 0;
+    const queue = subs.slice();
+    const workers = Array.from({ length: Math.min(this.maxConcurrent, queue.length) }, async () => {
+      while (queue.length > 0) {
+        const sub = queue.shift();
+        if (!sub) break;
+        const result = await this.sendOne(sub, payload);
+        if (result.ok) {
+          await this.subscriptionStore.markSuccess(sub.endpointHash).catch(() => {});
+          sent += 1;
+        } else if (result.gone) {
+          await this.subscriptionStore.markFailure(sub.endpointHash, { gone: true }).catch(() => {});
+          gone += 1;
+        } else {
+          await this.subscriptionStore.markFailure(sub.endpointHash, { gone: false }).catch(() => {});
+          failed += 1;
+        }
+      }
+    });
+    await Promise.all(workers);
+    return { sent, failed, gone, recipients: subs.length };
+  }
+}
+
+module.exports = {
+  NotificationService,
+  NotificationServiceError,
+  buildPayload,
+  classifyResponse,
+  PAYLOAD_MAX_BYTES,
+  TITLE_MAX_LENGTH,
+  BODY_MAX_LENGTH
+};

--- a/lib/push-subscription-store.js
+++ b/lib/push-subscription-store.js
@@ -1,0 +1,440 @@
+"use strict";
+
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const nodeCrypto = require("node:crypto");
+
+const STORE_VERSION = 1;
+const ENDPOINT_HASH_PATTERN = /^[a-f0-9]{16}$/;
+const ENDPOINT_PATTERN = /^https:\/\//;
+const ENDPOINT_MAX_LENGTH = 4096;
+const P256DH_MAX_LENGTH = 256;
+const AUTH_MAX_LENGTH = 64;
+const UA_MAX_LENGTH = 256;
+// Mirror admin-jobs-store.js — Windows surfaces these on rename-over-existing.
+const WINDOWS_RENAME_OVERWRITE_CODES = new Set(["EEXIST", "EPERM", "EACCES"]);
+
+class PushSubscriptionStoreError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = "PushSubscriptionStoreError";
+    this.code = code;
+    if (options.cause) this.cause = options.cause;
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function endpointHashOf(endpoint) {
+  return nodeCrypto.createHash("sha256").update(endpoint).digest("hex").slice(0, 16);
+}
+
+function normalizeEndpoint(raw) {
+  if (typeof raw !== "string") {
+    throw new PushSubscriptionStoreError("INVALID_REQUEST", "endpoint must be a string.");
+  }
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.length > ENDPOINT_MAX_LENGTH) {
+    throw new PushSubscriptionStoreError("INVALID_REQUEST", "endpoint must be 1–4096 chars.");
+  }
+  if (!ENDPOINT_PATTERN.test(trimmed)) {
+    throw new PushSubscriptionStoreError("INVALID_REQUEST", "endpoint must use https:// scheme.");
+  }
+  try {
+    new URL(trimmed);
+  } catch (_err) {
+    throw new PushSubscriptionStoreError("INVALID_REQUEST", "endpoint is not a valid URL.");
+  }
+  return trimmed;
+}
+
+function normalizeKeys(raw) {
+  if (!isPlainObject(raw)) {
+    throw new PushSubscriptionStoreError("INVALID_REQUEST", "keys must be an object.");
+  }
+  if (typeof raw.p256dh !== "string" || raw.p256dh.length === 0 || raw.p256dh.length > P256DH_MAX_LENGTH) {
+    throw new PushSubscriptionStoreError(
+      "INVALID_REQUEST",
+      `keys.p256dh must be a 1–${P256DH_MAX_LENGTH} char string.`
+    );
+  }
+  if (typeof raw.auth !== "string" || raw.auth.length === 0 || raw.auth.length > AUTH_MAX_LENGTH) {
+    throw new PushSubscriptionStoreError(
+      "INVALID_REQUEST",
+      `keys.auth must be a 1–${AUTH_MAX_LENGTH} char string.`
+    );
+  }
+  return { p256dh: raw.p256dh, auth: raw.auth };
+}
+
+function normalizeUa(raw) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  if (typeof raw !== "string") {
+    throw new PushSubscriptionStoreError("INVALID_REQUEST", "ua must be a string.");
+  }
+  return raw.length > UA_MAX_LENGTH ? raw.slice(0, UA_MAX_LENGTH) : raw;
+}
+
+function normalizeSubscription(raw) {
+  if (!isPlainObject(raw)) {
+    throw new PushSubscriptionStoreError("INVALID_SUBSCRIPTION", "Subscription must be an object.");
+  }
+  if (!ENDPOINT_HASH_PATTERN.test(raw.endpointHash || "")) {
+    throw new PushSubscriptionStoreError(
+      "INVALID_SUBSCRIPTION",
+      `Invalid endpointHash: ${raw.endpointHash}`
+    );
+  }
+  const out = {
+    endpointHash: raw.endpointHash,
+    endpoint: normalizeEndpoint(raw.endpoint),
+    keys: normalizeKeys(raw.keys),
+    createdAt: typeof raw.createdAt === "string" && raw.createdAt
+      ? raw.createdAt
+      : new Date().toISOString()
+  };
+  const ua = normalizeUa(raw.ua);
+  if (ua !== undefined) out.ua = ua;
+  if (typeof raw.lastSuccessAt === "string" || raw.lastSuccessAt === null) {
+    if (raw.lastSuccessAt) out.lastSuccessAt = raw.lastSuccessAt;
+  }
+  if (typeof raw.lastFailureAt === "string" || raw.lastFailureAt === null) {
+    if (raw.lastFailureAt) out.lastFailureAt = raw.lastFailureAt;
+  }
+  if (typeof raw.firstFailureAt === "string" || raw.firstFailureAt === null) {
+    if (raw.firstFailureAt) out.firstFailureAt = raw.firstFailureAt;
+  }
+  if (Number.isInteger(raw.failureStreak) && raw.failureStreak >= 0) {
+    out.failureStreak = raw.failureStreak;
+  }
+  return out;
+}
+
+function buildDefaultStore() {
+  return {
+    version: STORE_VERSION,
+    updatedAt: new Date().toISOString(),
+    lastBroadcastAt: null,
+    lastDailyFireAt: null,
+    subscriptions: []
+  };
+}
+
+function normalizeStore(raw) {
+  if (!isPlainObject(raw)) {
+    throw new PushSubscriptionStoreError("INVALID_STORE", "Store must be an object.");
+  }
+  if (raw.version !== STORE_VERSION) {
+    throw new PushSubscriptionStoreError(
+      "VERSION_UNSUPPORTED",
+      `Push subscription store version ${raw.version} is not supported.`
+    );
+  }
+  if (typeof raw.updatedAt !== "string") {
+    throw new PushSubscriptionStoreError("INVALID_STORE", "updatedAt is required.");
+  }
+  if (!Array.isArray(raw.subscriptions)) {
+    throw new PushSubscriptionStoreError("INVALID_STORE", "subscriptions must be an array.");
+  }
+  const seen = new Set();
+  const subscriptions = [];
+  for (const sub of raw.subscriptions) {
+    const normalized = normalizeSubscription(sub);
+    if (seen.has(normalized.endpointHash)) continue;
+    seen.add(normalized.endpointHash);
+    subscriptions.push(normalized);
+  }
+  subscriptions.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.endpointHash.localeCompare(b.endpointHash));
+  return {
+    version: STORE_VERSION,
+    updatedAt: raw.updatedAt,
+    lastBroadcastAt: typeof raw.lastBroadcastAt === "string" ? raw.lastBroadcastAt : null,
+    lastDailyFireAt: typeof raw.lastDailyFireAt === "string" ? raw.lastDailyFireAt : null,
+    subscriptions
+  };
+}
+
+async function writeJsonAtomic(filePath, payload) {
+  const tempPath = `${filePath}.${process.pid}.${nodeCrypto.randomUUID()}.tmp`;
+  try {
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+    await fsp.writeFile(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    try {
+      await fsp.rename(tempPath, filePath);
+    } catch (renameErr) {
+      if (!renameErr || !WINDOWS_RENAME_OVERWRITE_CODES.has(renameErr.code)) throw renameErr;
+      await fsp.rm(filePath, { force: true });
+      await fsp.rename(tempPath, filePath);
+    }
+  } catch (err) {
+    try { await fsp.rm(tempPath, { force: true }); } catch (_e) { /* best-effort */ }
+    throw new PushSubscriptionStoreError(
+      "STORE_WRITE_FAILED",
+      `Failed to persist push-subscription store to ${filePath}: ${err.message}`,
+      { cause: err }
+    );
+  }
+}
+
+class PushSubscriptionStore {
+  constructor(options = {}) {
+    if (!options.filePath) {
+      throw new PushSubscriptionStoreError("INVALID_REQUEST", "filePath is required.");
+    }
+    this.filePath = options.filePath;
+    this.logger = options.logger || console;
+    this.now = typeof options.now === "function" ? options.now : () => new Date();
+    // 410 Gone responses are pruned after this many days of consecutive
+    // failures. Transient 4xx/5xx don't prune; only persistent 410.
+    this.pruneAfterDays = Number.isInteger(options.pruneAfterDays) && options.pruneAfterDays > 0
+      ? options.pruneAfterDays
+      : 7;
+    // Same atomic-claim wiring as webhook stores — see WebhookStore for
+    // the rationale around backup/restore safety.
+    this.claimDirectDataWriteSlot = typeof options.claimDirectDataWriteSlot === "function"
+      ? options.claimDirectDataWriteSlot
+      : null;
+    this.state = null;
+    this.loadPromise = null;
+    this.commitQueue = Promise.resolve();
+  }
+
+  async load() {
+    if (this.state) return cloneState(this.state);
+    if (!this.loadPromise) {
+      this.loadPromise = this.#loadInternal().catch((err) => {
+        this.loadPromise = null;
+        throw err;
+      });
+    }
+    await this.loadPromise;
+    return cloneState(this.state);
+  }
+
+  async #loadInternal() {
+    let raw;
+    try {
+      raw = await fsp.readFile(this.filePath, "utf8");
+    } catch (err) {
+      if (err && err.code === "ENOENT") {
+        const fresh = buildDefaultStore();
+        fresh.updatedAt = this.now().toISOString();
+        await writeJsonAtomic(this.filePath, fresh);
+        this.state = fresh;
+        return;
+      }
+      throw new PushSubscriptionStoreError(
+        "STORE_READ_FAILED",
+        `Failed to read push-subscription store from ${this.filePath}: ${err.message}`,
+        { cause: err }
+      );
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new PushSubscriptionStoreError(
+        "STORE_PARSE_FAILED",
+        `Push-subscription store ${this.filePath} is not valid JSON: ${err.message}`,
+        { cause: err }
+      );
+    }
+    this.state = normalizeStore(parsed);
+  }
+
+  async getSnapshot() {
+    return this.load();
+  }
+
+  async reload() {
+    await this.commitQueue.catch(() => {});
+    if (this.loadPromise) await this.loadPromise.catch(() => {});
+    this.state = null;
+    this.loadPromise = null;
+    return this.load();
+  }
+
+  async #commit(updater) {
+    let releaseSlot = null;
+    if (this.claimDirectDataWriteSlot) {
+      releaseSlot = await this.claimDirectDataWriteSlot();
+    }
+    const run = async () => {
+      try {
+        const current = this.state ? cloneState(this.state) : await this.load();
+        const next = updater(current);
+        next.updatedAt = this.now().toISOString();
+        const finalState = normalizeStore(next);
+        await writeJsonAtomic(this.filePath, finalState);
+        this.state = finalState;
+        return cloneState(this.state);
+      } finally {
+        if (releaseSlot) releaseSlot();
+      }
+    };
+    const next = this.commitQueue.then(run, run);
+    this.commitQueue = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  // Insert or update by endpoint. Two browsers on the same host hit
+  // different endpoints — they're separate subscriptions. The same
+  // endpoint re-registering (re-subscribe after permission toggle)
+  // updates the existing row in place rather than duplicating.
+  async upsert({ endpoint, keys, ua } = {}) {
+    const normalizedEndpoint = normalizeEndpoint(endpoint);
+    const normalizedKeys = normalizeKeys(keys);
+    const normalizedUa = normalizeUa(ua);
+    const endpointHash = endpointHashOf(normalizedEndpoint);
+    let result;
+    await this.#commit((state) => {
+      const idx = state.subscriptions.findIndex((s) => s.endpointHash === endpointHash);
+      const nowIso = this.now().toISOString();
+      if (idx >= 0) {
+        const merged = { ...state.subscriptions[idx], endpoint: normalizedEndpoint, keys: normalizedKeys };
+        if (normalizedUa !== undefined) merged.ua = normalizedUa;
+        state.subscriptions.splice(idx, 1, merged);
+        result = merged;
+      } else {
+        const fresh = {
+          endpointHash,
+          endpoint: normalizedEndpoint,
+          keys: normalizedKeys,
+          createdAt: nowIso
+        };
+        if (normalizedUa !== undefined) fresh.ua = normalizedUa;
+        state.subscriptions.push(fresh);
+        result = fresh;
+      }
+      return state;
+    });
+    return cloneState(result);
+  }
+
+  async removeByHash(endpointHash) {
+    if (!ENDPOINT_HASH_PATTERN.test(String(endpointHash || ""))) {
+      throw new PushSubscriptionStoreError("INVALID_REQUEST", "Invalid endpointHash.");
+    }
+    let removed = null;
+    await this.#commit((state) => {
+      const idx = state.subscriptions.findIndex((s) => s.endpointHash === endpointHash);
+      if (idx === -1) return state;
+      removed = state.subscriptions[idx];
+      state.subscriptions.splice(idx, 1);
+      return state;
+    });
+    return cloneState(removed);
+  }
+
+  async findByHash(endpointHash) {
+    const snap = await this.load();
+    return snap.subscriptions.find((s) => s.endpointHash === endpointHash) || null;
+  }
+
+  async list() {
+    const snap = await this.load();
+    return snap.subscriptions.slice();
+  }
+
+  // Mark a successful send: clear failure tracking, bump lastSuccessAt.
+  async markSuccess(endpointHash) {
+    if (!ENDPOINT_HASH_PATTERN.test(String(endpointHash || ""))) {
+      throw new PushSubscriptionStoreError("INVALID_REQUEST", "Invalid endpointHash.");
+    }
+    let updated = null;
+    await this.#commit((state) => {
+      const idx = state.subscriptions.findIndex((s) => s.endpointHash === endpointHash);
+      if (idx === -1) return state;
+      const merged = { ...state.subscriptions[idx], lastSuccessAt: this.now().toISOString() };
+      delete merged.failureStreak;
+      delete merged.firstFailureAt;
+      delete merged.lastFailureAt;
+      state.subscriptions.splice(idx, 1, merged);
+      updated = merged;
+      return state;
+    });
+    return cloneState(updated);
+  }
+
+  // Mark a failure. If `gone === true`, the row is deleted immediately
+  // (HTTP 410 means the subscription is permanently invalid). Otherwise
+  // we increment failureStreak and stamp firstFailureAt; the prune()
+  // method evicts streaks older than `pruneAfterDays`.
+  async markFailure(endpointHash, { gone = false } = {}) {
+    if (!ENDPOINT_HASH_PATTERN.test(String(endpointHash || ""))) {
+      throw new PushSubscriptionStoreError("INVALID_REQUEST", "Invalid endpointHash.");
+    }
+    let result = null;
+    await this.#commit((state) => {
+      const idx = state.subscriptions.findIndex((s) => s.endpointHash === endpointHash);
+      if (idx === -1) return state;
+      if (gone) {
+        result = { ...state.subscriptions[idx], pruned: true };
+        state.subscriptions.splice(idx, 1);
+        return state;
+      }
+      const current = state.subscriptions[idx];
+      const nowIso = this.now().toISOString();
+      const merged = {
+        ...current,
+        lastFailureAt: nowIso,
+        failureStreak: (current.failureStreak || 0) + 1,
+        firstFailureAt: current.firstFailureAt || nowIso
+      };
+      state.subscriptions.splice(idx, 1, merged);
+      result = merged;
+      return state;
+    });
+    return cloneState(result);
+  }
+
+  // Evict subscriptions whose failure streak first started more than
+  // `pruneAfterDays` ago. This catches rows that returned non-410 errors
+  // but never came back; the operator's logs will show the streak.
+  async pruneStale() {
+    const cutoff = this.now().getTime() - this.pruneAfterDays * 24 * 60 * 60 * 1000;
+    const removed = [];
+    await this.#commit((state) => {
+      state.subscriptions = state.subscriptions.filter((s) => {
+        if (!s.firstFailureAt) return true;
+        const firstFailMs = new Date(s.firstFailureAt).getTime();
+        if (Number.isNaN(firstFailMs) || firstFailMs > cutoff) return true;
+        removed.push(s.endpointHash);
+        return false;
+      });
+      return state;
+    });
+    return removed;
+  }
+
+  async stampLastBroadcast(at = this.now()) {
+    await this.#commit((state) => {
+      state.lastBroadcastAt = at.toISOString();
+      return state;
+    });
+  }
+
+  async stampLastDailyFire(at = this.now()) {
+    await this.#commit((state) => {
+      state.lastDailyFireAt = at.toISOString();
+      return state;
+    });
+  }
+}
+
+function cloneState(state) {
+  if (state === null || state === undefined) return state;
+  return JSON.parse(JSON.stringify(state));
+}
+
+module.exports = {
+  PushSubscriptionStore,
+  PushSubscriptionStoreError,
+  endpointHashOf,
+  normalizeSubscription,
+  normalizeStore,
+  STORE_VERSION,
+  ENDPOINT_HASH_PATTERN
+};

--- a/lib/push-subscription-store.js
+++ b/lib/push-subscription-store.js
@@ -198,8 +198,11 @@ class PushSubscriptionStore {
     this.filePath = options.filePath;
     this.logger = options.logger || console;
     this.now = typeof options.now === "function" ? options.now : () => new Date();
-    // 410 Gone responses are pruned after this many days of consecutive
-    // failures. Transient 4xx/5xx don't prune; only persistent 410.
+    // Cutoff (in days) used by `pruneStale()` to evict subscriptions
+    // whose `firstFailureAt` is older than this. HTTP 410 (Gone)
+    // responses are pruned IMMEDIATELY in `markFailure({gone:true})`
+    // and don't depend on this value; only non-410 transient failure
+    // streaks rely on the cutoff to eventually purge dead rows.
     this.pruneAfterDays = Number.isInteger(options.pruneAfterDays) && options.pruneAfterDays > 0
       ? options.pruneAfterDays
       : 7;

--- a/lib/push-subscription-store.js
+++ b/lib/push-subscription-store.js
@@ -87,9 +87,21 @@ function normalizeSubscription(raw) {
       `Invalid endpointHash: ${raw.endpointHash}`
     );
   }
+  const normalizedEndpoint = normalizeEndpoint(raw.endpoint);
+  // The hash MUST match the endpoint — every dedupe/lookup/remove path
+  // keys off endpointHash, so a hand-edited row with mismatched hash
+  // would orphan the real endpoint or collide with the wrong row. Re-
+  // compute and reject divergence rather than trusting on-disk input.
+  const expectedHash = endpointHashOf(normalizedEndpoint);
+  if (raw.endpointHash !== expectedHash) {
+    throw new PushSubscriptionStoreError(
+      "INVALID_SUBSCRIPTION",
+      "endpointHash does not match sha256 of endpoint."
+    );
+  }
   const out = {
-    endpointHash: raw.endpointHash,
-    endpoint: normalizeEndpoint(raw.endpoint),
+    endpointHash: expectedHash,
+    endpoint: normalizedEndpoint,
     keys: normalizeKeys(raw.keys),
     createdAt: typeof raw.createdAt === "string" && raw.createdAt
       ? raw.createdAt
@@ -294,6 +306,14 @@ class PushSubscriptionStore {
       const nowIso = this.now().toISOString();
       if (idx >= 0) {
         const merged = { ...state.subscriptions[idx], endpoint: normalizedEndpoint, keys: normalizedKeys };
+        // Reset failure tracking — a re-upsert is the user explicitly
+        // re-establishing this device's subscription; without this,
+        // a browser refreshing after a few transient failures could be
+        // pruned by `pruneStale` almost immediately on its fresh
+        // registration.
+        delete merged.failureStreak;
+        delete merged.firstFailureAt;
+        delete merged.lastFailureAt;
         if (normalizedUa !== undefined) merged.ua = normalizedUa;
         state.subscriptions.splice(idx, 1, merged);
         result = merged;

--- a/lib/vapid-store.js
+++ b/lib/vapid-store.js
@@ -1,0 +1,179 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const nodeCrypto = require("node:crypto");
+
+// Dedicated store for the VAPID keypair so the private half stays out
+// of any user-visible export path. The earlier design persisted these
+// in `data/app-config.json`, but that file is part of the backup
+// archive — admin-key-holders downloading a backup could extract the
+// private key from offline copies. Splitting it into a separate file
+// (NOT in the backup `IN_SCOPE_FILES` list) keeps the secret pinned
+// to the host that generated it; restoring a backup on a fresh node
+// triggers re-generation, which invalidates existing subscriptions
+// — but that was already true for any restore-to-new-host scenario.
+
+const SCHEMA_VERSION = 1;
+const VAPID_SUBJECT_PATTERN = /^(mailto:|https:)/;
+const WINDOWS_RENAME_OVERWRITE_CODES = new Set(["EEXIST", "EPERM", "EACCES"]);
+
+class VapidStoreError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = "VapidStoreError";
+    this.code = code;
+    if (options.cause) this.cause = options.cause;
+  }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function clone(value) {
+  if (value === null || value === undefined) return value;
+  return structuredClone(value);
+}
+
+function writeJsonAtomicSync(filePath, payload) {
+  const tempPath = `${filePath}.${process.pid}.${nodeCrypto.randomUUID()}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    try {
+      fs.renameSync(tempPath, filePath);
+    } catch (renameErr) {
+      if (!renameErr || !WINDOWS_RENAME_OVERWRITE_CODES.has(renameErr.code)) throw renameErr;
+      fs.rmSync(filePath, { force: true });
+      fs.renameSync(tempPath, filePath);
+    }
+  } catch (err) {
+    try { fs.rmSync(tempPath, { force: true }); } catch (_e) { /* best-effort */ }
+    throw new VapidStoreError(
+      "STORE_WRITE_FAILED",
+      `Failed to persist VAPID store at ${filePath}.`,
+      { cause: err }
+    );
+  }
+}
+
+function normalizeKeys(raw) {
+  if (!isObject(raw)) {
+    throw new VapidStoreError("INVALID_KEYS", "pushKeys must be an object.");
+  }
+  if (typeof raw.publicKey !== "string" || raw.publicKey.length < 80 || raw.publicKey.length > 200) {
+    throw new VapidStoreError(
+      "INVALID_KEYS",
+      "pushKeys.publicKey must be the URL-safe base64 string from generateVAPIDKeys()."
+    );
+  }
+  if (typeof raw.privateKey !== "string" || raw.privateKey.length < 40 || raw.privateKey.length > 100) {
+    throw new VapidStoreError(
+      "INVALID_KEYS",
+      "pushKeys.privateKey must be the URL-safe base64 string from generateVAPIDKeys()."
+    );
+  }
+  if (typeof raw.subject !== "string" || !VAPID_SUBJECT_PATTERN.test(raw.subject) || raw.subject.length > 256) {
+    throw new VapidStoreError(
+      "INVALID_KEYS",
+      "pushKeys.subject must be a mailto: or https: identifier (RFC 8292)."
+    );
+  }
+  return {
+    publicKey: raw.publicKey,
+    privateKey: raw.privateKey,
+    subject: raw.subject
+  };
+}
+
+class VapidStore {
+  constructor(options = {}) {
+    if (!options.filePath) {
+      throw new VapidStoreError("INVALID_REQUEST", "filePath is required.");
+    }
+    this.filePath = options.filePath;
+    this.logger = options.logger || console;
+    this.state = null;
+  }
+
+  loadSync() {
+    if (this.state) return clone(this.state);
+    if (!fs.existsSync(this.filePath)) {
+      this.state = null;
+      return null;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(this.filePath, "utf8"));
+    } catch (err) {
+      this.logger.warn?.(
+        `[vapid-store] ${this.filePath} is not valid JSON; treating as missing. (${err.message})`
+      );
+      this.state = null;
+      return null;
+    }
+    if (!isObject(parsed) || parsed.version !== SCHEMA_VERSION || !isObject(parsed.keys)) {
+      this.logger.warn?.(
+        `[vapid-store] ${this.filePath} has unsupported shape; treating as missing.`
+      );
+      this.state = null;
+      return null;
+    }
+    try {
+      const keys = normalizeKeys(parsed.keys);
+      this.state = { version: SCHEMA_VERSION, keys, updatedAt: parsed.updatedAt || new Date().toISOString() };
+    } catch (err) {
+      this.logger.warn?.(`[vapid-store] ignoring invalid keys in ${this.filePath}: ${err.message}`);
+      this.state = null;
+    }
+    return clone(this.state);
+  }
+
+  reloadSync() {
+    this.state = null;
+    return this.loadSync();
+  }
+
+  // Returns the persisted VAPID keypair or null if none exists yet.
+  // The private key is included — server-only callers; never echo to
+  // clients or include in backup/runtime-config responses.
+  getKeysSync() {
+    const snap = this.loadSync();
+    return snap ? clone(snap.keys) : null;
+  }
+
+  // Generate-on-missing: if no keys yet, calls `generate` (typically
+  // `web-push.generateVAPIDKeys`) and persists. Idempotent: subsequent
+  // calls return existing keys.
+  ensureKeysSync({ generate, subject } = {}) {
+    if (typeof generate !== "function") {
+      throw new VapidStoreError(
+        "INVALID_REQUEST",
+        "ensureKeysSync requires a generate function (e.g. web-push.generateVAPIDKeys)."
+      );
+    }
+    const existing = this.getKeysSync();
+    if (existing) return existing;
+    const fresh = generate();
+    const resolvedSubject = (typeof subject === "string" && VAPID_SUBJECT_PATTERN.test(subject))
+      ? subject
+      : "mailto:admin@localhost";
+    const normalized = normalizeKeys({ ...fresh, subject: resolvedSubject });
+    const nextState = {
+      version: SCHEMA_VERSION,
+      updatedAt: new Date().toISOString(),
+      keys: normalized
+    };
+    writeJsonAtomicSync(this.filePath, nextState);
+    this.state = nextState;
+    return clone(normalized);
+  }
+}
+
+module.exports = {
+  VapidStore,
+  VapidStoreError,
+  normalizeKeys,
+  SCHEMA_VERSION
+};

--- a/lib/vapid-store.js
+++ b/lib/vapid-store.js
@@ -65,19 +65,19 @@ function normalizeKeys(raw) {
   if (typeof raw.publicKey !== "string" || raw.publicKey.length < 80 || raw.publicKey.length > 200) {
     throw new VapidStoreError(
       "INVALID_KEYS",
-      "pushKeys.publicKey must be the URL-safe base64 string from generateVAPIDKeys()."
+      "vapid-keys.publicKey must be the URL-safe base64 string from generateVAPIDKeys()."
     );
   }
   if (typeof raw.privateKey !== "string" || raw.privateKey.length < 40 || raw.privateKey.length > 100) {
     throw new VapidStoreError(
       "INVALID_KEYS",
-      "pushKeys.privateKey must be the URL-safe base64 string from generateVAPIDKeys()."
+      "vapid-keys.privateKey must be the URL-safe base64 string from generateVAPIDKeys()."
     );
   }
   if (typeof raw.subject !== "string" || !VAPID_SUBJECT_PATTERN.test(raw.subject) || raw.subject.length > 256) {
     throw new VapidStoreError(
       "INVALID_KEYS",
-      "pushKeys.subject must be a mailto: or https: identifier (RFC 8292)."
+      "vapid-keys.subject must be a mailto: or https: identifier (RFC 8292)."
     );
   }
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^8.1.0",
         "nspell": "^2.1.5",
         "undici": "^7.25.0",
+        "web-push": "^3.6.7",
         "yauzl": "^3.3.0"
       },
       "devDependencies": {
@@ -2009,6 +2010,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -2199,6 +2209,18 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -2480,6 +2502,12 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -2604,6 +2632,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3125,6 +3159,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -4217,6 +4260,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4236,6 +4288,42 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -5287,6 +5375,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5548,6 +5657,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -5559,6 +5674,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -6969,6 +7093,25 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "helmet": "^8.1.0",
     "nspell": "^2.1.5",
     "undici": "^7.25.0",
+    "web-push": "^3.6.7",
     "yauzl": "^3.3.0"
   },
   "devDependencies": {

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -171,7 +171,10 @@ const state = {
   // an older subscription can't overwrite a fresh table when the
   // operator switches the dropdown rapidly.
   webhookDeliveriesRequestId: 0,
-  webhookDeliveries: []
+  webhookDeliveries: [],
+  notificationsLoading: false,
+  notificationsRequestId: 0,
+  notificationsSummary: null
 };
 
 let jobsRefreshTimer = null;
@@ -344,6 +347,9 @@ function activateTab(nextTab, focus = false) {
   }
   if (tabId === "webhooks" && state.unlocked && !state.webhooksLoading) {
     loadWebhooks({ announce: true }).catch(() => {});
+  }
+  if (tabId === "notifications" && state.unlocked && !state.notificationsLoading) {
+    loadNotifications({ announce: true }).catch(() => {});
   }
 }
 
@@ -2022,6 +2028,9 @@ async function unlockWorkspace() {
     if (state.unlocked && state.activeTab === "webhooks") {
       loadWebhooks({ announce: true }).catch(() => {});
     }
+    if (state.unlocked && state.activeTab === "notifications") {
+      loadNotifications({ announce: true }).catch(() => {});
+    }
   } finally {
     state.loading = false;
     renderWorkspace();
@@ -2364,6 +2373,9 @@ lockSessionBtnEl.addEventListener("click", () => {
   state.webhookSubscriptions = [];
   state.webhookDeliveries = [];
   state.webhookDeliveriesSubscriptionId = null;
+  state.notificationsRequestId += 1;
+  state.notificationsLoading = false;
+  state.notificationsSummary = null;
   // Clear any one-time secret that's still on screen — without this,
   // locking on the Webhooks tab and unlocking again would leave the
   // previously revealed secret visible until loadWebhooks() finishes.
@@ -3698,6 +3710,117 @@ if (webhookDeliveriesRefreshBtnEl) {
     const id = state.webhookDeliveriesSubscriptionId
       || (webhookDeliveriesSubscriptionEl && webhookDeliveriesSubscriptionEl.value);
     if (id) loadWebhookDeliveries(id).catch(() => {});
+  });
+}
+
+// ── Notifications tab ──────────────────────────────────────────────────
+const notificationsStatusEl = document.getElementById("notificationsStatus");
+const notifSubscriptionCountEl = document.getElementById("notifSubscriptionCount");
+const notifLastBroadcastEl = document.getElementById("notifLastBroadcast");
+const notifLastDailyFireEl = document.getElementById("notifLastDailyFire");
+const notifRefreshBtnEl = document.getElementById("notifRefreshBtn");
+const notifBroadcastFormEl = document.getElementById("notifBroadcastForm");
+const notifBroadcastTitleEl = document.getElementById("notifBroadcastTitle");
+const notifBroadcastBodyEl = document.getElementById("notifBroadcastBody");
+const notifBroadcastUrlEl = document.getElementById("notifBroadcastUrl");
+const notifBroadcastPreviewBtnEl = document.getElementById("notifBroadcastPreviewBtn");
+const notifBroadcastPreviewEl = document.getElementById("notifBroadcastPreview");
+const notifBroadcastPreviewTextEl = document.getElementById("notifBroadcastPreviewText");
+
+async function loadNotifications(options = {}) {
+  if (!state.unlocked) return;
+  if (state.notificationsLoading) return;
+  state.notificationsLoading = true;
+  const requestId = ++state.notificationsRequestId;
+  if (options.announce !== false) setStatus(notificationsStatusEl, "Loading…");
+  try {
+    const payload = await requestAdminJson("/api/admin/notifications/subscriptions");
+    if (requestId !== state.notificationsRequestId) return;
+    state.notificationsSummary = payload;
+    renderNotificationsSummary();
+    if (options.announce !== false) setStatus(notificationsStatusEl, "Loaded.", "admin-status-ok");
+  } catch (err) {
+    if (requestId !== state.notificationsRequestId) return;
+    setStatus(notificationsStatusEl, `Load failed: ${err.message}`, "admin-status-missing");
+  } finally {
+    if (requestId === state.notificationsRequestId) {
+      state.notificationsLoading = false;
+    }
+  }
+}
+
+function renderNotificationsSummary() {
+  const summary = state.notificationsSummary;
+  if (!summary) return;
+  if (notifSubscriptionCountEl) {
+    notifSubscriptionCountEl.textContent = String(summary.count ?? 0);
+  }
+  if (notifLastBroadcastEl) {
+    notifLastBroadcastEl.textContent = summary.lastBroadcastAt ? formatTimestamp(summary.lastBroadcastAt) : "Never";
+  }
+  if (notifLastDailyFireEl) {
+    notifLastDailyFireEl.textContent = summary.lastDailyFireAt ? formatTimestamp(summary.lastDailyFireAt) : "Never";
+  }
+}
+
+if (notifRefreshBtnEl) {
+  notifRefreshBtnEl.addEventListener("click", () => {
+    loadNotifications({ announce: true }).catch(() => {});
+  });
+}
+
+async function submitBroadcast({ dryRun }) {
+  if (!state.unlocked) return;
+  const title = String(notifBroadcastTitleEl?.value || "").trim();
+  const body = String(notifBroadcastBodyEl?.value || "").trim();
+  const url = String(notifBroadcastUrlEl?.value || "").trim() || "/";
+  if (!title || !body) {
+    setStatus(notificationsStatusEl, "Title and body are required.", "admin-status-missing");
+    return;
+  }
+  if (!dryRun) {
+    if (!window.confirm(`Send "${title}" to all subscribers?`)) return;
+  }
+  let payload;
+  try {
+    payload = await requestAdminJson("/api/admin/notifications/broadcast", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title, body, url, dryRun: dryRun === true })
+    });
+  } catch (err) {
+    setStatus(notificationsStatusEl, `Broadcast failed: ${err.message}`, "admin-status-missing");
+    return;
+  }
+  if (dryRun) {
+    if (notifBroadcastPreviewEl && notifBroadcastPreviewTextEl) {
+      const p = payload.result?.preview || { title, body, url };
+      notifBroadcastPreviewTextEl.textContent = `${p.title} · ${p.body} · ${p.url} (${payload.result?.recipients ?? 0} recipient(s))`;
+      notifBroadcastPreviewEl.hidden = false;
+    }
+    setStatus(notificationsStatusEl, "Preview rendered.", "admin-status-ok");
+  } else {
+    setStatus(
+      notificationsStatusEl,
+      `Sent: ${payload.result?.sent ?? 0}, failed: ${payload.result?.failed ?? 0}, gone: ${payload.result?.gone ?? 0}.`,
+      "admin-status-ok"
+    );
+    if (notifBroadcastPreviewEl) notifBroadcastPreviewEl.hidden = true;
+    notifBroadcastFormEl?.reset();
+    loadNotifications({ announce: false }).catch(() => {});
+  }
+}
+
+if (notifBroadcastPreviewBtnEl) {
+  notifBroadcastPreviewBtnEl.addEventListener("click", () => {
+    submitBroadcast({ dryRun: true }).catch(() => {});
+  });
+}
+
+if (notifBroadcastFormEl) {
+  notifBroadcastFormEl.addEventListener("submit", (event) => {
+    event.preventDefault();
+    submitBroadcast({ dryRun: false }).catch(() => {});
   });
 }
 

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -180,6 +180,18 @@
             >
               Webhooks
             </button>
+            <button
+              id="admin-tab-notifications"
+              type="button"
+              class="ghost admin-tab"
+              data-tab="notifications"
+              role="tab"
+              aria-controls="admin-panel-notifications"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              Notifications
+            </button>
           </nav>
 
           <section
@@ -1112,6 +1124,68 @@
                   </thead>
                   <tbody></tbody>
                 </table>
+              </div>
+            </section>
+          </section>
+
+          <section
+            id="admin-panel-notifications"
+            class="admin-slot"
+            data-panel="notifications"
+            role="tabpanel"
+            aria-labelledby="admin-tab-notifications"
+            tabindex="0"
+            hidden
+          >
+            <h3>Push notifications</h3>
+            <p class="note">
+              Self-hosted Web Push: subscribers register from the player
+              UI; the daily fire dispatches at the configured local time.
+              Use Broadcast for one-off operator messages. See
+              <code>docs/notifications.md</code> for VAPID, browser-support
+              caveats, and troubleshooting.
+            </p>
+
+            <div id="notificationsStatus" class="message" role="status" aria-live="polite"></div>
+
+            <section class="admin-subpanel">
+              <h4>Status</h4>
+              <div class="schedule-status-strip">
+                <span><strong>Subscriptions:</strong> <span id="notifSubscriptionCount">—</span></span>
+                <span><strong>Last broadcast:</strong> <span id="notifLastBroadcast">—</span></span>
+                <span><strong>Last daily fire:</strong> <span id="notifLastDailyFire">—</span></span>
+              </div>
+              <button type="button" id="notifRefreshBtn" class="ghost">Refresh</button>
+            </section>
+
+            <section class="admin-subpanel">
+              <h4>Broadcast</h4>
+              <form id="notifBroadcastForm" class="form-inline">
+                <label class="form-inline">
+                  <span>Title</span>
+                  <input type="text" id="notifBroadcastTitle" maxlength="80" required autocomplete="off" />
+                </label>
+                <label class="form-inline">
+                  <span>Body</span>
+                  <input type="text" id="notifBroadcastBody" maxlength="200" required autocomplete="off" />
+                </label>
+                <label class="form-inline">
+                  <span>URL (site-relative)</span>
+                  <input
+                    type="text"
+                    id="notifBroadcastUrl"
+                    maxlength="256"
+                    placeholder="/"
+                    pattern="^/.*"
+                    autocomplete="off"
+                  />
+                </label>
+                <button type="button" id="notifBroadcastPreviewBtn" class="ghost">Preview</button>
+                <button type="submit" id="notifBroadcastSendBtn">Send to all</button>
+              </form>
+              <div id="notifBroadcastPreview" class="message" role="status" aria-live="polite" hidden>
+                <strong>Preview:</strong>
+                <span id="notifBroadcastPreviewText"></span>
               </div>
             </section>
           </section>

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1176,7 +1176,8 @@
                     id="notifBroadcastUrl"
                     maxlength="256"
                     placeholder="/"
-                    pattern="^/.*"
+                    pattern="^/(?!/).*"
+                    title="Must be a root-relative path starting with a single /"
                     autocomplete="off"
                   />
                 </label>

--- a/public/app.js
+++ b/public/app.js
@@ -1546,8 +1546,172 @@ async function init() {
 
 init();
 
+// ── Daily puzzle push notifications ──────────────────────────────────
+// Self-contained block at the end so adding/removing the feature is a
+// single contiguous edit. The opt-in toggle is hidden unless the
+// browser supports Notification + Service Worker + PushManager AND the
+// page is loaded over a secure context (HTTPS or localhost).
+const NOTIFICATION_HASH_STORAGE_KEY = 'wordle.pushEndpointHash';
+const notificationToggleEl = document.getElementById('notificationToggle');
+const notificationToggleLabelEl = document.getElementById('notificationToggleLabel');
+const notificationStatusEl = document.getElementById('notificationStatus');
+
+function pushNotificationsSupported() {
+  return Boolean(
+    typeof window !== 'undefined'
+    && 'serviceWorker' in navigator
+    && 'PushManager' in window
+    && 'Notification' in window
+    && (window.isSecureContext || location.hostname === 'localhost' || location.hostname === '127.0.0.1')
+  );
+}
+
+function setNotificationStatus(text) {
+  if (notificationStatusEl) notificationStatusEl.textContent = text || '';
+}
+
+function setNotificationLabel(text) {
+  if (notificationToggleLabelEl) notificationToggleLabelEl.textContent = text;
+}
+
+function urlBase64ToUint8Array(base64String) {
+  // The PushManager subscribe API needs the VAPID public key as raw
+  // bytes, not the URL-safe base64 the server emits.
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = window.atob(base64);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+async function getNotificationRegistration() {
+  if (!('serviceWorker' in navigator)) return null;
+  // ready resolves once the active SW is installed AND activated, so a
+  // first-load subscribe doesn't race a still-installing worker.
+  return navigator.serviceWorker.ready;
+}
+
+async function refreshNotificationToggle() {
+  if (!notificationToggleEl) return;
+  if (!pushNotificationsSupported()) {
+    notificationToggleEl.hidden = true;
+    setNotificationStatus(window.isSecureContext ? '' : 'Notifications need HTTPS or localhost.');
+    return;
+  }
+  notificationToggleEl.hidden = false;
+  if (Notification.permission === 'denied') {
+    notificationToggleEl.disabled = true;
+    notificationToggleEl.setAttribute('aria-pressed', 'false');
+    setNotificationLabel('Notifications blocked');
+    setNotificationStatus('Open browser settings to allow notifications, then reload.');
+    return;
+  }
+  notificationToggleEl.disabled = false;
+  let subscribed = false;
+  try {
+    const reg = await getNotificationRegistration();
+    if (reg) {
+      const sub = await reg.pushManager.getSubscription();
+      subscribed = Boolean(sub);
+    }
+  } catch (_err) {
+    // pushManager API not available — leave subscribed=false.
+  }
+  notificationToggleEl.setAttribute('aria-pressed', subscribed ? 'true' : 'false');
+  setNotificationLabel(subscribed ? 'Notifications: on' : 'Get notified when daily puzzle is ready');
+  setNotificationStatus('');
+}
+
+async function fetchVapidPublicKey() {
+  const res = await fetch('/api/notifications/vapid-public-key');
+  if (!res.ok) {
+    throw new Error(`Could not fetch VAPID public key (HTTP ${res.status}).`);
+  }
+  const json = await res.json();
+  if (!json.publicKey) throw new Error('Server returned no public key.');
+  return json.publicKey;
+}
+
+async function subscribeToPush() {
+  const reg = await getNotificationRegistration();
+  if (!reg) throw new Error('Service worker not available.');
+  // Ask permission only on the user-gesture path. Auto-prompting is
+  // explicitly out of scope; this respects the locked decision in #92.
+  const permission = await Notification.requestPermission();
+  if (permission !== 'granted') {
+    throw new Error(permission === 'denied' ? 'Permission denied.' : 'Permission not granted.');
+  }
+  const publicKey = await fetchVapidPublicKey();
+  const sub = await reg.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(publicKey)
+  });
+  const subJson = sub.toJSON();
+  const res = await fetch('/api/notifications/subscribe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      endpoint: subJson.endpoint,
+      keys: subJson.keys
+    })
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Subscribe failed (HTTP ${res.status}).`);
+  }
+  const json = await res.json();
+  if (json.endpointHash) {
+    try { localStorage.setItem(NOTIFICATION_HASH_STORAGE_KEY, json.endpointHash); } catch (_e) { /* ignore */ }
+  }
+}
+
+async function unsubscribeFromPush() {
+  const reg = await getNotificationRegistration();
+  if (!reg) return;
+  const sub = await reg.pushManager.getSubscription();
+  let endpointHash = null;
+  try { endpointHash = localStorage.getItem(NOTIFICATION_HASH_STORAGE_KEY); } catch (_e) { /* ignore */ }
+  if (sub) {
+    try { await sub.unsubscribe(); } catch (_e) { /* best-effort */ }
+  }
+  if (endpointHash) {
+    try {
+      await fetch(`/api/notifications/subscribe/${encodeURIComponent(endpointHash)}`, {
+        method: 'DELETE'
+      });
+    } catch (_e) { /* server cleanup is best-effort; the row will prune via failure streak */ }
+    try { localStorage.removeItem(NOTIFICATION_HASH_STORAGE_KEY); } catch (_e) { /* ignore */ }
+  }
+}
+
+if (notificationToggleEl) {
+  notificationToggleEl.addEventListener('click', async () => {
+    if (notificationToggleEl.disabled) return;
+    notificationToggleEl.disabled = true;
+    setNotificationStatus('Working…');
+    try {
+      const isSubscribed = notificationToggleEl.getAttribute('aria-pressed') === 'true';
+      if (isSubscribed) {
+        await unsubscribeFromPush();
+        setNotificationStatus('Notifications turned off.');
+      } else {
+        await subscribeToPush();
+        setNotificationStatus('You will be notified when the daily puzzle is ready.');
+      }
+    } catch (err) {
+      setNotificationStatus(err.message || 'Something went wrong.');
+    } finally {
+      notificationToggleEl.disabled = false;
+      refreshNotificationToggle().catch(() => {});
+    }
+  });
+}
+
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(() => {});
+    navigator.serviceWorker.register('/sw.js')
+      .then(() => refreshNotificationToggle())
+      .catch(() => {});
   });
 }

--- a/public/app.js
+++ b/public/app.js
@@ -1648,16 +1648,28 @@ async function subscribeToPush() {
     applicationServerKey: urlBase64ToUint8Array(publicKey)
   });
   const subJson = sub.toJSON();
-  const res = await fetch('/api/notifications/subscribe', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      endpoint: subJson.endpoint,
-      keys: subJson.keys
-    })
-  });
+  let res;
+  try {
+    res = await fetch('/api/notifications/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        endpoint: subJson.endpoint,
+        keys: subJson.keys
+      })
+    });
+  } catch (err) {
+    // Network error: roll back the browser-side subscription so the
+    // next refreshNotificationToggle() doesn't read a phantom "on"
+    // state with no matching server row. Without this, the user has
+    // to toggle off and on again to recover, and the off path can't
+    // even DELETE because we never persisted endpointHash.
+    try { await sub.unsubscribe(); } catch (_e) { /* best-effort */ }
+    throw err;
+  }
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
+    try { await sub.unsubscribe(); } catch (_e) { /* best-effort */ }
     throw new Error(body.error || `Subscribe failed (HTTP ${res.status}).`);
   }
   const json = await res.json();

--- a/public/index.html
+++ b/public/index.html
@@ -55,6 +55,17 @@
           <input id="strictToggle" type="checkbox" />
           <span>Strict mode</span>
         </label>
+        <button
+          id="notificationToggle"
+          type="button"
+          class="toggle"
+          aria-pressed="false"
+          aria-label="Daily puzzle notifications"
+          hidden
+        >
+          <span id="notificationToggleLabel">Get notified when daily puzzle is ready</span>
+        </button>
+        <span id="notificationStatus" class="hint" aria-live="polite"></span>
       </div>
     </header>
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -80,14 +80,17 @@ self.addEventListener('notificationclick', (event) => {
   // If a tab is already open at the target URL, focus it; otherwise
   // open a new window. clients.matchAll requires the includeUncontrolled
   // option so we see tabs from before this SW activated.
+  // Compare PATH-ONLY: an URL with a query/hash like /play?day=123
+  // would never match `clientUrl.pathname === '/play?day=123'` if we
+  // compared the raw string, so we'd always open a new window.
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true })
       .then((windowClients) => {
         for (const client of windowClients) {
           try {
             const clientUrl = new URL(client.url);
-            const targetPath = targetUrl.startsWith('/') ? targetUrl : new URL(targetUrl, clientUrl.origin).pathname;
-            if (clientUrl.pathname === targetPath && 'focus' in client) {
+            const targetParsed = new URL(targetUrl, clientUrl.origin);
+            if (clientUrl.pathname === targetParsed.pathname && 'focus' in client) {
               return client.focus();
             }
           } catch (_err) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,8 @@
-// v2: admin shell now loads /dist/vendor/chart.umd.min.js for the
-// Analytics tab. Existing browsers with v1 cached would otherwise serve
-// the old /admin/app.js (no chart code) and 503 the new vendor URL on
-// offline loads, leaving window.Chart undefined. Bumping the cache name
-// forces a precache refresh on activate.
-const CACHE_NAME = 'wordle-cache-v2';
+// v3: adds `push` + `notificationclick` listeners for the daily-puzzle
+// Web Push notification flow (#92). Bumping the cache name forces a
+// service-worker update on existing installs so the new listeners
+// activate without a hard reload.
+const CACHE_NAME = 'wordle-cache-v3';
 const STATIC_ASSETS = [
   '/',
   '/index.html',
@@ -43,6 +42,62 @@ self.addEventListener('activate', (event) => {
       })
       .then(() => {
         return self.clients.claim();
+      })
+  );
+});
+
+// Push notifications. The server sends a JSON payload like
+// `{title, body, url, tag}` (built by lib/notification-service.js); on
+// an empty payload we fall back to a generic daily-puzzle copy so the
+// listener never throws.
+self.addEventListener('push', (event) => {
+  let payload = {};
+  if (event.data) {
+    try {
+      payload = event.data.json();
+    } catch (_err) {
+      payload = { title: 'Wordle', body: event.data.text() };
+    }
+  }
+  const title = payload.title || "Today's Wordle is ready";
+  const options = {
+    body: payload.body || 'Open the app to play today\'s puzzle.',
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    // `tag` collapses repeat notifications so a daily fire that lands
+    // before a previous one was dismissed doesn't pile up.
+    tag: typeof payload.tag === 'string' ? payload.tag : 'wordle-daily',
+    data: {
+      url: typeof payload.url === 'string' ? payload.url : '/'
+    }
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = event.notification.data?.url || '/';
+  // If a tab is already open at the target URL, focus it; otherwise
+  // open a new window. clients.matchAll requires the includeUncontrolled
+  // option so we see tabs from before this SW activated.
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+      .then((windowClients) => {
+        for (const client of windowClients) {
+          try {
+            const clientUrl = new URL(client.url);
+            const targetPath = targetUrl.startsWith('/') ? targetUrl : new URL(targetUrl, clientUrl.origin).pathname;
+            if (clientUrl.pathname === targetPath && 'focus' in client) {
+              return client.focus();
+            }
+          } catch (_err) {
+            // ignore parse errors and fall through to opening a new window
+          }
+        }
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(targetUrl);
+        }
+        return null;
       })
   );
 });

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -138,7 +138,10 @@ function createAdminRouter(deps) {
     WebhookDeliveryStoreError,
     redactWebhookSecret,
     webhooksEnabled,
-    webhookDefaultMaxAttempts
+    webhookDefaultMaxAttempts,
+    pushSubscriptionStore,
+    notificationService,
+    PushSubscriptionStoreError
   } = deps;
 
   // Required dep — the toggle and runtime-config handlers depend on
@@ -978,6 +981,120 @@ function createAdminRouter(deps) {
       });
     }
   });
+
+  // ── Push notifications (admin) ──────────────────────────────────────
+  // Player-facing endpoints (subscribe/unsubscribe/vapid-public-key)
+  // live in routes/notifications.js. These admin endpoints surface
+  // counts/timestamps and the broadcast control.
+  function notificationAudit(action, fields) {
+    try {
+      console.log(JSON.stringify({
+        event: `[notify] ${action}`,
+        ts: new Date().toISOString(),
+        ...fields
+      }));
+    } catch (_err) {
+      // best-effort
+    }
+  }
+
+  if (pushSubscriptionStore && notificationService) {
+    router.get("/api/admin/notifications/subscriptions", async (req, res) => {
+      try {
+        const snap = await pushSubscriptionStore.getSnapshot();
+        // Never echo raw endpoints or keys — admin only sees counts +
+        // timestamps and a list of opaque endpointHashes for visibility.
+        return res.json({
+          ok: true,
+          count: snap.subscriptions.length,
+          lastBroadcastAt: snap.lastBroadcastAt,
+          lastDailyFireAt: snap.lastDailyFireAt,
+          // Lightweight per-row info to surface stale subscriptions in
+          // the admin UI without leaking the endpoint URL.
+          rows: snap.subscriptions.map((s) => ({
+            endpointHash: s.endpointHash,
+            createdAt: s.createdAt,
+            lastSuccessAt: s.lastSuccessAt || null,
+            lastFailureAt: s.lastFailureAt || null,
+            failureStreak: s.failureStreak || 0,
+            ua: s.ua || null
+          }))
+        });
+      } catch (err) {
+        if (err instanceof PushSubscriptionStoreError) {
+          return res.status(503).json({ error: err.message, code: err.code });
+        }
+        console.error("[notify] subscriptions list failed:", err);
+        return res.status(503).json({
+          error: "Subscription list failed.",
+          code: "STORE_READ_FAILED"
+        });
+      }
+    });
+
+    router.post("/api/admin/notifications/broadcast", async (req, res) => {
+      const body = req.body || {};
+      const title = String(body.title || "").trim();
+      const messageBody = String(body.body || "").trim();
+      const url = String(body.url || "").trim();
+      const dryRun = body.dryRun === true;
+
+      if (!title || title.length > 80) {
+        return res.status(400).json({
+          error: "title is required and must be 1–80 characters.",
+          code: "INVALID_REQUEST"
+        });
+      }
+      if (!messageBody || messageBody.length > 200) {
+        return res.status(400).json({
+          error: "body is required and must be 1–200 characters.",
+          code: "INVALID_REQUEST"
+        });
+      }
+      if (url && url.length > 256) {
+        return res.status(400).json({
+          error: "url must be at most 256 characters.",
+          code: "INVALID_REQUEST"
+        });
+      }
+      // Reject absolute URLs to other origins — the click handler in
+      // sw.js opens the URL in a tab, and a malicious admin URL could
+      // be a phishing redirect. Allow site-relative paths only.
+      if (url && /^[a-z]+:/i.test(url) && !url.startsWith("/")) {
+        return res.status(400).json({
+          error: "url must be a site-relative path (e.g. /, /play).",
+          code: "INVALID_REQUEST"
+        });
+      }
+
+      const payload = {
+        title,
+        body: messageBody,
+        url: url || "/",
+        tag: "admin-broadcast"
+      };
+      try {
+        const result = await notificationService.broadcast(payload, { dryRun });
+        if (!dryRun) {
+          await pushSubscriptionStore.stampLastBroadcast(new Date()).catch(() => {});
+        }
+        notificationAudit(dryRun ? "broadcast.preview" : "broadcast.send", {
+          actor: actorFingerprint(req),
+          recipients: result.recipients ?? null,
+          sent: result.sent ?? null,
+          failed: result.failed ?? null,
+          gone: result.gone ?? null
+        });
+        return res.json({ ok: true, dryRun, result });
+      } catch (err) {
+        console.error("[notify] broadcast failed:", err);
+        return res.status(503).json({
+          error: "Broadcast failed.",
+          code: "BROADCAST_FAILED"
+        });
+      }
+    });
+  }
 
   router.delete("/api/admin/stats/profile/:id", async (req, res) => {
     const profileId = String(req.params.id || "").trim();

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1057,12 +1057,15 @@ function createAdminRouter(deps) {
           code: "INVALID_REQUEST"
         });
       }
-      // Reject absolute URLs to other origins — the click handler in
-      // sw.js opens the URL in a tab, and a malicious admin URL could
-      // be a phishing redirect. Allow site-relative paths only.
-      if (url && /^[a-z]+:/i.test(url) && !url.startsWith("/")) {
+      // Require a true root-relative path: must start with `/`, must
+      // NOT start with `//` (scheme-relative — `//evil.example/x`
+      // navigates off-origin from the click handler), and must not
+      // be a bare segment like `play` (`new URL('play', origin)`
+      // would resolve relative to the current page rather than the
+      // site root, which is also surprising for a stored config).
+      if (url && (!url.startsWith("/") || url.startsWith("//"))) {
         return res.status(400).json({
-          error: "url must be a site-relative path (e.g. /, /play).",
+          error: "url must be a root-relative path (e.g. /, /play). Scheme-relative // and bare segments are rejected.",
           code: "INVALID_REQUEST"
         });
       }

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -216,6 +216,7 @@ function createBackupRouter(deps) {
     scheduleStore,
     webhookStore,
     webhookDeliveryStore,
+    pushSubscriptionStore,
     rebuildLanguageRuntimeCatalog,
     reloadWordData,
     providerImportQueueActiveRef,
@@ -242,6 +243,7 @@ function createBackupRouter(deps) {
     if (scheduleStore?.load) await scheduleStore.load();
     if (webhookStore?.load) await webhookStore.load();
     if (webhookDeliveryStore?.load) await webhookDeliveryStore.load();
+    if (pushSubscriptionStore?.load) await pushSubscriptionStore.load();
     if (appConfigStore?.loadSync) appConfigStore.loadSync();
     if (languageRegistryStore?.loadSync) languageRegistryStore.loadSync();
   }
@@ -260,7 +262,8 @@ function createBackupRouter(deps) {
       classesStore?.writeQueue,
       scheduleStore?.commitQueue,
       webhookStore?.commitQueue,
-      webhookDeliveryStore?.commitQueue
+      webhookDeliveryStore?.commitQueue,
+      pushSubscriptionStore?.commitQueue
     ].filter(Boolean);
     if (queues.length === 0) return;
     await Promise.allSettled(queues);
@@ -624,6 +627,7 @@ function createBackupRouter(deps) {
         ["scheduleStore", () => scheduleStore?.reload?.()],
         ["webhookStore", () => webhookStore?.reload?.()],
         ["webhookDeliveryStore", () => webhookDeliveryStore?.reload?.()],
+        ["pushSubscriptionStore", () => pushSubscriptionStore?.reload?.()],
         ["appConfigStore", () => appConfigStore?.reloadSync?.()],
         ["languageRegistryStore", () => languageRegistryStore?.reloadSync?.()],
         ["languageRuntimeCatalog", () => rebuildLanguageRuntimeCatalog?.()],

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -14,15 +14,15 @@ const express = require("express");
 function createNotificationsRouter(deps) {
   const {
     pushSubscriptionStore,
-    appConfigStore,
+    vapidStore,
     PushSubscriptionStoreError
   } = deps;
 
   if (!pushSubscriptionStore) {
     throw new TypeError("createNotificationsRouter: pushSubscriptionStore dep is required.");
   }
-  if (!appConfigStore) {
-    throw new TypeError("createNotificationsRouter: appConfigStore dep is required.");
+  if (!vapidStore) {
+    throw new TypeError("createNotificationsRouter: vapidStore dep is required.");
   }
 
   const router = express.Router();
@@ -30,7 +30,7 @@ function createNotificationsRouter(deps) {
   // Public endpoint — never returns the private key. The client uses
   // this to subscribe via PushManager.subscribe({applicationServerKey}).
   router.get("/api/notifications/vapid-public-key", (req, res) => {
-    const keys = appConfigStore.getPushKeysSync();
+    const keys = vapidStore.getKeysSync();
     if (!keys || !keys.publicKey) {
       return res.status(503).json({
         error: "VAPID keys not provisioned yet. Try again after server boot completes.",

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -1,0 +1,91 @@
+"use strict";
+
+const express = require("express");
+
+/**
+ * Player-facing notification endpoints.
+ * - GET    /api/notifications/vapid-public-key
+ * - POST   /api/notifications/subscribe
+ * - DELETE /api/notifications/subscribe/:endpointHash
+ *
+ * Admin endpoints (broadcast, count, broadcast preview) live in
+ * routes/admin.js because they require admin auth.
+ */
+function createNotificationsRouter(deps) {
+  const {
+    pushSubscriptionStore,
+    appConfigStore,
+    PushSubscriptionStoreError
+  } = deps;
+
+  if (!pushSubscriptionStore) {
+    throw new TypeError("createNotificationsRouter: pushSubscriptionStore dep is required.");
+  }
+  if (!appConfigStore) {
+    throw new TypeError("createNotificationsRouter: appConfigStore dep is required.");
+  }
+
+  const router = express.Router();
+
+  // Public endpoint — never returns the private key. The client uses
+  // this to subscribe via PushManager.subscribe({applicationServerKey}).
+  router.get("/api/notifications/vapid-public-key", (req, res) => {
+    const keys = appConfigStore.getPushKeysSync();
+    if (!keys || !keys.publicKey) {
+      return res.status(503).json({
+        error: "VAPID keys not provisioned yet. Try again after server boot completes.",
+        code: "VAPID_MISSING"
+      });
+    }
+    return res.json({ publicKey: keys.publicKey });
+  });
+
+  router.post("/api/notifications/subscribe", async (req, res) => {
+    try {
+      const body = req.body || {};
+      const ua = typeof req.headers["user-agent"] === "string"
+        ? req.headers["user-agent"]
+        : undefined;
+      const sub = await pushSubscriptionStore.upsert({
+        endpoint: body.endpoint,
+        keys: body.keys,
+        ua
+      });
+      return res.status(201).json({
+        ok: true,
+        endpointHash: sub.endpointHash
+      });
+    } catch (err) {
+      if (err instanceof PushSubscriptionStoreError) {
+        const status = err.code === "INVALID_REQUEST" ? 400 : 503;
+        return res.status(status).json({ error: err.message, code: err.code });
+      }
+      console.error("[notify] subscribe failed:", err);
+      return res.status(503).json({
+        error: "Subscription failed. Try again later.",
+        code: "STORE_WRITE_FAILED"
+      });
+    }
+  });
+
+  router.delete("/api/notifications/subscribe/:endpointHash", async (req, res) => {
+    try {
+      await pushSubscriptionStore.removeByHash(req.params.endpointHash);
+      return res.status(204).send();
+    } catch (err) {
+      if (err instanceof PushSubscriptionStoreError) {
+        const status = err.code === "INVALID_REQUEST" ? 400 : 503;
+        return res.status(status).json({ error: err.message, code: err.code });
+      }
+      console.error("[notify] unsubscribe failed:", err);
+      return res.status(503).json({
+        error: "Unsubscribe failed. Try again later.",
+        code: "STORE_WRITE_FAILED"
+      });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createNotificationsRouter;

--- a/scripts/validate-schemas.js
+++ b/scripts/validate-schemas.js
@@ -37,6 +37,8 @@ const webhooksSchemaPath = path.join(projectRoot, "data", "webhooks.schema.json"
 const webhooksExamplePath = path.join(projectRoot, "data", "webhooks.example.json");
 const webhookDeliveriesSchemaPath = path.join(projectRoot, "data", "webhook-deliveries.schema.json");
 const webhookDeliveriesExamplePath = path.join(projectRoot, "data", "webhook-deliveries.example.json");
+const pushSubscriptionsSchemaPath = path.join(projectRoot, "data", "push-subscriptions.schema.json");
+const pushSubscriptionsExamplePath = path.join(projectRoot, "data", "push-subscriptions.example.json");
 
 function readJson(filePath, kind) {
   let raw;
@@ -124,6 +126,11 @@ function runSchemaChecks() {
       schemaPath: webhookDeliveriesSchemaPath,
       dataPath: webhookDeliveriesExamplePath,
       schemaLabel: "webhook deliveries schema"
+    },
+    {
+      schemaPath: pushSubscriptionsSchemaPath,
+      dataPath: pushSubscriptionsExamplePath,
+      schemaLabel: "push subscriptions schema"
     }
   ];
 

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ const {
 } = require("./lib/push-subscription-store");
 const { NotificationService } = require("./lib/notification-service");
 const { DailyNotificationScheduler } = require("./lib/daily-notification-scheduler");
+const { VapidStore } = require("./lib/vapid-store");
 const { LanguageRegistryError, LanguageRegistryStore } = require("./lib/language-registry");
 const { SUPPORTED_VARIANT_IDS } = require("./lib/provider-artifact-shared");
 const { fetchAndPersistProviderSource, computeSha256 } = require("./lib/provider-fetch");
@@ -169,6 +170,9 @@ const WEBHOOK_DELIVERIES_DATA_PATH = process.env.WEBHOOK_DELIVERIES_STORE_PATH
 const PUSH_SUBSCRIPTIONS_DATA_PATH = process.env.PUSH_SUBSCRIPTIONS_STORE_PATH
   ? path.resolve(process.env.PUSH_SUBSCRIPTIONS_STORE_PATH)
   : path.join(__dirname, "data", "push-subscriptions.json");
+const VAPID_KEYS_DATA_PATH = process.env.VAPID_KEYS_STORE_PATH
+  ? path.resolve(process.env.VAPID_KEYS_STORE_PATH)
+  : path.join(__dirname, "data", "vapid-keys.json");
 const ENV_CLASSES_MAX_MEMBERS_PER_CLASS = clampEnvBounded(
   process.env.CLASSES_MAX_MEMBERS_PER_CLASS,
   1000,
@@ -324,7 +328,7 @@ const ENV_PUSH_GRACE_PERIOD_MINUTES_DEFAULT = clampEnvBounded(
   process.env.PUSH_GRACE_PERIOD_MINUTES,
   60,
   0,
-  1440,
+  60,
   "PUSH_GRACE_PERIOD_MINUTES"
 );
 const ENV_PUSH_VAPID_SUBJECT = (() => {
@@ -1372,6 +1376,13 @@ const pushSubscriptionStore = new PushSubscriptionStore({
   logger: console,
   claimDirectDataWriteSlot
 });
+// VAPID keys live in their own file (NOT in backup scope) so the
+// private half can't leak through admin backup exports. See
+// lib/vapid-store.js for the full rationale.
+const vapidStore = new VapidStore({
+  filePath: VAPID_KEYS_DATA_PATH,
+  logger: console
+});
 // Resolve runtime notifications config from app-config overrides (live)
 // with env-var seed fallbacks. Called every time scheduler/service
 // needs the config so admin edits take effect without restart.
@@ -1389,11 +1400,14 @@ function getNotificationsConfig() {
 }
 const notificationService = new NotificationService({
   subscriptionStore: pushSubscriptionStore,
-  enabled: true,
+  // Read the runtime `notifications.enabled` flag on every send so
+  // toggling off in the admin UI also stops admin broadcasts (not
+  // just the daily scheduler).
+  isEnabled: () => getNotificationsConfig().enabled,
   logger: console,
-  // Read pushKeys from app-config on every send so admin-rotated keys
-  // (future feature) take effect without restart.
-  getPushKeys: () => appConfigStore.getPushKeysSync()
+  // Read VAPID keys from the dedicated store on every send so admin-
+  // rotated keys (future feature) take effect without restart.
+  getPushKeys: () => vapidStore.getKeysSync()
 });
 const dailyNotificationScheduler = new DailyNotificationScheduler({
   subscriptionStore: pushSubscriptionStore,
@@ -3223,7 +3237,7 @@ const createNotificationsRouter = require("./routes/notifications.js");
 app.use(
   createNotificationsRouter({
     pushSubscriptionStore,
-    appConfigStore,
+    vapidStore,
     PushSubscriptionStoreError
   })
 );
@@ -3420,12 +3434,11 @@ async function startServer(listener = app.listen.bind(app)) {
     }
   }
   // Provision VAPID keys on first boot. Idempotent: subsequent boots
-  // see existing keys and skip generation. Persisting in app-config.json
-  // means a single keypair survives across restarts forever, which is
-  // what subscribers expect (rotating VAPID would invalidate every
-  // existing subscription).
+  // see existing keys and skip generation. The keypair lives in its
+  // own file (NOT backed up) so admin-key-holders downloading a
+  // backup archive can't extract the private half offline.
   try {
-    appConfigStore.ensurePushKeysSync({
+    vapidStore.ensureKeysSync({
       generate: () => require("web-push").generateVAPIDKeys(),
       subject: ENV_PUSH_VAPID_SUBJECT
     });

--- a/server.js
+++ b/server.js
@@ -23,6 +23,12 @@ const { reconcileDailyWord } = require("./lib/scheduler-tick");
 const { WebhookStore, WebhookStoreError, redactSecret } = require("./lib/webhook-store");
 const { WebhookDeliveryStore, WebhookDeliveryStoreError } = require("./lib/webhook-delivery-store");
 const { WebhookService } = require("./lib/webhook-service");
+const {
+  PushSubscriptionStore,
+  PushSubscriptionStoreError
+} = require("./lib/push-subscription-store");
+const { NotificationService } = require("./lib/notification-service");
+const { DailyNotificationScheduler } = require("./lib/daily-notification-scheduler");
 const { LanguageRegistryError, LanguageRegistryStore } = require("./lib/language-registry");
 const { SUPPORTED_VARIANT_IDS } = require("./lib/provider-artifact-shared");
 const { fetchAndPersistProviderSource, computeSha256 } = require("./lib/provider-fetch");
@@ -160,6 +166,9 @@ const WEBHOOKS_DATA_PATH = process.env.WEBHOOKS_STORE_PATH
 const WEBHOOK_DELIVERIES_DATA_PATH = process.env.WEBHOOK_DELIVERIES_STORE_PATH
   ? path.resolve(process.env.WEBHOOK_DELIVERIES_STORE_PATH)
   : path.join(__dirname, "data", "webhook-deliveries.json");
+const PUSH_SUBSCRIPTIONS_DATA_PATH = process.env.PUSH_SUBSCRIPTIONS_STORE_PATH
+  ? path.resolve(process.env.PUSH_SUBSCRIPTIONS_STORE_PATH)
+  : path.join(__dirname, "data", "push-subscriptions.json");
 const ENV_CLASSES_MAX_MEMBERS_PER_CLASS = clampEnvBounded(
   process.env.CLASSES_MAX_MEMBERS_PER_CLASS,
   1000,
@@ -296,6 +305,36 @@ const ENV_WEBHOOK_GLOBAL_INFLIGHT_LIMIT = clampEnvBounded(
   64,
   "WEBHOOK_GLOBAL_INFLIGHT_LIMIT"
 );
+
+// Web Push notifications. Disabled at the runtime level via the
+// notifications.enabled config flag (operator-controlled at runtime
+// via the admin Notifications tab). The PUSH_NOTIFICATIONS_ENABLED env
+// var only seeds the default config on first boot.
+const ENV_PUSH_NOTIFICATIONS_ENABLED_DEFAULT =
+  String(process.env.PUSH_NOTIFICATIONS_ENABLED || "true").toLowerCase() !== "false";
+const ENV_PUSH_DAILY_FIRE_LOCAL_TIME_DEFAULT = (() => {
+  const raw = String(process.env.PUSH_DAILY_FIRE_LOCAL_TIME || "00:00").trim();
+  if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(raw)) {
+    console.warn(`PUSH_DAILY_FIRE_LOCAL_TIME=${raw} is not HH:MM; using 00:00.`);
+    return "00:00";
+  }
+  return raw;
+})();
+const ENV_PUSH_GRACE_PERIOD_MINUTES_DEFAULT = clampEnvBounded(
+  process.env.PUSH_GRACE_PERIOD_MINUTES,
+  60,
+  0,
+  1440,
+  "PUSH_GRACE_PERIOD_MINUTES"
+);
+const ENV_PUSH_VAPID_SUBJECT = (() => {
+  const raw = String(process.env.PUSH_VAPID_SUBJECT || "mailto:admin@localhost").trim();
+  if (!/^(mailto:|https:)/.test(raw)) {
+    console.warn(`PUSH_VAPID_SUBJECT=${raw} is not mailto:/https:; using mailto:admin@localhost.`);
+    return "mailto:admin@localhost";
+  }
+  return raw;
+})();
 
 const MIN_LEN = 3;
 const MAX_LEN = 12;
@@ -1327,6 +1366,56 @@ const webhookService = new WebhookService({
   maxBodyBytes: ENV_WEBHOOK_MAX_BODY_BYTES,
   globalInflight: ENV_WEBHOOK_GLOBAL_INFLIGHT_LIMIT,
   logger: console
+});
+const pushSubscriptionStore = new PushSubscriptionStore({
+  filePath: PUSH_SUBSCRIPTIONS_DATA_PATH,
+  logger: console,
+  claimDirectDataWriteSlot
+});
+// Resolve runtime notifications config from app-config overrides (live)
+// with env-var seed fallbacks. Called every time scheduler/service
+// needs the config so admin edits take effect without restart.
+function getNotificationsConfig() {
+  const overrides = appConfigStore.getOverridesSync().notifications || {};
+  return {
+    enabled: typeof overrides.enabled === "boolean"
+      ? overrides.enabled
+      : ENV_PUSH_NOTIFICATIONS_ENABLED_DEFAULT,
+    localFireTime: overrides.localFireTime || ENV_PUSH_DAILY_FIRE_LOCAL_TIME_DEFAULT,
+    gracePeriodMinutes: Number.isInteger(overrides.gracePeriodMinutes)
+      ? overrides.gracePeriodMinutes
+      : ENV_PUSH_GRACE_PERIOD_MINUTES_DEFAULT
+  };
+}
+const notificationService = new NotificationService({
+  subscriptionStore: pushSubscriptionStore,
+  enabled: true,
+  logger: console,
+  // Read pushKeys from app-config on every send so admin-rotated keys
+  // (future feature) take effect without restart.
+  getPushKeys: () => appConfigStore.getPushKeysSync()
+});
+const dailyNotificationScheduler = new DailyNotificationScheduler({
+  subscriptionStore: pushSubscriptionStore,
+  notificationService,
+  logger: console,
+  getConfig: getNotificationsConfig,
+  buildPayload: () => {
+    // Pull today's word into the body so a notification reads
+    // "Today's Wordle is ready: 5 letters". Falls back to a generic
+    // copy if the daily word isn't set yet.
+    const data = wordDataCache || readWordData() || buildDefaultWordData();
+    const wordLen = typeof data.word === "string" ? data.word.length : null;
+    const body = wordLen
+      ? `Today's puzzle is live — ${wordLen} letters.`
+      : "Open the app to play today's puzzle.";
+    return {
+      title: "Today's Wordle is ready",
+      body,
+      url: "/",
+      tag: "daily-puzzle"
+    };
+  }
 });
 let schedulerIntervalRef = null;
 
@@ -2940,6 +3029,7 @@ app.use(
     scheduleStore,
     webhookStore,
     webhookDeliveryStore,
+    pushSubscriptionStore,
     rebuildLanguageRuntimeCatalog,
     reloadWordData: () => {
       // Re-read data/word.json from disk and refresh the in-memory cache
@@ -3046,7 +3136,10 @@ app.use(
     WebhookDeliveryStoreError,
     redactWebhookSecret: redactSecret,
     webhooksEnabled: ENV_WEBHOOKS_ENABLED,
-    webhookDefaultMaxAttempts: ENV_WEBHOOK_MAX_ATTEMPTS_DEFAULT
+    webhookDefaultMaxAttempts: ENV_WEBHOOK_MAX_ATTEMPTS_DEFAULT,
+    pushSubscriptionStore,
+    notificationService,
+    PushSubscriptionStoreError
   })
 );
 
@@ -3123,6 +3216,15 @@ app.use(
     DEFAULT_LANG,
     isPerfLoggingEnabled,
     getDefinitionsMode
+  })
+);
+
+const createNotificationsRouter = require("./routes/notifications.js");
+app.use(
+  createNotificationsRouter({
+    pushSubscriptionStore,
+    appConfigStore,
+    PushSubscriptionStoreError
   })
 );
 
@@ -3317,6 +3419,27 @@ async function startServer(listener = app.listen.bind(app)) {
       console.error("[webhook] recovery failed:", err);
     }
   }
+  // Provision VAPID keys on first boot. Idempotent: subsequent boots
+  // see existing keys and skip generation. Persisting in app-config.json
+  // means a single keypair survives across restarts forever, which is
+  // what subscribers expect (rotating VAPID would invalidate every
+  // existing subscription).
+  try {
+    appConfigStore.ensurePushKeysSync({
+      generate: () => require("web-push").generateVAPIDKeys(),
+      subject: ENV_PUSH_VAPID_SUBJECT
+    });
+  } catch (err) {
+    console.error("[notify] VAPID provisioning failed:", err.message);
+  }
+  // Start the daily notification scheduler. Always-on: the scheduler
+  // itself respects the runtime `enabled` flag from app-config so
+  // operators can toggle without restart.
+  try {
+    await dailyNotificationScheduler.start();
+  } catch (err) {
+    console.error("[notify] scheduler boot failed:", err);
+  }
   return listener(PORT, HOST, () => {
     console.log(`local-hosted-wordle server running at http://localhost:${PORT}`);
     console.log(`Definitions mode: ${getDefinitionsMode()}`);
@@ -3356,3 +3479,6 @@ module.exports.scheduleStore = scheduleStore;
 module.exports.webhookStore = webhookStore;
 module.exports.webhookDeliveryStore = webhookDeliveryStore;
 module.exports.webhookService = webhookService;
+module.exports.pushSubscriptionStore = pushSubscriptionStore;
+module.exports.notificationService = notificationService;
+module.exports.dailyNotificationScheduler = dailyNotificationScheduler;

--- a/server.js
+++ b/server.js
@@ -1416,16 +1416,27 @@ const dailyNotificationScheduler = new DailyNotificationScheduler({
   getConfig: getNotificationsConfig,
   buildPayload: () => {
     // Pull today's word into the body so a notification reads
-    // "Today's Wordle is ready: 5 letters". Falls back to a generic
-    // copy if the daily word isn't set yet.
+    // "Today's puzzle is live — 5 letters". `/daily` 404s when the
+    // cached word's date doesn't match today's server-local date,
+    // so check that BEFORE claiming a daily exists. If stale or
+    // unset, drop into generic-non-daily copy and link to `/` (the
+    // create-a-puzzle page) instead.
     const data = wordDataCache || readWordData() || buildDefaultWordData();
-    const wordLen = typeof data.word === "string" ? data.word.length : null;
-    const body = wordLen
-      ? `Today's puzzle is live — ${wordLen} letters.`
-      : "Open the app to play today's puzzle.";
+    const today = getLocalDateString(new Date());
+    const isFresh = typeof data.word === "string"
+      && typeof data.date === "string"
+      && data.date === today;
+    if (isFresh) {
+      return {
+        title: "Today's Wordle is ready",
+        body: `Today's puzzle is live — ${data.word.length} letters.`,
+        url: "/daily",
+        tag: "daily-puzzle"
+      };
+    }
     return {
-      title: "Today's Wordle is ready",
-      body,
+      title: "Wordle",
+      body: "Open the app to play.",
       url: "/",
       tag: "daily-puzzle"
     };

--- a/tests/backup-restore.integration.test.js
+++ b/tests/backup-restore.integration.test.js
@@ -37,6 +37,9 @@ function makeTempState() {
     "data/app-config.schema.json",
     "data/classes.schema.json",
     "data/schedule.schema.json",
+    "data/webhooks.schema.json",
+    "data/webhook-deliveries.schema.json",
+    "data/push-subscriptions.schema.json",
     "data/backup-manifest.schema.json"
   ]) {
     const dest = path.join(projectRoot, rel);

--- a/tests/backup-restore.integration.test.js
+++ b/tests/backup-restore.integration.test.js
@@ -138,9 +138,21 @@ function makeTempState() {
     }, null, 2)}\n`,
     "utf8"
   );
+  const pushSubscriptionsPath = path.join(dir, "push-subscriptions.json");
+  fs.writeFileSync(
+    pushSubscriptionsPath,
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: new Date(0).toISOString(),
+      lastBroadcastAt: null,
+      lastDailyFireAt: null,
+      subscriptions: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
   return {
     statsPath, classesPath, adminJobsPath, appConfigPath, schedulePath,
-    webhooksPath, webhookDeliveriesPath, projectRoot
+    webhooksPath, webhookDeliveriesPath, pushSubscriptionsPath, projectRoot
   };
 }
 
@@ -155,6 +167,7 @@ function loadFreshApp(adminKey, paths, extraEnv = {}) {
   if (paths.schedulePath) process.env.SCHEDULE_STORE_PATH = paths.schedulePath;
   if (paths.webhooksPath) process.env.WEBHOOKS_STORE_PATH = paths.webhooksPath;
   if (paths.webhookDeliveriesPath) process.env.WEBHOOK_DELIVERIES_STORE_PATH = paths.webhookDeliveriesPath;
+  if (paths.pushSubscriptionsPath) process.env.PUSH_SUBSCRIPTIONS_STORE_PATH = paths.pushSubscriptionsPath;
   process.env.RATE_LIMIT_MAX = "1000";
   process.env.ADMIN_RATE_LIMIT_MAX = "1000";
   process.env.ADMIN_WRITE_RATE_LIMIT_MAX = "1000";

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -43,6 +43,7 @@ async function makeProjectRoot() {
     "data/schedule.schema.json",
     "data/webhooks.schema.json",
     "data/webhook-deliveries.schema.json",
+    "data/push-subscriptions.schema.json",
     "data/backup-manifest.schema.json"
   ]) {
     await copyFileFromRepo(rel, dir);
@@ -120,6 +121,17 @@ async function makeProjectRoot() {
       version: 1,
       updatedAt: "2026-01-01T00:00:00.000Z",
       deliveries: []
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  await fsp.writeFile(
+    path.join(dir, "data", "push-subscriptions.json"),
+    `${JSON.stringify({
+      version: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      lastBroadcastAt: null,
+      lastDailyFireAt: null,
+      subscriptions: []
     }, null, 2)}\n`,
     "utf8"
   );

--- a/tests/daily-notification-scheduler.test.js
+++ b/tests/daily-notification-scheduler.test.js
@@ -104,6 +104,48 @@ describe("decideBootAction", () => {
     });
     expect(result.action).toBe("fire-now");
   });
+
+  test("cross-midnight: late fire time, brief downtime that crossed midnight, fires for yesterday's window", () => {
+    // Fire time 23:30. Server was down through 23:30 yesterday and
+    // boots at 00:10 today. Today's 23:30 hasn't arrived yet, but
+    // yesterday's 23:30 was 40 min ago — within the 60-min grace.
+    const now = new Date(2026, 4, 9, 0, 10, 0);
+    const result = decideBootAction({
+      now,
+      localFireTime: "23:30",
+      lastDailyFireAt: null,
+      gracePeriodMinutes: 60
+    });
+    expect(result.action).toBe("fire-now");
+    expect(result.missedAt).toBeTruthy();
+    // Should be yesterday's 23:30, not today's.
+    expect(new Date(result.missedAt).getTime()).toBeLessThan(now.getTime());
+  });
+
+  test("cross-midnight: yesterday already fired → no-recent-miss when today's window not yet arrived", () => {
+    const now = new Date(2026, 4, 9, 0, 10, 0);
+    const yesterdayFireAt = new Date(2026, 4, 8, 23, 30, 5).toISOString();
+    const result = decideBootAction({
+      now,
+      localFireTime: "23:30",
+      lastDailyFireAt: yesterdayFireAt,
+      gracePeriodMinutes: 60
+    });
+    expect(result.action).toBe("no-recent-miss");
+  });
+
+  test("cross-midnight: yesterday's window outside grace → no-recent-miss", () => {
+    // Boot 3h after yesterday's 23:30 fire (i.e. today 02:30). Beyond
+    // 60-min grace from yesterday, but today's 23:30 hasn't arrived.
+    const now = new Date(2026, 4, 9, 2, 30, 0);
+    const result = decideBootAction({
+      now,
+      localFireTime: "23:30",
+      lastDailyFireAt: null,
+      gracePeriodMinutes: 60
+    });
+    expect(result.action).toBe("no-recent-miss");
+  });
 });
 
 describe("DailyNotificationScheduler", () => {

--- a/tests/daily-notification-scheduler.test.js
+++ b/tests/daily-notification-scheduler.test.js
@@ -1,0 +1,176 @@
+"use strict";
+
+const {
+  computeNextFireAt,
+  decideBootAction,
+  DailyNotificationScheduler
+} = require("../lib/daily-notification-scheduler");
+
+describe("computeNextFireAt", () => {
+  test("returns today at the configured time when it's still in the future", () => {
+    const now = new Date("2026-05-09T12:00:00.000-04:00");
+    const next = computeNextFireAt(now, "20:00");
+    expect(next.getHours()).toBe(20);
+    expect(next.getMinutes()).toBe(0);
+    expect(next.toDateString()).toBe(now.toDateString());
+  });
+
+  test("returns tomorrow at the configured time when it's already passed today", () => {
+    const now = new Date("2026-05-09T15:30:00.000-04:00");
+    const next = computeNextFireAt(now, "00:00");
+    expect(next.getHours()).toBe(0);
+    expect(next.getMinutes()).toBe(0);
+    // Tomorrow.
+    expect(next.getTime()).toBeGreaterThan(now.getTime());
+    expect(next.getTime() - now.getTime()).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+  });
+
+  test("invalid HH:MM throws", () => {
+    expect(() => computeNextFireAt(new Date(), "25:00")).toThrow();
+    expect(() => computeNextFireAt(new Date(), "noon")).toThrow();
+    expect(() => computeNextFireAt(new Date(), "")).toThrow();
+  });
+
+  test("midnight rolls to next day cleanly across DST", () => {
+    // US/Eastern spring-forward: 2026-03-08 02:00 EST → 03:00 EDT.
+    // After DST transition at 02:00, computing next fire from
+    // 03:30 EDT for 00:00 should still give the next day's 00:00.
+    const now = new Date("2026-03-08T03:30:00.000-04:00");
+    const next = computeNextFireAt(now, "00:00");
+    expect(next.getTime()).toBeGreaterThan(now.getTime());
+    // Should be within 25 hours (allow one extra hour for DST slack).
+    expect(next.getTime() - now.getTime()).toBeLessThanOrEqual(25 * 60 * 60 * 1000);
+  });
+});
+
+describe("decideBootAction", () => {
+  test("returns no-recent-miss when today's window hasn't arrived yet", () => {
+    const now = new Date("2026-05-09T08:00:00.000-04:00");
+    expect(decideBootAction({
+      now,
+      localFireTime: "20:00",
+      lastDailyFireAt: null,
+      gracePeriodMinutes: 60
+    })).toEqual({ action: "no-recent-miss" });
+  });
+
+  test("returns fire-now when window passed within grace and no fire yet today", () => {
+    const now = new Date("2026-05-09T00:30:00.000-04:00");
+    const result = decideBootAction({
+      now,
+      localFireTime: "00:00",
+      lastDailyFireAt: null,
+      gracePeriodMinutes: 60
+    });
+    expect(result.action).toBe("fire-now");
+    expect(result.missedAt).toBeTruthy();
+  });
+
+  test("returns skip when window passed beyond grace", () => {
+    const now = new Date("2026-05-09T03:00:00.000-04:00");
+    const result = decideBootAction({
+      now,
+      localFireTime: "00:00",
+      lastDailyFireAt: null,
+      gracePeriodMinutes: 60
+    });
+    expect(result.action).toBe("skip");
+  });
+
+  test("returns no-recent-miss when today's window already fired", () => {
+    const now = new Date("2026-05-09T12:00:00.000-04:00");
+    expect(decideBootAction({
+      now,
+      localFireTime: "00:00",
+      lastDailyFireAt: "2026-05-09T00:01:00.000-04:00",
+      gracePeriodMinutes: 60
+    })).toEqual({ action: "no-recent-miss" });
+  });
+
+  test("yesterday's lastDailyFireAt does NOT count for today", () => {
+    const now = new Date("2026-05-09T00:30:00.000-04:00");
+    const result = decideBootAction({
+      now,
+      localFireTime: "00:00",
+      lastDailyFireAt: "2026-05-08T00:00:30.000-04:00",
+      gracePeriodMinutes: 60
+    });
+    expect(result.action).toBe("fire-now");
+  });
+});
+
+describe("DailyNotificationScheduler", () => {
+  function buildHarness({ enabled = true, localFireTime = "00:00", initialNow, lastDailyFireAt = null } = {}) {
+    const broadcastCalls = [];
+    const stampCalls = [];
+    const subscriptionStore = {
+      getSnapshot: jest.fn(async () => ({ lastDailyFireAt })),
+      stampLastDailyFire: jest.fn(async (...args) => { stampCalls.push(args); })
+    };
+    const notificationService = {
+      broadcast: jest.fn(async (payload) => {
+        broadcastCalls.push(payload);
+        return { sent: 1, failed: 0, gone: 0, recipients: 1 };
+      })
+    };
+    const sched = new DailyNotificationScheduler({
+      subscriptionStore,
+      notificationService,
+      now: () => initialNow || new Date("2026-05-09T12:00:00.000-04:00"),
+      logger: { warn: () => {}, error: () => {}, log: () => {} },
+      getConfig: () => ({ enabled, localFireTime, gracePeriodMinutes: 60 }),
+      buildPayload: () => ({ title: "T", body: "B", url: "/" })
+    });
+    return { sched, broadcastCalls, stampCalls, subscriptionStore, notificationService };
+  }
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("start() with notifications disabled: no broadcast, no timer", async () => {
+    const { sched, notificationService } = buildHarness({ enabled: false });
+    await sched.start();
+    expect(notificationService.broadcast).not.toHaveBeenCalled();
+    sched.shutdown();
+  });
+
+  test("start() during the grace window fires once, then arms next", async () => {
+    const initialNow = new Date("2026-05-09T00:30:00.000-04:00");
+    const { sched, broadcastCalls } = buildHarness({
+      localFireTime: "00:00",
+      initialNow
+    });
+    await sched.start();
+    expect(broadcastCalls).toHaveLength(1);
+    expect(broadcastCalls[0]).toEqual({ title: "T", body: "B", url: "/" });
+    sched.shutdown();
+  });
+
+  test("start() outside grace skips and arms next", async () => {
+    const initialNow = new Date("2026-05-09T03:00:00.000-04:00"); // 3h after window
+    const { sched, broadcastCalls } = buildHarness({
+      localFireTime: "00:00",
+      initialNow
+    });
+    await sched.start();
+    expect(broadcastCalls).toHaveLength(0);
+    sched.shutdown();
+  });
+
+  test("fireOnce broadcasts and stamps lastDailyFireAt", async () => {
+    const { sched, broadcastCalls, subscriptionStore } = buildHarness();
+    await sched.fireOnce();
+    expect(broadcastCalls).toHaveLength(1);
+    expect(subscriptionStore.stampLastDailyFire).toHaveBeenCalled();
+  });
+
+  test("shutdown clears the timer and prevents further work", async () => {
+    const { sched } = buildHarness();
+    await sched.start();
+    expect(sched.timer).toBeTruthy();
+    sched.shutdown();
+    expect(sched.timer).toBe(null);
+    expect(sched.shutdownRequested).toBe(true);
+  });
+});

--- a/tests/daily-notification-scheduler.test.js
+++ b/tests/daily-notification-scheduler.test.js
@@ -6,9 +6,16 @@ const {
   DailyNotificationScheduler
 } = require("../lib/daily-notification-scheduler");
 
+// IMPORTANT: scheduler logic uses server-LOCAL setHours, so tests
+// must construct `now` via the local-time Date constructor
+// (`new Date(y, m, d, hh, mm)`), NOT an ISO string with a fixed UTC
+// offset — the latter only happens to land on the right local hour
+// on developer machines in EDT and would fail in any other zone (CI
+// runs UTC).
+
 describe("computeNextFireAt", () => {
   test("returns today at the configured time when it's still in the future", () => {
-    const now = new Date("2026-05-09T12:00:00.000-04:00");
+    const now = new Date(2026, 4, 9, 12, 0, 0); // 2026-05-09 12:00 local
     const next = computeNextFireAt(now, "20:00");
     expect(next.getHours()).toBe(20);
     expect(next.getMinutes()).toBe(0);
@@ -16,11 +23,10 @@ describe("computeNextFireAt", () => {
   });
 
   test("returns tomorrow at the configured time when it's already passed today", () => {
-    const now = new Date("2026-05-09T15:30:00.000-04:00");
+    const now = new Date(2026, 4, 9, 15, 30, 0); // 2026-05-09 15:30 local
     const next = computeNextFireAt(now, "00:00");
     expect(next.getHours()).toBe(0);
     expect(next.getMinutes()).toBe(0);
-    // Tomorrow.
     expect(next.getTime()).toBeGreaterThan(now.getTime());
     expect(next.getTime() - now.getTime()).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
   });
@@ -31,21 +37,20 @@ describe("computeNextFireAt", () => {
     expect(() => computeNextFireAt(new Date(), "")).toThrow();
   });
 
-  test("midnight rolls to next day cleanly across DST", () => {
-    // US/Eastern spring-forward: 2026-03-08 02:00 EST → 03:00 EDT.
-    // After DST transition at 02:00, computing next fire from
-    // 03:30 EDT for 00:00 should still give the next day's 00:00.
-    const now = new Date("2026-03-08T03:30:00.000-04:00");
+  test("midnight rolls to next day cleanly across the spring-forward boundary", () => {
+    // Local 03:30 on the spring-forward day. The setHours(0,0,0,0)
+    // path lands on local midnight; the test only asserts the delta
+    // is positive and ≤ 25h (allowing one extra hour for DST slack).
+    const now = new Date(2026, 2, 8, 3, 30, 0); // 2026-03-08 03:30 local
     const next = computeNextFireAt(now, "00:00");
     expect(next.getTime()).toBeGreaterThan(now.getTime());
-    // Should be within 25 hours (allow one extra hour for DST slack).
     expect(next.getTime() - now.getTime()).toBeLessThanOrEqual(25 * 60 * 60 * 1000);
   });
 });
 
 describe("decideBootAction", () => {
   test("returns no-recent-miss when today's window hasn't arrived yet", () => {
-    const now = new Date("2026-05-09T08:00:00.000-04:00");
+    const now = new Date(2026, 4, 9, 8, 0, 0); // 08:00 local
     expect(decideBootAction({
       now,
       localFireTime: "20:00",
@@ -55,7 +60,7 @@ describe("decideBootAction", () => {
   });
 
   test("returns fire-now when window passed within grace and no fire yet today", () => {
-    const now = new Date("2026-05-09T00:30:00.000-04:00");
+    const now = new Date(2026, 4, 9, 0, 30, 0); // 00:30 local
     const result = decideBootAction({
       now,
       localFireTime: "00:00",
@@ -67,7 +72,7 @@ describe("decideBootAction", () => {
   });
 
   test("returns skip when window passed beyond grace", () => {
-    const now = new Date("2026-05-09T03:00:00.000-04:00");
+    const now = new Date(2026, 4, 9, 3, 0, 0); // 03:00 local
     const result = decideBootAction({
       now,
       localFireTime: "00:00",
@@ -78,21 +83,23 @@ describe("decideBootAction", () => {
   });
 
   test("returns no-recent-miss when today's window already fired", () => {
-    const now = new Date("2026-05-09T12:00:00.000-04:00");
+    const now = new Date(2026, 4, 9, 12, 0, 0); // 12:00 local
+    const lastFireAt = new Date(2026, 4, 9, 0, 1, 0).toISOString(); // 00:01 local
     expect(decideBootAction({
       now,
       localFireTime: "00:00",
-      lastDailyFireAt: "2026-05-09T00:01:00.000-04:00",
+      lastDailyFireAt: lastFireAt,
       gracePeriodMinutes: 60
     })).toEqual({ action: "no-recent-miss" });
   });
 
   test("yesterday's lastDailyFireAt does NOT count for today", () => {
-    const now = new Date("2026-05-09T00:30:00.000-04:00");
+    const now = new Date(2026, 4, 9, 0, 30, 0); // 00:30 today local
+    const yesterdaysFireAt = new Date(2026, 4, 8, 0, 0, 30).toISOString();
     const result = decideBootAction({
       now,
       localFireTime: "00:00",
-      lastDailyFireAt: "2026-05-08T00:00:30.000-04:00",
+      lastDailyFireAt: yesterdaysFireAt,
       gracePeriodMinutes: 60
     });
     expect(result.action).toBe("fire-now");
@@ -116,7 +123,10 @@ describe("DailyNotificationScheduler", () => {
     const sched = new DailyNotificationScheduler({
       subscriptionStore,
       notificationService,
-      now: () => initialNow || new Date("2026-05-09T12:00:00.000-04:00"),
+      // Default to 12:00 local on a fixed date — local-time
+      // constructor so the test result doesn't depend on the host's
+      // timezone offset (production uses local TZ via setHours).
+      now: () => initialNow || new Date(2026, 4, 9, 12, 0, 0),
       logger: { warn: () => {}, error: () => {}, log: () => {} },
       getConfig: () => ({ enabled, localFireTime, gracePeriodMinutes: 60 }),
       buildPayload: () => ({ title: "T", body: "B", url: "/" })
@@ -136,7 +146,7 @@ describe("DailyNotificationScheduler", () => {
   });
 
   test("start() during the grace window fires once, then arms next", async () => {
-    const initialNow = new Date("2026-05-09T00:30:00.000-04:00");
+    const initialNow = new Date(2026, 4, 9, 0, 30, 0); // 00:30 local
     const { sched, broadcastCalls } = buildHarness({
       localFireTime: "00:00",
       initialNow
@@ -148,7 +158,7 @@ describe("DailyNotificationScheduler", () => {
   });
 
   test("start() outside grace skips and arms next", async () => {
-    const initialNow = new Date("2026-05-09T03:00:00.000-04:00"); // 3h after window
+    const initialNow = new Date(2026, 4, 9, 3, 0, 0); // 3h after window
     const { sched, broadcastCalls } = buildHarness({
       localFireTime: "00:00",
       initialNow

--- a/tests/notification-routes.test.js
+++ b/tests/notification-routes.test.js
@@ -1,0 +1,232 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const supertest = require("supertest");
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv() {
+  Object.keys(process.env).forEach((key) => {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  });
+  Object.entries(ORIGINAL_ENV).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+}
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "lhw-notify-int-"));
+}
+
+function loadApp({ adminKey, dir, env = {} } = {}) {
+  jest.resetModules();
+  resetEnv();
+  if (adminKey) process.env.ADMIN_KEY = adminKey;
+  else delete process.env.ADMIN_KEY;
+  process.env.NODE_ENV = "test";
+  process.env.SCHEDULER_CHECK_INTERVAL_MS = String(60 * 60 * 1000);
+  if (dir) {
+    process.env.PUSH_SUBSCRIPTIONS_STORE_PATH = path.join(dir, "push.json");
+    process.env.APP_CONFIG_PATH = path.join(dir, "app-config.json");
+    process.env.SCHEDULE_STORE_PATH = path.join(dir, "schedule.json");
+    process.env.STATS_STORE_PATH = path.join(dir, "leaderboard.json");
+    process.env.CLASSES_STORE_PATH = path.join(dir, "classes.json");
+    process.env.ADMIN_JOBS_STORE_PATH = path.join(dir, "admin-jobs.json");
+  }
+  for (const [k, v] of Object.entries(env)) {
+    process.env[k] = v;
+  }
+  return require("../server");
+}
+
+afterEach(() => {
+  resetEnv();
+});
+
+describe("GET /api/notifications/vapid-public-key", () => {
+  test("returns 503 before VAPID is provisioned", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app).get("/api/notifications/vapid-public-key");
+    expect(res.status).toBe(503);
+    expect(res.body.code).toBe("VAPID_MISSING");
+  });
+
+  test("returns the public key once provisioned (post-startServer)", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    // Provision VAPID via the boot path. We invoke startServer with a
+    // listener stub so it doesn't actually bind a port.
+    const stubListener = (port, host, cb) => { if (cb) setImmediate(cb); return { close: () => {} }; };
+    await app.startServer(stubListener);
+    const res = await supertest(app).get("/api/notifications/vapid-public-key");
+    expect(res.status).toBe(200);
+    expect(typeof res.body.publicKey).toBe("string");
+    expect(res.body.publicKey.length).toBeGreaterThan(80);
+    expect(res.body.publicKey.length).toBeLessThan(200);
+    // privateKey must NEVER appear in the response.
+    expect(res.body.privateKey).toBeUndefined();
+    app.stopSchedulerInterval();
+    app.dailyNotificationScheduler.shutdown();
+  });
+});
+
+describe("POST /api/notifications/subscribe", () => {
+  test("creates a subscription with hashed id", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app)
+      .post("/api/notifications/subscribe")
+      .send({
+        endpoint: "https://fcm.googleapis.com/fcm/send/abc123",
+        keys: { p256dh: "p", auth: "a" }
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.endpointHash).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  test("400 on invalid endpoint", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app)
+      .post("/api/notifications/subscribe")
+      .send({ endpoint: "http://insecure.example", keys: { p256dh: "p", auth: "a" } });
+    expect(res.status).toBe(400);
+  });
+
+  test("dedupes by endpoint", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const r1 = await supertest(app)
+      .post("/api/notifications/subscribe")
+      .send({ endpoint: "https://example.com/p", keys: { p256dh: "p1", auth: "a1" } });
+    const r2 = await supertest(app)
+      .post("/api/notifications/subscribe")
+      .send({ endpoint: "https://example.com/p", keys: { p256dh: "p2", auth: "a2" } });
+    expect(r1.body.endpointHash).toBe(r2.body.endpointHash);
+  });
+});
+
+describe("DELETE /api/notifications/subscribe/:endpointHash", () => {
+  test("204 on existing row", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const created = await supertest(app)
+      .post("/api/notifications/subscribe")
+      .send({ endpoint: "https://example.com/p", keys: { p256dh: "p", auth: "a" } });
+    const del = await supertest(app)
+      .delete(`/api/notifications/subscribe/${encodeURIComponent(created.body.endpointHash)}`);
+    expect(del.status).toBe(204);
+  });
+
+  test("204 on missing row (idempotent)", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const del = await supertest(app).delete("/api/notifications/subscribe/" + "0".repeat(16));
+    expect(del.status).toBe(204);
+  });
+
+  test("400 on malformed hash", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const del = await supertest(app).delete("/api/notifications/subscribe/not-hex");
+    expect(del.status).toBe(400);
+  });
+});
+
+describe("GET /api/admin/notifications/subscriptions", () => {
+  test("requires admin key when configured", async () => {
+    const dir = tempDir();
+    const app = loadApp({ adminKey: "test-key", dir });
+    const noKey = await supertest(app).get("/api/admin/notifications/subscriptions");
+    expect(noKey.status).toBe(401);
+    const withKey = await supertest(app)
+      .get("/api/admin/notifications/subscriptions")
+      .set("x-admin-key", "test-key");
+    expect(withKey.status).toBe(200);
+  });
+
+  test("returns count + timestamps; rows include only opaque hashes", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    await supertest(app)
+      .post("/api/notifications/subscribe")
+      .send({ endpoint: "https://example.com/p", keys: { p256dh: "p", auth: "a" } });
+    const res = await supertest(app).get("/api/admin/notifications/subscriptions");
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.rows).toHaveLength(1);
+    const row = res.body.rows[0];
+    expect(row.endpointHash).toMatch(/^[a-f0-9]{16}$/);
+    // Raw endpoint must NEVER appear in admin responses.
+    expect(row.endpoint).toBeUndefined();
+    expect(row.keys).toBeUndefined();
+  });
+});
+
+describe("POST /api/admin/notifications/broadcast", () => {
+  test("400 on missing title", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app)
+      .post("/api/admin/notifications/broadcast")
+      .send({ body: "x" });
+    expect(res.status).toBe(400);
+  });
+
+  test("400 rejects absolute non-relative URLs", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const res = await supertest(app)
+      .post("/api/admin/notifications/broadcast")
+      .send({ title: "T", body: "B", url: "https://malicious.example/" });
+    expect(res.status).toBe(400);
+  });
+
+  test("dryRun returns recipient count without sending", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const sub = await supertest(app)
+      .post("/api/notifications/subscribe")
+      .send({ endpoint: "https://example.com/p", keys: { p256dh: "p", auth: "a" } });
+    expect(sub.status).toBe(201);
+    const res = await supertest(app)
+      .post("/api/admin/notifications/broadcast")
+      .send({ title: "Hi", body: "Test", url: "/", dryRun: true });
+    expect(res.status).toBe(200);
+    expect(res.body.dryRun).toBe(true);
+    expect(res.body.result.recipients).toBe(1);
+  });
+});
+
+describe("VAPID private key never leaks", () => {
+  test("private key is absent from /api/meta", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const stubListener = (port, host, cb) => { if (cb) setImmediate(cb); return { close: () => {} }; };
+    await app.startServer(stubListener);
+    const res = await supertest(app).get("/api/meta");
+    expect(res.status).toBe(200);
+    const json = JSON.stringify(res.body);
+    expect(json).not.toContain("privateKey");
+    expect(json).not.toContain("pushKeys");
+    app.stopSchedulerInterval();
+    app.dailyNotificationScheduler.shutdown();
+  });
+
+  test("private key is absent from /api/admin/notifications/subscriptions", async () => {
+    const dir = tempDir();
+    const app = loadApp({ dir });
+    const stubListener = (port, host, cb) => { if (cb) setImmediate(cb); return { close: () => {} }; };
+    await app.startServer(stubListener);
+    const res = await supertest(app).get("/api/admin/notifications/subscriptions");
+    expect(res.status).toBe(200);
+    const json = JSON.stringify(res.body);
+    expect(json).not.toContain("privateKey");
+    expect(json).not.toContain("pushKeys");
+    app.stopSchedulerInterval();
+    app.dailyNotificationScheduler.shutdown();
+  });
+});

--- a/tests/notification-routes.test.js
+++ b/tests/notification-routes.test.js
@@ -29,6 +29,7 @@ function loadApp({ adminKey, dir, env = {} } = {}) {
   process.env.SCHEDULER_CHECK_INTERVAL_MS = String(60 * 60 * 1000);
   if (dir) {
     process.env.PUSH_SUBSCRIPTIONS_STORE_PATH = path.join(dir, "push.json");
+    process.env.VAPID_KEYS_STORE_PATH = path.join(dir, "vapid-keys.json");
     process.env.APP_CONFIG_PATH = path.join(dir, "app-config.json");
     process.env.SCHEDULE_STORE_PATH = path.join(dir, "schedule.json");
     process.env.STATS_STORE_PATH = path.join(dir, "leaderboard.json");
@@ -198,6 +199,17 @@ describe("POST /api/admin/notifications/broadcast", () => {
     expect(res.status).toBe(200);
     expect(res.body.dryRun).toBe(true);
     expect(res.body.result.recipients).toBe(1);
+  });
+});
+
+describe("VAPID private key is excluded from backup IN_SCOPE_FILES", () => {
+  test("data/vapid-keys.json is NOT a backup-scope file", () => {
+    const { IN_SCOPE_FILES } = require("../lib/backup-store");
+    expect(IN_SCOPE_FILES).not.toContain("data/vapid-keys.json");
+    // Sanity: app-config IS in scope (the public-half side of the keys
+    // never lived there after the move, but we still expect the rest of
+    // app-config to ship).
+    expect(IN_SCOPE_FILES).toContain("data/app-config.json");
   });
 });
 

--- a/tests/notification-service.test.js
+++ b/tests/notification-service.test.js
@@ -1,0 +1,221 @@
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  NotificationService,
+  buildPayload,
+  classifyResponse,
+  PAYLOAD_MAX_BYTES
+} = require("../lib/notification-service");
+const { PushSubscriptionStore } = require("../lib/push-subscription-store");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "lhw-notify-"));
+}
+
+async function buildService(extra = {}) {
+  const dir = tempDir();
+  const subStore = new PushSubscriptionStore({
+    filePath: path.join(dir, "push.json")
+  });
+  const fakeKeys = {
+    publicKey: "B".repeat(87),
+    privateKey: "p".repeat(43),
+    subject: "mailto:test@example.com"
+  };
+  const fakeWebPush = {
+    setVapidDetails: jest.fn(),
+    sendNotification: jest.fn(async () => ({ statusCode: 200 }))
+  };
+  const svc = new NotificationService({
+    subscriptionStore: subStore,
+    enabled: true,
+    webPush: fakeWebPush,
+    getPushKeys: () => fakeKeys,
+    logger: { warn: () => {}, error: () => {}, log: () => {} },
+    ...extra
+  });
+  return { svc, subStore, fakeWebPush, dir };
+}
+
+afterEach(async () => {
+  // dirs are leaked per test run but fine in tmp; jest --runInBand
+  // serializes so there's no cross-test contention.
+});
+
+describe("buildPayload", () => {
+  test("clamps overlong title and body", () => {
+    const out = buildPayload({
+      title: "x".repeat(200),
+      body: "y".repeat(500),
+      url: "/"
+    });
+    expect(out.title.length).toBe(80);
+    expect(out.body.length).toBe(200);
+    expect(out.url).toBe("/");
+  });
+
+  test("includes optional tag", () => {
+    const out = buildPayload({ title: "t", body: "b", url: "/", tag: "daily" });
+    expect(out.tag).toBe("daily");
+  });
+
+  test("missing inputs become empty strings", () => {
+    const out = buildPayload({});
+    expect(out).toEqual({ title: "", body: "", url: "" });
+  });
+});
+
+describe("classifyResponse", () => {
+  test("HTTP 410 → gone (prune)", () => {
+    expect(classifyResponse({ statusCode: 410 })).toEqual({
+      ok: false, retriable: false, gone: true, status: 410
+    });
+  });
+
+  test("HTTP 404 → gone (prune)", () => {
+    expect(classifyResponse({ statusCode: 404 })).toEqual({
+      ok: false, retriable: false, gone: true, status: 404
+    });
+  });
+
+  test("HTTP 408/429 → retriable, not gone", () => {
+    expect(classifyResponse({ statusCode: 429 }).retriable).toBe(true);
+    expect(classifyResponse({ statusCode: 429 }).gone).toBe(false);
+    expect(classifyResponse({ statusCode: 408 }).retriable).toBe(true);
+  });
+
+  test("Other 4xx → not retriable, not gone", () => {
+    const r = classifyResponse({ statusCode: 400 });
+    expect(r.retriable).toBe(false);
+    expect(r.gone).toBe(false);
+  });
+
+  test("5xx → retriable", () => {
+    expect(classifyResponse({ statusCode: 500 }).retriable).toBe(true);
+    expect(classifyResponse({ statusCode: 502 }).retriable).toBe(true);
+  });
+
+  test("network error (no statusCode) → retriable", () => {
+    expect(classifyResponse({}).retriable).toBe(true);
+  });
+
+  test("null err → ok", () => {
+    expect(classifyResponse(null).ok).toBe(true);
+  });
+});
+
+describe("NotificationService.sendOne", () => {
+  test("sets VAPID details on every send", async () => {
+    const { svc, subStore, fakeWebPush } = await buildService();
+    const sub = await subStore.upsert({
+      endpoint: "https://example.com/push",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    const result = await svc.sendOne(sub, { title: "T", body: "B", url: "/" });
+    expect(result.ok).toBe(true);
+    expect(fakeWebPush.setVapidDetails).toHaveBeenCalledWith(
+      "mailto:test@example.com",
+      expect.any(String),
+      expect.any(String)
+    );
+    expect(fakeWebPush.sendNotification).toHaveBeenCalledTimes(1);
+  });
+
+  test("missing VAPID throws VAPID_MISSING", async () => {
+    const { svc } = await buildService({ getPushKeys: () => null });
+    await expect(svc.sendOne(
+      { endpoint: "https://example.com/push", keys: { p256dh: "p", auth: "a" } },
+      { title: "T", body: "B", url: "/" }
+    )).rejects.toMatchObject({ code: "VAPID_MISSING" });
+  });
+
+  test("disabled service returns skipped", async () => {
+    const { svc, subStore } = await buildService({ enabled: false });
+    const sub = await subStore.upsert({
+      endpoint: "https://example.com/push",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    const result = await svc.sendOne(sub, { title: "T", body: "B" });
+    expect(result.skipped).toBe(true);
+  });
+
+  test("HTTP 410 surface gone:true so caller can prune", async () => {
+    const fakeWebPush = {
+      setVapidDetails: jest.fn(),
+      sendNotification: jest.fn().mockRejectedValue(Object.assign(new Error("gone"), { statusCode: 410 }))
+    };
+    const { svc, subStore } = await buildService({ webPush: fakeWebPush });
+    const sub = await subStore.upsert({
+      endpoint: "https://example.com/push",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    const result = await svc.sendOne(sub, { title: "T", body: "B" });
+    expect(result.ok).toBe(false);
+    expect(result.gone).toBe(true);
+  });
+
+  // The PAYLOAD_TOO_LARGE check is defense-in-depth — buildPayload
+  // clamps title/body so an oversize payload never reaches the byte
+  // check under normal flow. Verify the constant exists and is sane.
+  test("PAYLOAD_MAX_BYTES guards the JSON body length", () => {
+    expect(PAYLOAD_MAX_BYTES).toBeGreaterThanOrEqual(512);
+    expect(PAYLOAD_MAX_BYTES).toBeLessThanOrEqual(4 * 1024);
+  });
+});
+
+describe("NotificationService.broadcast", () => {
+  test("dryRun returns recipient count + preview without sending", async () => {
+    const { svc, subStore, fakeWebPush } = await buildService();
+    await subStore.upsert({
+      endpoint: "https://example.com/a",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    await subStore.upsert({
+      endpoint: "https://example.com/b",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    const result = await svc.broadcast({ title: "T", body: "B", url: "/" }, { dryRun: true });
+    expect(result.dryRun).toBe(true);
+    expect(result.recipients).toBe(2);
+    expect(result.preview).toEqual({ title: "T", body: "B", url: "/" });
+    expect(fakeWebPush.sendNotification).not.toHaveBeenCalled();
+  });
+
+  test("aggregate counts: sent + failed + gone", async () => {
+    const fakeWebPush = {
+      setVapidDetails: jest.fn(),
+      sendNotification: jest.fn()
+        .mockResolvedValueOnce({ statusCode: 200 }) // sent
+        .mockRejectedValueOnce(Object.assign(new Error("gone"), { statusCode: 410 })) // gone
+        .mockRejectedValueOnce(Object.assign(new Error("server"), { statusCode: 500 })) // failed
+    };
+    const { svc, subStore } = await buildService({ webPush: fakeWebPush });
+    await subStore.upsert({ endpoint: "https://a.example/push", keys: { p256dh: "p", auth: "a" } });
+    await subStore.upsert({ endpoint: "https://b.example/push", keys: { p256dh: "p", auth: "a" } });
+    await subStore.upsert({ endpoint: "https://c.example/push", keys: { p256dh: "p", auth: "a" } });
+    const result = await svc.broadcast({ title: "T", body: "B", url: "/" });
+    expect(result.recipients).toBe(3);
+    expect(result.sent).toBe(1);
+    expect(result.gone + result.failed).toBe(2);
+    // 410-row should be evicted from the store; failed-row stays with a streak.
+    const remaining = await subStore.list();
+    expect(remaining).toHaveLength(2); // gone subscription pruned
+  });
+
+  test("disabled service returns skipped without listing subs", async () => {
+    const { svc, fakeWebPush } = await buildService({ enabled: false });
+    const result = await svc.broadcast({ title: "T", body: "B" });
+    expect(result.skipped).toBe(true);
+    expect(fakeWebPush.sendNotification).not.toHaveBeenCalled();
+  });
+});
+
+describe("PAYLOAD_MAX_BYTES", () => {
+  test("is small enough to fit Web Push 4 KiB cap with crypto overhead", () => {
+    expect(PAYLOAD_MAX_BYTES).toBeLessThanOrEqual(4 * 1024);
+  });
+});

--- a/tests/push-subscription-store.test.js
+++ b/tests/push-subscription-store.test.js
@@ -1,0 +1,196 @@
+"use strict";
+
+const fs = require("fs");
+const fsp = require("fs/promises");
+const os = require("os");
+const path = require("path");
+
+const {
+  PushSubscriptionStore,
+  endpointHashOf,
+  normalizeSubscription,
+  normalizeStore,
+  ENDPOINT_HASH_PATTERN
+} = require("../lib/push-subscription-store");
+
+function tempPath(name = "push-subscriptions.json") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-pss-"));
+  return path.join(dir, name);
+}
+
+function frozenNow(iso = "2026-05-09T00:00:00.000Z") {
+  return () => new Date(iso);
+}
+
+describe("push-subscription-store helpers", () => {
+  test("endpointHashOf is 16 lowercase hex chars and stable", () => {
+    const a = endpointHashOf("https://fcm.googleapis.com/fcm/send/abc");
+    const b = endpointHashOf("https://fcm.googleapis.com/fcm/send/abc");
+    expect(a).toBe(b);
+    expect(ENDPOINT_HASH_PATTERN.test(a)).toBe(true);
+  });
+
+  test("endpointHashOf differs per endpoint", () => {
+    const a = endpointHashOf("https://fcm.googleapis.com/fcm/send/abc");
+    const b = endpointHashOf("https://fcm.googleapis.com/fcm/send/xyz");
+    expect(a).not.toBe(b);
+  });
+
+  test("normalizeSubscription rejects non-https endpoint", () => {
+    expect(() => normalizeSubscription({
+      endpointHash: "a".repeat(16),
+      endpoint: "http://insecure.example",
+      keys: { p256dh: "x", auth: "y" },
+      createdAt: "2026-05-09T00:00:00.000Z"
+    })).toThrow();
+  });
+
+  test("normalizeStore drops duplicate endpointHashes", () => {
+    const out = normalizeStore({
+      version: 1,
+      updatedAt: "2026-05-09T00:00:00.000Z",
+      lastBroadcastAt: null,
+      lastDailyFireAt: null,
+      subscriptions: [
+        {
+          endpointHash: "a".repeat(16),
+          endpoint: "https://example.com/a",
+          keys: { p256dh: "k1", auth: "a1" },
+          createdAt: "2026-05-09T00:00:00.000Z"
+        },
+        {
+          endpointHash: "a".repeat(16),
+          endpoint: "https://example.com/a-dup",
+          keys: { p256dh: "k2", auth: "a2" },
+          createdAt: "2026-05-09T00:00:01.000Z"
+        }
+      ]
+    });
+    expect(out.subscriptions).toHaveLength(1);
+    expect(out.subscriptions[0].endpoint).toBe("https://example.com/a");
+  });
+});
+
+describe("PushSubscriptionStore CRUD", () => {
+  let store;
+  let filePath;
+
+  beforeEach(() => {
+    filePath = tempPath();
+    store = new PushSubscriptionStore({ filePath, now: frozenNow() });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(path.dirname(filePath), { recursive: true, force: true });
+  });
+
+  test("first load creates an empty store", async () => {
+    const snap = await store.load();
+    expect(snap.subscriptions).toEqual([]);
+    expect(snap.lastBroadcastAt).toBeNull();
+    expect(snap.lastDailyFireAt).toBeNull();
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  test("upsert dedupes by endpoint", async () => {
+    const sub1 = await store.upsert({
+      endpoint: "https://fcm.googleapis.com/fcm/send/abc",
+      keys: { p256dh: "p1", auth: "a1" }
+    });
+    const sub2 = await store.upsert({
+      endpoint: "https://fcm.googleapis.com/fcm/send/abc",
+      keys: { p256dh: "p2", auth: "a2" }
+    });
+    expect(sub1.endpointHash).toBe(sub2.endpointHash);
+    const snap = await store.load();
+    expect(snap.subscriptions).toHaveLength(1);
+    expect(snap.subscriptions[0].keys.p256dh).toBe("p2"); // updated
+  });
+
+  test("upsert rejects http:// endpoints", async () => {
+    await expect(store.upsert({
+      endpoint: "http://insecure.example/push",
+      keys: { p256dh: "p", auth: "a" }
+    })).rejects.toThrow();
+  });
+
+  test("upsert rejects missing keys", async () => {
+    await expect(store.upsert({
+      endpoint: "https://example.com/push",
+      keys: {}
+    })).rejects.toThrow();
+  });
+
+  test("removeByHash deletes the row", async () => {
+    const sub = await store.upsert({
+      endpoint: "https://example.com/push",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    const removed = await store.removeByHash(sub.endpointHash);
+    expect(removed.endpointHash).toBe(sub.endpointHash);
+    const snap = await store.load();
+    expect(snap.subscriptions).toEqual([]);
+  });
+
+  test("removeByHash on missing row is a no-op", async () => {
+    const removed = await store.removeByHash("0".repeat(16));
+    expect(removed).toBeNull();
+  });
+
+  test("markFailure with gone:true prunes immediately", async () => {
+    const sub = await store.upsert({
+      endpoint: "https://example.com/push",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    await store.markFailure(sub.endpointHash, { gone: true });
+    const snap = await store.load();
+    expect(snap.subscriptions).toEqual([]);
+  });
+
+  test("markFailure increments streak; markSuccess clears it", async () => {
+    const sub = await store.upsert({
+      endpoint: "https://example.com/push",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    await store.markFailure(sub.endpointHash);
+    await store.markFailure(sub.endpointHash);
+    let row = await store.findByHash(sub.endpointHash);
+    expect(row.failureStreak).toBe(2);
+    expect(row.firstFailureAt).toBeTruthy();
+    await store.markSuccess(sub.endpointHash);
+    row = await store.findByHash(sub.endpointHash);
+    expect(row.failureStreak).toBeUndefined();
+    expect(row.firstFailureAt).toBeUndefined();
+    expect(row.lastSuccessAt).toBeTruthy();
+  });
+
+  test("pruneStale evicts rows whose first failure is older than the cutoff", async () => {
+    const oldNow = new Date("2026-04-01T00:00:00.000Z");
+    store.now = () => oldNow;
+    const oldSub = await store.upsert({
+      endpoint: "https://example.com/old",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    await store.markFailure(oldSub.endpointHash);
+    const recentNow = new Date("2026-05-09T00:00:00.000Z");
+    store.now = () => recentNow;
+    const newSub = await store.upsert({
+      endpoint: "https://example.com/new",
+      keys: { p256dh: "p", auth: "a" }
+    });
+    await store.markFailure(newSub.endpointHash);
+    const removed = await store.pruneStale();
+    expect(removed).toEqual([oldSub.endpointHash]);
+    const snap = await store.load();
+    expect(snap.subscriptions.map((s) => s.endpointHash)).toEqual([newSub.endpointHash]);
+  });
+
+  test("stampLastBroadcast and stampLastDailyFire persist", async () => {
+    const at = new Date("2026-05-09T12:00:00.000Z");
+    await store.stampLastBroadcast(at);
+    await store.stampLastDailyFire(at);
+    const snap = await store.load();
+    expect(snap.lastBroadcastAt).toBe(at.toISOString());
+    expect(snap.lastDailyFireAt).toBe(at.toISOString());
+  });
+});

--- a/tests/push-subscription-store.test.js
+++ b/tests/push-subscription-store.test.js
@@ -38,14 +38,28 @@ describe("push-subscription-store helpers", () => {
 
   test("normalizeSubscription rejects non-https endpoint", () => {
     expect(() => normalizeSubscription({
-      endpointHash: "a".repeat(16),
+      endpointHash: endpointHashOf("http://insecure.example"),
       endpoint: "http://insecure.example",
       keys: { p256dh: "x", auth: "y" },
       createdAt: "2026-05-09T00:00:00.000Z"
     })).toThrow();
   });
 
-  test("normalizeStore drops duplicate endpointHashes", () => {
+  test("normalizeSubscription rejects mismatched endpointHash", () => {
+    expect(() => normalizeSubscription({
+      endpointHash: "a".repeat(16),
+      endpoint: "https://example.com/p",
+      keys: { p256dh: "x", auth: "y" },
+      createdAt: "2026-05-09T00:00:00.000Z"
+    })).toThrow(/does not match/);
+  });
+
+  test("normalizeStore drops rows with duplicate canonical endpointHashes", () => {
+    // Two rows with the same endpoint will produce the same expected
+    // hash; the second is dropped on dedupe even when the inputs
+    // claim different (mismatched) hashes — but we can only test the
+    // dedupe path with VALID inputs now, so use the same endpoint.
+    const sharedHash = endpointHashOf("https://example.com/a");
     const out = normalizeStore({
       version: 1,
       updatedAt: "2026-05-09T00:00:00.000Z",
@@ -53,21 +67,21 @@ describe("push-subscription-store helpers", () => {
       lastDailyFireAt: null,
       subscriptions: [
         {
-          endpointHash: "a".repeat(16),
+          endpointHash: sharedHash,
           endpoint: "https://example.com/a",
           keys: { p256dh: "k1", auth: "a1" },
           createdAt: "2026-05-09T00:00:00.000Z"
         },
         {
-          endpointHash: "a".repeat(16),
-          endpoint: "https://example.com/a-dup",
+          endpointHash: sharedHash,
+          endpoint: "https://example.com/a",
           keys: { p256dh: "k2", auth: "a2" },
           createdAt: "2026-05-09T00:00:01.000Z"
         }
       ]
     });
     expect(out.subscriptions).toHaveLength(1);
-    expect(out.subscriptions[0].endpoint).toBe("https://example.com/a");
+    expect(out.subscriptions[0].keys.p256dh).toBe("k1"); // first wins
   });
 });
 


### PR DESCRIPTION
## Summary
- Self-hosted Web Push (VAPID, no FCM/APNs/third-party). VAPID keypair generated at first boot and persisted in `data/app-config.json` under `pushKeys` — private key never exposed via any client/admin endpoint.
- Player opt-in toggle in header settings strip; explicit user-gesture only (no auto-prompt). Keyboard-reachable, aria-pressed, status line.
- Admin Notifications tab with subscription count, last-fire timestamps, and broadcast form (preview + send). URLs must be site-relative.
- Daily fire scheduler: wall-clock anchored (DST-safe, no `+24h` drift), restart re-arm with 60-minute grace window for missed fires.
- HTTP 410 → prune immediately; non-410 failures tracked with streak, pruned after 7 days.
- Service worker v3 adds `push` and `notificationclick` listeners; tab-focus-or-open-new behavior with tag-based collapsing.

Closes [#92](https://github.com/curdriceaurora/wordle-local/issues/92)

## Test plan
- [x] `npm run check` — lint + schema:check + nit-guardrails + 596 tests, all green
- [x] `tests/push-subscription-store.test.js` (14 cases — atomic CRUD, dedupe, prune-on-410, pruneStale)
- [x] `tests/notification-service.test.js` (19 cases — buildPayload clamps, classifyResponse decision table, sendOne mocking, broadcast aggregate counts, VAPID-missing guard)
- [x] `tests/daily-notification-scheduler.test.js` (14 cases — computeNextFireAt across DST, decideBootAction grace window, scheduler integration)
- [x] `tests/notification-routes.test.js` (15 cases — subscribe/unsubscribe/vapid-public-key/admin/broadcast, **VAPID-private-key-leak guards** for `/api/meta` AND `/api/admin/notifications/*`)
- [x] Backup + restore tests cover the new data file end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added daily push notifications for the puzzle, with user opt-in toggle in settings.
  * Added admin panel for managing and broadcasting notifications to subscribers.
  * Subscribers can now receive real-time puzzle notifications on supported browsers.

* **Documentation**
  * Added comprehensive guide for the push notification system, including setup, browser support, and troubleshooting.

* **Tests**
  * Added test coverage for notification scheduling, subscription management, and broadcast functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->