### PR TITLE
chore: post-merge review cleanup across PRs #100-#103

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -29,4 +29,8 @@ expose the lower-level `aes128gcm` content encoding helpers needed
 for RFC 8291 message bodies.
 
 - Project: https://github.com/web-push-libs/web-push
-- License: MIT
+- License: MPL-2.0 (Mozilla Public License 2.0)
+- Source obligation: distributing modified versions of `web-push` (or
+  any covered file) requires making that modified source available to
+  recipients under MPL-2.0. We use the upstream package unmodified;
+  any future fork/patch must preserve this disclosure.

--- a/docs/challenge-mode.md
+++ b/docs/challenge-mode.md
@@ -64,8 +64,13 @@ score = sum(perPuzzleScore for each solved puzzle)
 - Timeouts settle on the server's `Date.now()` against the persisted
   `startedAt`; tab-backgrounding on the client can't pause the budget.
 - Wrong-length guesses are rejected without consuming a try.
-- Non-dictionary guesses are rejected (when the answer dictionary for
-  the language is loaded).
+- Non-dictionary guesses are rejected (when the guess dictionary for
+  the language is loaded). The guess dictionary is the broader
+  vocabulary used for input validation — distinct from the answer pool
+  used to PICK target words. Provider-imported languages with a
+  curated answer pool will still accept any guess in the full guess
+  dictionary, matching `/api/guess`'s behavior for daily/created
+  puzzles.
 
 ## Storage
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -129,14 +129,16 @@ runtime.
 | --- | --- |
 | Toggle hidden | Browser lacks `PushManager` / Service Worker, or the site is HTTP (not HTTPS or localhost). |
 | Toggle disabled, "Notifications blocked" | Browser permission denied. Open browser settings → site permissions → reload. |
-| Subscribe returns 503 `VAPID_MISSING` | Boot path hasn't run `ensurePushKeysSync` yet — wait a few seconds and retry. |
+| Subscribe returns 503 `VAPID_MISSING` | Boot path hasn't run `vapidStore.ensureKeysSync()` yet — wait a few seconds and retry. |
 | No notification at midnight | Check `notifications.enabled` in admin Runtime Settings, server-local timezone of the host, and the `lastDailyFireAt` timestamp on the admin Notifications tab. |
 | Notification body shows wrong word length | The scheduler reads `wordDataCache` at fire time. If admin set a new word AFTER the daily reconcile, the new word reflects on the next fire. |
 
 ## Dependencies
 
-- `web-push@^3.6.0` — runtime dependency for VAPID JWT signing and
-  RFC 8291 message encryption.
+- `web-push@^3.6.7` — runtime dependency for VAPID JWT signing and
+  RFC 8291 message encryption. (License: MPL-2.0; see
+  `THIRD_PARTY_NOTICES.md` for source-disclosure requirements if you
+  ship a modified fork.)
 
 ## Test coverage
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -84,10 +84,26 @@ sequence (or coordinate across deployments).
 `data/word.json.lastScheduledFor = today` whenever it persists a word;
 manual writes don't set that field. The next reconcile sees:
 
-- `word.json.date === today` AND `lastScheduledFor !== today` → manual
-  override is fresh; **leave it alone** for the rest of the local day.
-- `word.json.date < today` (or any other state) → fair game; write the
-  scheduled or auto-rotated word.
+- `word.json.date === serverToday` AND `lastScheduledFor !== todayLocal`
+  → manual override is fresh; **leave it alone** for the rest of the
+  local day. ("serverToday" is the server's local date — `getLocalDateString(now)`,
+  not the schedule's timezone.)
+- `word.json.date === null` or omitted entirely → still treated as a
+  fresh manual override and left alone, expiring at the next
+  server-local midnight. The expiry boundary is computed from the
+  server's own clock, NOT from `updatedAt` or the schedule's timezone,
+  so an operator POSTing without `date` shouldn't be surprised that the
+  override expires sooner than expected if the server's TZ differs from
+  the schedule's. Recommend setting `date: serverToday` in manual
+  writes for explicit clarity.
+- `word.json.date < serverToday` (or any other state) → fair game; write
+  the scheduled or auto-rotated word.
+
+The scheduler is NOT timezone-aware in the override-freshness check —
+it always uses the server's own `getLocalDateString(now)`. The
+schedule's `timezone` only affects which row is picked from
+`scheduled_words`, not whether a manual override is still considered
+fresh.
 
 ## Timezone alignment
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -81,23 +81,38 @@ sequence (or coordinate across deployments).
 ### Manual override semantics
 
 `POST /api/word` is still the manual-override path. The scheduler writes
-`data/word.json.lastScheduledFor = today` whenever it persists a word;
-manual writes don't set that field. The next reconcile sees:
+`data/word.json.lastScheduledFor = todayLocal` whenever it persists a
+word; manual writes don't set that field at all. The reconciler decides
+"manual override?" by checking `lastScheduledFor` for **absence**
+(`=== undefined || === null`) — NOT by comparing it to `todayLocal`. A
+prior scheduler write whose `lastScheduledFor` is yesterday's
+schedule-local day is therefore correctly classified as a stale
+scheduler write (not a manual override) and is fair game to overwrite.
 
-- `word.json.date === serverToday` AND `lastScheduledFor !== todayLocal`
-  → manual override is fresh; **leave it alone** for the rest of the
-  local day. ("serverToday" is the server's local date — `getLocalDateString(now)`,
-  not the schedule's timezone.)
-- `word.json.date === null` or omitted entirely → still treated as a
-  fresh manual override and left alone, expiring at the next
-  server-local midnight. The expiry boundary is computed from the
-  server's own clock, NOT from `updatedAt` or the schedule's timezone,
-  so an operator POSTing without `date` shouldn't be surprised that the
-  override expires sooner than expected if the server's TZ differs from
-  the schedule's. Recommend setting `date: serverToday` in manual
-  writes for explicit clarity.
-- `word.json.date < serverToday` (or any other state) → fair game; write
-  the scheduled or auto-rotated word.
+When the reconciler runs, it sees one of:
+
+- `lastScheduledFor` absent (manual override path) AND the override is
+  fresh (see "fresh enough to honour" rules below) → **leave it alone**
+  for the rest of the local day.
+- `lastScheduledFor` absent AND the override is stale → fair game.
+- `lastScheduledFor` present (scheduler-owned write) → fair game; the
+  reconciler may overwrite with the day's scheduled or auto-rotated
+  word, regardless of whether `lastScheduledFor` matches `todayLocal`.
+
+A manual override is "fresh enough to honour" if either:
+
+1. `word.json.date === serverToday` (the operator pinned today
+   explicitly), OR
+2. `word.json.date === null` or omitted entirely AND the override's
+   effective day, computed from `updatedAt`'s server-local date, is
+   still `serverToday`. Without this fallback, a null-date override
+   would live forever instead of expiring at the next midnight.
+
+`serverToday` is the server's local date (`getLocalDateString(now)`),
+NOT the schedule's timezone. An operator POSTing without `date`
+shouldn't be surprised that the override expires sooner than expected
+if the server's TZ differs from the schedule's. Recommend setting
+`date: serverToday` in manual writes for explicit clarity.
 
 The scheduler is NOT timezone-aware in the override-freshness check —
 it always uses the server's own `getLocalDateString(now)`. The

--- a/lib/app-config-store.js
+++ b/lib/app-config-store.js
@@ -353,9 +353,25 @@ class AppConfigStore {
     // merge, an unrelated Settings save silently drops a previously
     // persisted notifications.{enabled,localFireTime,gracePeriodMinutes}
     // and reverts to env-default values.
+    //
+    // The merge is keyed on whether the CALLER mentioned `notifications`
+    // at all (hasOwnProperty), not whether the normalized value is
+    // present. That distinction matters for the reset path: if the
+    // operator explicitly POSTs `{notifications: null}` (or sends a
+    // body that, after normalization, clears the field), we honor the
+    // reset. Only an absent key triggers preserve-merge. Without this
+    // contract, an operator could never clear notification overrides
+    // via this API — even sending `{notifications: null}` would be
+    // silently overwritten by the prior value because incoming.notifications
+    // would be undefined after normalize and we'd preserve.
     const merged = { ...incoming };
     const previousNotifications = this.state?.overrides?.notifications;
-    if (previousNotifications && incoming.notifications === undefined) {
+    const callerProvidedNotifications = Boolean(
+      rawOverrides
+      && typeof rawOverrides === "object"
+      && Object.prototype.hasOwnProperty.call(rawOverrides, "notifications")
+    );
+    if (previousNotifications && !callerProvidedNotifications) {
       merged.notifications = clone(previousNotifications);
     }
 

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -969,6 +969,28 @@ async function applyRestore({ archivePath, projectRoot, logger = console }, opti
         removalQueue.push({ archivePath: file.archivePath });
       }
     }
+    // Replace-all semantics for BACKWARDS_COMPATIBLE_FILES: when an old
+    // archive omits one of these files (e.g. a pre-scheduler backup
+    // doesn't declare data/schedule.json), the live file on a newer
+    // node would otherwise survive the restore — producing a mix of
+    // archived and current state that breaks the "true restore"
+    // contract. Queue the live file for removal so the post-restore
+    // reload of each store hits the missing-file path and writes its
+    // own auto-recover default (the same state a clean install of
+    // that feature would produce). Files declared in the manifest are
+    // already in restorablePaths and won't be queued for removal.
+    {
+      const declaredPaths = new Set(manifest.files.map((entry) => entry.path));
+      for (const compatPath of BACKWARDS_COMPATIBLE_FILES) {
+        if (declaredPaths.has(compatPath)) continue;
+        const liveAbs = path.join(projectRoot, compatPath);
+        // Skip if no live file: nothing to remove. This is the
+        // fresh-install path — no replace-all action needed because
+        // there's nothing to replace.
+        if (!(await fileExists(liveAbs))) continue;
+        removalQueue.push({ archivePath: compatPath });
+      }
+    }
 
     // Phase 3: snapshot existing files into the rollback dir, then swap
     // staged files into place. Each file is snapshot-then-swap individually
@@ -1131,6 +1153,7 @@ module.exports = {
   IN_SCOPE_FILES,
   IN_SCOPE_SCHEMAS,
   DIAGNOSTIC_SCHEMAS,
+  BACKWARDS_COMPATIBLE_FILES,
   DEFAULT_TOTAL_UNCOMPRESSED_MAX_BYTES,
   DEFAULT_PER_ENTRY_MAX_BYTES,
   buildManifest,

--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -27,6 +27,23 @@ const IN_SCOPE_FILES = Object.freeze([
   "data/word.json"
 ]);
 
+// Files added after the initial backup spec shipped. An archive produced
+// before each feature landed would not declare these in its manifest;
+// validateArchive must not fail MANIFEST_INCOMPLETE for them, and
+// applyRestore intentionally leaves the live file untouched (each store's
+// own auto-recover default kicks in if the file is missing entirely).
+// When adding a new IN_SCOPE_FILES entry for a feature shipping AFTER
+// this date, add it here too — failure to do so makes every prior backup
+// non-restorable until the fleet catches up.
+const BACKWARDS_COMPATIBLE_FILES = Object.freeze([
+  "data/schedule.json",
+  "data/webhooks.json",
+  "data/webhook-deliveries.json",
+  "data/push-subscriptions.json",
+  "data/challenges.json",
+  "data/challenge-results.json"
+]);
+
 const IN_SCOPE_SCHEMAS = Object.freeze({
   "data/leaderboard.json": "data/leaderboard.schema.json",
   "data/languages.json": "data/languages.schema.json",
@@ -631,18 +648,27 @@ async function validateArchive(archivePath, options = {}) {
     }
   }
 
-  // Reject manifests that omit any IN_SCOPE_FILES entry. The runbook
-  // documents these as "always included / replace-all", and applyRestore
-  // relies on each one being staged before phase 3. A crafted (or
-  // accidentally-trimmed) archive that drops, say, data/app-config.json
+  // Reject manifests that omit any required IN_SCOPE_FILES entry. The
+  // runbook documents these as "always included / replace-all", and
+  // applyRestore relies on each one being staged before phase 3. A crafted
+  // (or accidentally-trimmed) archive that drops, say, data/app-config.json
   // would otherwise produce a partial restore that violates the
   // documented semantics — the dropped file would silently retain its
   // pre-restore contents. Runs AFTER the optional-set checks so a
   // crafted manifest that's both incomplete AND has bad optional-set
   // paths still surfaces the security-relevant error first.
+  //
+  // BACKWARDS_COMPATIBLE_FILES are excepted: archives produced before the
+  // corresponding feature landed cannot declare those entries, and the
+  // runbook explicitly allows restoring those older archives — the
+  // post-restore reload of each store handles a missing file by writing
+  // its own default (which is the same behavior as a clean install).
   {
     const declaredPaths = new Set(manifest.files.map((entry) => entry.path));
-    const missing = IN_SCOPE_FILES.filter((p) => !declaredPaths.has(p));
+    const backwardsCompatible = new Set(BACKWARDS_COMPATIBLE_FILES);
+    const missing = IN_SCOPE_FILES.filter(
+      (p) => !declaredPaths.has(p) && !backwardsCompatible.has(p)
+    );
     if (missing.length > 0) {
       throw new BackupError(
         "MANIFEST_INCOMPLETE",

--- a/lib/challenge-config-store.js
+++ b/lib/challenge-config-store.js
@@ -241,18 +241,29 @@ class ChallengeConfigStore {
       raw = await fsp.readFile(this.filePath, "utf8");
     } catch (err) {
       if (err && err.code === "ENOENT") {
-        // ENOENT on the read path: bootstrap an in-memory default but
-        // do NOT persist here. Writing through `writeJsonAtomic` from
-        // a read-triggered code path bypasses `claimDirectDataWriteSlot`,
-        // which would race with an in-flight backup/restore (their
-        // contract is "no direct writes outside the slot"). The first
-        // legitimate mutation will go through `commitWithSlot` and
-        // persist this default plus any update — until then the
-        // default lives only in memory, which is exactly the same
-        // behavior callers see for any cold cache.
+        // ENOENT on the read path: bootstrap a default and persist it,
+        // but go through the data-write slot so we don't race a
+        // concurrent backup/restore. Earlier code wrote via
+        // writeJsonAtomic directly, bypassing the slot; the followup
+        // (no-write) broke backup-warming because buildManifest()
+        // requires every in-scope file to exist on disk before
+        // hashing — a cold-start node that warms the store and then
+        // exports a backup would hit INSCOPE_FILE_MISSING. Claiming
+        // the slot here is safe: it's the same contract every other
+        // direct write follows. We can't go through #commit() because
+        // its inner `await this.load()` recurses into us.
         const fresh = buildDefaultStore();
         fresh.updatedAt = this.now().toISOString();
-        this.state = fresh;
+        let releaseSlot = null;
+        try {
+          if (this.claimDirectDataWriteSlot) {
+            releaseSlot = await this.claimDirectDataWriteSlot();
+          }
+          await writeJsonAtomic(this.filePath, fresh);
+          this.state = fresh;
+        } finally {
+          if (releaseSlot) releaseSlot();
+        }
         return;
       }
       throw new ChallengeConfigStoreError(

--- a/lib/challenge-config-store.js
+++ b/lib/challenge-config-store.js
@@ -241,9 +241,17 @@ class ChallengeConfigStore {
       raw = await fsp.readFile(this.filePath, "utf8");
     } catch (err) {
       if (err && err.code === "ENOENT") {
+        // ENOENT on the read path: bootstrap an in-memory default but
+        // do NOT persist here. Writing through `writeJsonAtomic` from
+        // a read-triggered code path bypasses `claimDirectDataWriteSlot`,
+        // which would race with an in-flight backup/restore (their
+        // contract is "no direct writes outside the slot"). The first
+        // legitimate mutation will go through `commitWithSlot` and
+        // persist this default plus any update — until then the
+        // default lives only in memory, which is exactly the same
+        // behavior callers see for any cold cache.
         const fresh = buildDefaultStore();
         fresh.updatedAt = this.now().toISOString();
-        await writeJsonAtomic(this.filePath, fresh);
         this.state = fresh;
         return;
       }

--- a/lib/challenge-config-store.js
+++ b/lib/challenge-config-store.js
@@ -241,29 +241,37 @@ class ChallengeConfigStore {
       raw = await fsp.readFile(this.filePath, "utf8");
     } catch (err) {
       if (err && err.code === "ENOENT") {
-        // ENOENT on the read path: bootstrap a default and persist it,
-        // but go through the data-write slot so we don't race a
-        // concurrent backup/restore. Earlier code wrote via
-        // writeJsonAtomic directly, bypassing the slot; the followup
-        // (no-write) broke backup-warming because buildManifest()
-        // requires every in-scope file to exist on disk before
-        // hashing — a cold-start node that warms the store and then
-        // exports a backup would hit INSCOPE_FILE_MISSING. Claiming
-        // the slot here is safe: it's the same contract every other
-        // direct write follows. We can't go through #commit() because
-        // its inner `await this.load()` recurses into us.
+        // Bootstrap on first read: write the default directly.
+        //
+        // This intentionally does NOT claim claimDirectDataWriteSlot.
+        // Two earlier attempts at this were both wrong:
+        //   - Round 1 removed the write entirely. That broke the
+        //     backup route, which calls warmInScopeStores() →
+        //     load() before buildManifest() and requires the file
+        //     to exist for hashing (INSCOPE_FILE_MISSING otherwise).
+        //   - Round 2 added a claimDirectDataWriteSlot() call. That
+        //     deadlocked: the backup/restore routes set
+        //     dataMutationLockRef.value=true BEFORE warmInScopeStores(),
+        //     and claimDirectDataWriteSlot() awaits that lock to
+        //     release — but the lock can only release after the
+        //     backup/restore finishes, which is waiting on this
+        //     load(). Indefinite hang with the data lock held.
+        //
+        // Direct write is safe in practice because every code path
+        // that reaches this load() in production is either:
+        //   a) under the /api gate, which 503s during backup, or
+        //   b) the backup/restore route itself calling
+        //      warmInScopeStores while it already holds the data
+        //      lock — that lock provides the same mutual exclusion
+        //      the slot would have, without the deadlock.
+        // This matches the bootstrap pattern used by every other
+        // in-scope store (lib/schedule-store.js, lib/webhook-store.js,
+        // lib/push-subscription-store.js, lib/challenge-results-store.js,
+        // etc.).
         const fresh = buildDefaultStore();
         fresh.updatedAt = this.now().toISOString();
-        let releaseSlot = null;
-        try {
-          if (this.claimDirectDataWriteSlot) {
-            releaseSlot = await this.claimDirectDataWriteSlot();
-          }
-          await writeJsonAtomic(this.filePath, fresh);
-          this.state = fresh;
-        } finally {
-          if (releaseSlot) releaseSlot();
-        }
+        await writeJsonAtomic(this.filePath, fresh);
+        this.state = fresh;
         return;
       }
       throw new ChallengeConfigStoreError(

--- a/lib/challenge-engine.js
+++ b/lib/challenge-engine.js
@@ -155,7 +155,19 @@ function buildLeaderboard({ challenge, sessions }) {
       continue;
     }
     if (policy === "best") {
-      if ((s.score || 0) > (existing.score || 0)) byProfile.set(s.profileId, s);
+      // Use the same comparator as the leaderboard so the "best"
+      // session for a profile is the one that would actually outrank
+      // the others on the leaderboard. Comparing by score alone made
+      // ties order-dependent on insertion sequence — two sessions with
+      // identical score but different elapsed time would non-
+      // deterministically pick whichever arrived first. The full
+      // sorter cascades score → elapsed → finishedAt so ties resolve
+      // the same way the leaderboard would display them.
+      const sRow = projectLeaderboardRow(s);
+      const existingRow = projectLeaderboardRow(existing);
+      if (leaderboardSorter(sRow, existingRow) < 0) {
+        byProfile.set(s.profileId, s);
+      }
     } else if (policy === "first-only") {
       if (Date.parse(s.startedAt) < Date.parse(existing.startedAt)) {
         byProfile.set(s.profileId, s);

--- a/lib/challenge-results-store.js
+++ b/lib/challenge-results-store.js
@@ -264,11 +264,35 @@ class ChallengeResultsStore {
       puzzles: puzzles.map(normalizePuzzle)
     };
     if (typeof profileName === "string" && profileName) session.profileName = profileName;
+    let resolved = session;
+    let resumed = false;
     await this.#commit((state) => {
+      // Atomic re-check of the single-in-flight invariant. The route
+      // already calls findInFlight() outside the commit and falls
+      // through to here only if no in-flight session exists, but two
+      // concurrent /start requests for the same (challengeId,
+      // profileId) can both pass that check and arrive here. Without
+      // this re-check, the second commit would push a SECOND in-flight
+      // session and the user would see two parallel timers/scores. By
+      // checking inside the updater we guarantee only one session
+      // exists per (challengeId, profileId, in-progress|pending) — the
+      // racing second caller gets the existing session back as a
+      // resume, which is the same observable outcome as if findInFlight
+      // had hit it.
+      const existing = state.sessions.find((s) =>
+        s.challengeId === challengeId
+        && s.profileId === profileId
+        && (s.status === "in-progress" || s.status === "pending")
+      );
+      if (existing) {
+        resolved = existing;
+        resumed = true;
+        return state;
+      }
       state.sessions.push(session);
       return state;
     });
-    return cloneState(session);
+    return { session: cloneState(resolved), resumed };
   }
 
   async update(id, patch) {
@@ -314,13 +338,80 @@ class ChallengeResultsStore {
         } else merged.elapsedSeconds = patch.elapsedSeconds;
       }
       if (patch.profileName !== undefined) {
-        if (patch.profileName === null) delete merged.profileName;
-        else if (typeof patch.profileName === "string" && patch.profileName.length >= 1 && patch.profileName.length <= 64) {
+        if (patch.profileName === null) {
+          delete merged.profileName;
+        } else if (
+          typeof patch.profileName === "string"
+          && patch.profileName.length >= 1
+          && patch.profileName.length <= 64
+        ) {
           merged.profileName = patch.profileName;
+        } else {
+          // Previously this branch fell through silently — an invalid
+          // profileName (wrong type, empty, or > 64 chars) was just
+          // ignored. Every other patch field throws INVALID_REQUEST in
+          // that case, so callers can't distinguish "ignored" from
+          // "applied" without re-fetching. Bring this in line so the
+          // contract is uniform: invalid → throw.
+          throw new ChallengeResultsStoreError(
+            "INVALID_REQUEST",
+            "profileName must be a 1-64 character string, or null to clear."
+          );
         }
       }
       state.sessions.splice(idx, 1, merged);
       updated = merged;
+      return state;
+    });
+    return cloneState(updated);
+  }
+
+  // Atomic transactional update for the per-guess hot path. Two
+  // concurrent /guess requests for the same session were producing a
+  // last-write-wins race: both handlers read `session.puzzles`, both
+  // computed `updatedPuzzles` from that stale snapshot, both called
+  // update({puzzles: updatedPuzzles}), and the second commit overwrote
+  // the first guess. By passing a mutator that runs INSIDE the same
+  // #commit lock the store uses for every other write, we guarantee
+  // the latest persisted session is the one being mutated.
+  //
+  // The mutator receives a deep clone of the current session and
+  // either returns a new merged session (which is persisted) or
+  // throws to abort. The store calls normalizePuzzle/etc. via the
+  // outer normalizeStore so structural validation still applies.
+  // Returns the post-commit cloned session.
+  async transactionalUpdate(id, mutator) {
+    if (!ID_PATTERN.test(String(id || ""))) {
+      throw new ChallengeResultsStoreError("INVALID_REQUEST", "Invalid session id.");
+    }
+    if (typeof mutator !== "function") {
+      throw new ChallengeResultsStoreError("INVALID_REQUEST", "mutator must be a function.");
+    }
+    let updated;
+    await this.#commit((state) => {
+      const idx = state.sessions.findIndex((s) => s.id === id);
+      if (idx === -1) {
+        throw new ChallengeResultsStoreError("SESSION_NOT_FOUND", `No session with id ${id}.`);
+      }
+      const current = JSON.parse(JSON.stringify(state.sessions[idx]));
+      const next = mutator(current);
+      if (!isPlainObject(next)) {
+        throw new ChallengeResultsStoreError(
+          "INVALID_REQUEST",
+          "mutator must return a session object."
+        );
+      }
+      // Identity invariants: id/challengeId/profileId are immutable.
+      if (next.id !== current.id
+        || next.challengeId !== current.challengeId
+        || next.profileId !== current.profileId) {
+        throw new ChallengeResultsStoreError(
+          "INVALID_REQUEST",
+          "mutator must not change id/challengeId/profileId."
+        );
+      }
+      state.sessions.splice(idx, 1, next);
+      updated = next;
       return state;
     });
     return cloneState(updated);

--- a/lib/challenge-results-store.js
+++ b/lib/challenge-results-store.js
@@ -387,7 +387,6 @@ class ChallengeResultsStore {
     if (typeof mutator !== "function") {
       throw new ChallengeResultsStoreError("INVALID_REQUEST", "mutator must be a function.");
     }
-    let updated;
     await this.#commit((state) => {
       const idx = state.sessions.findIndex((s) => s.id === id);
       if (idx === -1) {
@@ -411,10 +410,16 @@ class ChallengeResultsStore {
         );
       }
       state.sessions.splice(idx, 1, next);
-      updated = next;
       return state;
     });
-    return cloneState(updated);
+    // Return the POST-commit (post-normalize) session, not the
+    // mutator's raw return value. #commit() runs the whole state
+    // through normalizeStore — which strips unknown fields and
+    // re-derives a few — so the persisted version can diverge from
+    // what the mutator handed back. Reading from this.state ensures
+    // callers see exactly what's on disk.
+    const persisted = this.state.sessions.find((s) => s.id === id);
+    return cloneState(persisted);
   }
 
   async findById(id) {

--- a/lib/notification-service.js
+++ b/lib/notification-service.js
@@ -171,7 +171,11 @@ class NotificationService {
         `Notification payload is ${Buffer.byteLength(previewBody, "utf8")} bytes; cap is ${PAYLOAD_MAX_BYTES}.`
       );
     }
-    if (!this.getPushKeys() || !this.getPushKeys().publicKey || !this.getPushKeys().privateKey) {
+    // Capture getPushKeys() once: each call goes through a synchronous
+    // file read in production (vapidStore.getKeysSync), so the previous
+    // triple-call here did three disk reads to validate one shape.
+    const broadcastKeys = this.getPushKeys();
+    if (!broadcastKeys || !broadcastKeys.publicKey || !broadcastKeys.privateKey) {
       throw new NotificationServiceError(
         "VAPID_MISSING",
         "Cannot send: VAPID keypair not provisioned."

--- a/lib/notification-service.js
+++ b/lib/notification-service.js
@@ -154,6 +154,29 @@ class NotificationService {
         dryRun: true
       };
     }
+    // Pre-flight the payload once. The same body is sent to every
+    // subscriber, so a PAYLOAD_TOO_LARGE / VAPID_MISSING throw from
+    // sendOne would short-circuit Promise.all on the FIRST attempt
+    // and the remaining subscribers would never be touched. Worse,
+    // the throw rejects the whole `Promise.all([...workers])` so the
+    // already-completed sends in the other workers don't get their
+    // store updates committed (they ran but the rejection bubbles
+    // out of broadcast before the store-update awaits land). Doing
+    // the check up front turns a global config error into a clean,
+    // counted failure path.
+    const previewBody = JSON.stringify(buildPayload(payload));
+    if (Buffer.byteLength(previewBody, "utf8") > PAYLOAD_MAX_BYTES) {
+      throw new NotificationServiceError(
+        "PAYLOAD_TOO_LARGE",
+        `Notification payload is ${Buffer.byteLength(previewBody, "utf8")} bytes; cap is ${PAYLOAD_MAX_BYTES}.`
+      );
+    }
+    if (!this.getPushKeys() || !this.getPushKeys().publicKey || !this.getPushKeys().privateKey) {
+      throw new NotificationServiceError(
+        "VAPID_MISSING",
+        "Cannot send: VAPID keypair not provisioned."
+      );
+    }
     let sent = 0;
     let failed = 0;
     let gone = 0;
@@ -162,7 +185,19 @@ class NotificationService {
       while (queue.length > 0) {
         const sub = queue.shift();
         if (!sub) break;
-        const result = await this.sendOne(sub, payload);
+        // Defense in depth: wrap sendOne so a per-subscriber bug
+        // (e.g. an unexpected throw inside web-push that classifyResponse
+        // didn't anticipate) doesn't poison Promise.all and silently
+        // skip the rest of the queue. The pre-flight above handles the
+        // known global failures (oversized payload, missing VAPID); this
+        // catches the unknown-unknowns and keeps the batch progressing.
+        let result;
+        try {
+          result = await this.sendOne(sub, payload);
+        } catch (err) {
+          this.logger.error?.(`[notify] sendOne crashed for ${sub.endpointHash}:`, err);
+          result = { ok: false, gone: false, error: err.message || String(err) };
+        }
         if (result.ok) {
           await this.subscriptionStore.markSuccess(sub.endpointHash).catch(() => {});
           sent += 1;

--- a/lib/scheduler-tick.js
+++ b/lib/scheduler-tick.js
@@ -125,9 +125,29 @@ async function pickAutoRotateWord({
   languagesPath,
   logger
 }) {
-  const lang = preferredLang || defaultLang;
-  if (!lang) return null;
-  const langInfo = readActiveCommitForLang(languagesPath, lang);
+  const initialLang = preferredLang || defaultLang;
+  if (!initialLang) return null;
+  // Try the preferred lang first; fall back to defaultLang if the
+  // preferred one is no longer in languages.json (e.g. word.json's lang
+  // points at a now-disabled locale, or the operator removed a lang
+  // after a previous manual write). Without this fallback,
+  // auto-rotate silently disables for that operator's deployment
+  // until they manually fix word.json — even though defaultLang has
+  // a perfectly good active commit. We only fall back when the
+  // initial lang differs from defaultLang and defaultLang is set;
+  // otherwise the original error path applies.
+  let lang = initialLang;
+  let langInfo = readActiveCommitForLang(languagesPath, lang);
+  if ((!langInfo || !langInfo.commit) && defaultLang && defaultLang !== initialLang) {
+    const fallbackInfo = readActiveCommitForLang(languagesPath, defaultLang);
+    if (fallbackInfo && fallbackInfo.commit) {
+      logger?.warn?.(
+        `[scheduler] auto-rotate falling back from disabled lang=${initialLang} to defaultLang=${defaultLang} for ${todayLocal}.`
+      );
+      lang = defaultLang;
+      langInfo = fallbackInfo;
+    }
+  }
   if (!langInfo || !langInfo.commit) {
     logger?.warn?.(
       `[scheduler] auto-rotate skipped for ${todayLocal}: no active commit for lang=${lang}.`

--- a/lib/vapid-store.js
+++ b/lib/vapid-store.js
@@ -60,7 +60,7 @@ function writeJsonAtomicSync(filePath, payload) {
 
 function normalizeKeys(raw) {
   if (!isObject(raw)) {
-    throw new VapidStoreError("INVALID_KEYS", "pushKeys must be an object.");
+    throw new VapidStoreError("INVALID_KEYS", "vapid-keys.keys must be an object.");
   }
   if (typeof raw.publicKey !== "string" || raw.publicKey.length < 80 || raw.publicKey.length > 200) {
     throw new VapidStoreError(

--- a/lib/webhook-service.js
+++ b/lib/webhook-service.js
@@ -211,11 +211,19 @@ function parseRetryAfterHeader(value, now) {
 }
 
 function classifyHttpStatus(status) {
-  // 2xx success; 4xx (excluding 408/429) non-retriable; rest retriable.
+  // 2xx success.
+  // 3xx terminal: deliveries use redirect: "manual", so a 3xx means the
+  // recipient is asking us to redirect but we won't follow. Retrying
+  // would burn the attempt budget against an endpoint that's signaling
+  // misconfiguration, so mark non-retriable and let the operator update
+  // the URL or handle the redirect on their side.
+  // 4xx (excluding 408/429) non-retriable.
+  // 5xx + everything else retriable.
   if (status >= 200 && status < 300) return { ok: true, retriable: false };
+  if (status >= 300 && status < 400) return { ok: false, retriable: false };
   if (status === 408 || status === 429) return { ok: false, retriable: true };
   if (status >= 400 && status < 500) return { ok: false, retriable: false };
-  return { ok: false, retriable: true }; // 5xx + everything else
+  return { ok: false, retriable: true };
 }
 
 async function readResponseSnippet(response, maxBytes) {
@@ -417,9 +425,17 @@ class WebhookService {
       this.logger.warn?.(`[webhook] delivery ${deliveryId} not found at execute time.`);
       return;
     }
-    if (delivery.status !== "queued" && delivery.status !== "running") {
-      // Already handled by another path (manual retry / cancellation /
-      // duplicate timer).
+    if (delivery.status !== "queued") {
+      // Only "queued" rows are eligible to start a fresh attempt. Skipping
+      // "running" here closes a duplicate-timer race: if the same
+      // deliveryId is scheduled twice (e.g. two enqueueReady() passes
+      // overlap, or recovery races a freshly-armed timer), the second
+      // call would otherwise launch a concurrent send and double-
+      // increment `attempts`. recoverOnBoot() already requeues stuck
+      // "running" rows by transitioning status back to "queued" before
+      // re-arming the timer, so refusing to start mid-flight loses no
+      // functionality. Other terminal/canceled statuses also short-
+      // circuit here as before.
       return;
     }
     // Always look up the subscription fresh from the store. Caching

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -2394,6 +2394,32 @@ lockSessionBtnEl.addEventListener("click", () => {
   if (typeof webhookDeliveriesSubscriptionEl !== "undefined" && webhookDeliveriesSubscriptionEl) {
     webhookDeliveriesSubscriptionEl.innerHTML = "";
   }
+  // Scrub the challenge-admin tab's state + DOM the same way other
+  // tabs do. Without this, locking on the Challenges tab and unlocking
+  // again would briefly render the previous (now-stale) challenge
+  // table and leaderboard contents until the next loadChallengesAdmin()
+  // fetch completes — same shared-machine PII concern as the classes
+  // tab.
+  state.challengesAdmin = [];
+  state.challengesAdminLoading = false;
+  if (typeof challengesAdminTbodyEl !== "undefined" && challengesAdminTbodyEl) {
+    challengesAdminTbodyEl.innerHTML = "";
+  }
+  if (typeof challengesAdminLbTbodyEl !== "undefined" && challengesAdminLbTbodyEl) {
+    challengesAdminLbTbodyEl.innerHTML = "";
+  }
+  if (typeof challengeAdminLeaderboardNameEl !== "undefined" && challengeAdminLeaderboardNameEl) {
+    challengeAdminLeaderboardNameEl.textContent = "";
+  }
+  if (typeof challengeAdminLeaderboardSectionEl !== "undefined" && challengeAdminLeaderboardSectionEl) {
+    challengeAdminLeaderboardSectionEl.hidden = true;
+  }
+  if (typeof challengeAdminFormEl !== "undefined" && challengeAdminFormEl) {
+    challengeAdminFormEl.reset();
+  }
+  if (typeof challengesAdminStatusEl !== "undefined" && challengesAdminStatusEl) {
+    setStatus(challengesAdminStatusEl, "", "");
+  }
   destroyAllAnalyticsCharts();
   if (analyticsCardsEl) {
     analyticsCardsEl.querySelectorAll('[data-metric]').forEach((el) => {
@@ -3102,15 +3128,34 @@ function renderScheduleStrip(snapshot) {
   } catch (_err) {
     // best-effort; bad zone surfaces in the existing form
   }
-  const todayEntry = (snapshot.scheduled_words || []).find(
+  // The reconciler (scheduler-tick.scheduledEntryFor) picks today's
+  // entry by language: prefer the row matching word.json.lang else
+  // fall back to the first today-row by lang asc. Reproduce that
+  // selection in the strip so the operator's "Today" line matches
+  // what /daily will actually serve. With a single language this
+  // collapses to "first match by date" which is what the previous
+  // code did; with multiple langs the strip used to lie by always
+  // showing the first row regardless of which lang word.json names.
+  const todayRows = (snapshot.scheduled_words || []).filter(
     (row) => row.date === todayLocal
   );
-  setStripField(
-    "todayResolved",
-    todayEntry
-      ? `${todayLocal} → ${todayEntry.word} (${todayEntry.lang})`
-      : `${todayLocal} (no entry)`
-  );
+  let todayEntry = null;
+  if (todayRows.length > 0) {
+    const preferredLang = snapshot.current_word_lang || null;
+    todayEntry =
+      (preferredLang && todayRows.find((row) => row.lang === preferredLang))
+      || todayRows[0];
+  }
+  let todayValue;
+  if (todayEntry) {
+    const extra = todayRows.length > 1
+      ? ` · ${todayRows.length - 1} other lang${todayRows.length === 2 ? "" : "s"} scheduled`
+      : "";
+    todayValue = `${todayLocal} → ${todayEntry.word} (${todayEntry.lang})${extra}`;
+  } else {
+    todayValue = `${todayLocal} (no entry)`;
+  }
+  setStripField("todayResolved", todayValue);
   setStripField(
     "lastReconciledAt",
     snapshot.last_reconciled_at

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -2402,6 +2402,12 @@ lockSessionBtnEl.addEventListener("click", () => {
   // tab.
   state.challengesAdmin = [];
   state.challengesAdminLoading = false;
+  // Bump the request-id so any in-flight loadChallengesAdmin() /
+  // loadChallengeAdminLeaderboard() promise is invalidated. Without
+  // this, a fetch started before lock could resolve afterward and
+  // repopulate state.challengesAdmin / the table bodies after we've
+  // just scrubbed them — surfacing as stale data on the next unlock.
+  state.challengesAdminRequestId = (state.challengesAdminRequestId || 0) + 1;
   if (typeof challengesAdminTbodyEl !== "undefined" && challengesAdminTbodyEl) {
     challengesAdminTbodyEl.innerHTML = "";
   }
@@ -3136,9 +3142,17 @@ function renderScheduleStrip(snapshot) {
   // collapses to "first match by date" which is what the previous
   // code did; with multiple langs the strip used to lie by always
   // showing the first row regardless of which lang word.json names.
-  const todayRows = (snapshot.scheduled_words || []).filter(
-    (row) => row.date === todayLocal
-  );
+  // Sort today's rows by lang BEFORE choosing the fallback. The
+  // reconciler's scheduledEntryFor falls back by language order
+  // (because the schedule is stored sorted by lang asc) — relying on
+  // the array's natural order would let the strip disagree with the
+  // backend if the schedule payload ever changed shape (e.g. a
+  // future store version emits unsorted entries). Sorting here makes
+  // the disambiguation deterministic against the same lang ordering.
+  const todayRows = (snapshot.scheduled_words || [])
+    .filter((row) => row.date === todayLocal)
+    .slice()
+    .sort((a, b) => (a.lang < b.lang ? -1 : a.lang > b.lang ? 1 : 0));
   let todayEntry = null;
   if (todayRows.length > 0) {
     const preferredLang = snapshot.current_word_lang || null;
@@ -3894,6 +3908,13 @@ const challengeAdminLbCloseBtnEl = document.getElementById("challengeAdminLbClos
 if (typeof state !== "undefined") {
   state.challengesAdminLoading = false;
   state.challengesAdmin = [];
+  // Monotonic request id for both Challenges admin loaders. Mirrors
+  // the analytics/webhooks/schedule pattern so a fetch started before
+  // a session lock can't repopulate the (now hidden) Challenges DOM
+  // when its response arrives after the lock. Bumped on lock, so
+  // any in-flight request whose captured id no longer matches is
+  // discarded at response time without rendering.
+  state.challengesAdminRequestId = 0;
 }
 
 function setChallengeAdminStatus(text, tone = "") {
@@ -3905,17 +3926,23 @@ function setChallengeAdminStatus(text, tone = "") {
 
 async function loadChallengesAdmin() {
   if (!state?.unlocked) return;
+  state.challengesAdminRequestId += 1;
+  const requestId = state.challengesAdminRequestId;
   state.challengesAdminLoading = true;
   setChallengeAdminStatus("Loading…");
   try {
     const payload = await requestAdminJson("/api/admin/challenges");
+    if (requestId !== state.challengesAdminRequestId) return;
     state.challengesAdmin = Array.isArray(payload.challenges) ? payload.challenges : [];
     renderChallengesAdmin();
     setChallengeAdminStatus("Loaded.", "admin-status-ok");
   } catch (err) {
+    if (requestId !== state.challengesAdminRequestId) return;
     setChallengeAdminStatus(`Load failed: ${err.message}`, "admin-status-missing");
   } finally {
-    state.challengesAdminLoading = false;
+    if (requestId === state.challengesAdminRequestId) {
+      state.challengesAdminLoading = false;
+    }
   }
 }
 
@@ -4066,11 +4093,19 @@ async function deleteChallenge(id, name) {
 
 async function loadChallengeAdminLeaderboard(id, name) {
   if (!state?.unlocked || !challengeAdminLeaderboardSectionEl || !challengesAdminLbTbodyEl) return;
+  // Same request-id guard as loadChallengesAdmin: a leaderboard
+  // fetch started before lock could otherwise resolve afterward and
+  // repopulate the panel with stale data that survives until the
+  // next legit unlock. Capture the id at start and discard responses
+  // that don't match.
+  state.challengesAdminRequestId += 1;
+  const requestId = state.challengesAdminRequestId;
   challengeAdminLeaderboardSectionEl.hidden = false;
   if (challengeAdminLeaderboardNameEl) challengeAdminLeaderboardNameEl.textContent = name;
   challengesAdminLbTbodyEl.innerHTML = "";
   try {
     const payload = await requestAdminJson(`/api/admin/challenges/${encodeURIComponent(id)}/leaderboard`);
+    if (requestId !== state.challengesAdminRequestId) return;
     const rows = Array.isArray(payload.rows) ? payload.rows : [];
     if (rows.length === 0) {
       const tr = document.createElement("tr");
@@ -4094,6 +4129,7 @@ async function loadChallengeAdminLeaderboard(id, name) {
       rank += 1;
     }
   } catch (err) {
+    if (requestId !== state.challengesAdminRequestId) return;
     setChallengeAdminStatus(`Leaderboard load failed: ${err.message}`, "admin-status-missing");
   }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -2193,7 +2193,11 @@ function renderChallengeKeyboard() {
   const rows = ['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM'];
   for (let r = 0; r < rows.length; r++) {
     const rowEl = document.createElement('div');
-    rowEl.className = 'kb-row';
+    // Match the daily/created keyboard's class names (.key-row / .key /
+    // .key.wide). The earlier kb-row/kb-key naming had no styles in
+    // public/styles.css, so the challenge keyboard rendered as
+    // unstyled buttons stacked vertically.
+    rowEl.className = 'key-row';
     if (r === rows.length - 1) {
       rowEl.appendChild(makeKbKey('Enter', 'Enter', 'wide'));
     }
@@ -2208,8 +2212,18 @@ function renderChallengeKeyboard() {
 function makeKbKey(label, key, extraClass) {
   const btn = document.createElement('button');
   btn.type = 'button';
-  btn.className = 'kb-key' + (extraClass ? ` ${extraClass}` : '');
+  btn.className = 'key' + (extraClass ? ` ${extraClass}` : '');
   btn.textContent = label;
+  // Special keys render glyphs/labels that don't read well to screen
+  // readers — "⌫" is a private-use character with no semantic name in
+  // most assistive-tech voices, and "Enter" without context can be
+  // ambiguous. Provide an explicit accessible name for the special
+  // keys; alphabet keys already announce their letter via textContent.
+  if (key === 'Backspace') {
+    btn.setAttribute('aria-label', 'Backspace');
+  } else if (key === 'Enter') {
+    btn.setAttribute('aria-label', 'Submit guess');
+  }
   btn.addEventListener('click', () => onChallengeKey(key));
   return btn;
 }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -454,12 +454,19 @@ function createAdminRouter(deps) {
       // disambiguate today's entry the same way scheduledEntryFor does
       // server-side. Without this, a multi-language schedule would show
       // the alphabetically-first row and lie about what /daily actually
-      // serves. Treat missing as null so older clients still render.
+      // serves. Treat missing/disabled as null so older clients still
+      // render and so a stale lang (e.g. provider language was turned
+      // off after word.json was written) doesn't point the UI at an
+      // entry the runtime won't actually serve.
       let currentWordLang = null;
       if (typeof getCurrentWordData === "function") {
         const wd = getCurrentWordData();
         if (wd && typeof wd.lang === "string" && wd.lang) {
-          currentWordLang = wd.lang;
+          // resolveLang returns null when the lang isn't in the active
+          // catalog — same fallback /daily applies before serving.
+          currentWordLang = (typeof resolveLang === "function")
+            ? resolveLang(wd.lang)
+            : wd.lang;
         }
       }
       return res.json({ ...snapshot, current_word_lang: currentWordLang });

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -124,8 +124,10 @@ function createAdminRouter(deps) {
     parseBulkNames,
     UTF8_BOM,
     normalizeLang,
+    resolveLang,
     getLocalDateString,
     aggregateAnalytics,
+    getCurrentWordData,
     analyticsCacheTtlMs,
     analyticsTimezone,
     scheduleStore,
@@ -448,7 +450,19 @@ function createAdminRouter(deps) {
   router.get("/api/admin/schedule", async (req, res) => {
     try {
       const snapshot = await scheduleStore.getSnapshot();
-      return res.json(snapshot);
+      // Decorate with the current word.json's lang so the admin UI can
+      // disambiguate today's entry the same way scheduledEntryFor does
+      // server-side. Without this, a multi-language schedule would show
+      // the alphabetically-first row and lie about what /daily actually
+      // serves. Treat missing as null so older clients still render.
+      let currentWordLang = null;
+      if (typeof getCurrentWordData === "function") {
+        const wd = getCurrentWordData();
+        if (wd && typeof wd.lang === "string" && wd.lang) {
+          currentWordLang = wd.lang;
+        }
+      }
+      return res.json({ ...snapshot, current_word_lang: currentWordLang });
     } catch (err) {
       if (err instanceof ScheduleStoreError) {
         return res.status(scheduleErrorStatus(err)).json(scheduleErrorBody(err));
@@ -477,6 +491,22 @@ function createAdminRouter(deps) {
 
   router.post("/api/admin/schedule/entries", async (req, res) => {
     const overwriteFlag = String(req.query.overwrite || "").toLowerCase() === "true";
+    // The schedule store only enforces LANG_PATTERN syntax; it doesn't
+    // know which langs are actually loaded into the runtime catalog.
+    // Without this guard, an admin could schedule "zz" or a disabled
+    // locale and the reconciler would write that lang to word.json,
+    // making /daily silently fall back to DEFAULT_LANG and serve the
+    // wrong dictionary. Reject before claiming the data-mutation slot
+    // so we don't waste lock time on a 400.
+    const requestedLang = req.body && req.body.lang;
+    if (requestedLang !== undefined && requestedLang !== null) {
+      if (typeof resolveLang !== "function" || !resolveLang(requestedLang)) {
+        return res.status(400).json({
+          error: `Unknown or disabled language: ${String(requestedLang)}.`,
+          code: "UNKNOWN_LANG"
+        });
+      }
+    }
     try {
       const result = await withSlot(async () => {
         return scheduleStore.addEntry(req.body || {}, { overwrite: overwriteFlag });
@@ -506,6 +536,16 @@ function createAdminRouter(deps) {
   });
 
   router.put("/api/admin/schedule/entries/:date/:lang", async (req, res) => {
+    // Same lang-allowlist guard as POST /entries: the path lang is the
+    // entry being edited, so it must resolve. We don't accept a body
+    // override that swaps to a different lang here (the store treats
+    // (date,lang) as the primary key), so we only validate the path.
+    if (typeof resolveLang !== "function" || !resolveLang(req.params.lang)) {
+      return res.status(400).json({
+        error: `Unknown or disabled language: ${String(req.params.lang)}.`,
+        code: "UNKNOWN_LANG"
+      });
+    }
     try {
       const result = await withSlot(async () => {
         return scheduleStore.updateEntry(req.params.date, req.params.lang, req.body || {});
@@ -1115,6 +1155,23 @@ function createAdminRouter(deps) {
           : err.code === "CHALLENGE_NOT_FOUND" || err.code === "SESSION_NOT_FOUND" ? 404
           : err.code === "CONFIG_LOCKED" || err.code === "DUPLICATE_ID" ? 409
           : 503;
+        // Mask STORE_* error messages: their templates include the
+        // absolute file path on disk (e.g. "Failed to read challenge
+        // config store from /var/lib/wordle/data/challenges.json: ...")
+        // which leaks deployment-internal layout to admin clients.
+        // Authoring-curated codes (INVALID_REQUEST, CHALLENGE_NOT_FOUND,
+        // CONFIG_LOCKED, DUPLICATE_ID, SESSION_NOT_FOUND) describe the
+        // request, not server filesystem state, so they pass through.
+        const isStoreError = err.code === "STORE_READ_FAILED"
+          || err.code === "STORE_WRITE_FAILED"
+          || err.code === "STORE_PARSE_FAILED";
+        if (isStoreError) {
+          console.error(`[challenge:admin] ${context} ${err.code}:`, err);
+          return res.status(status).json({
+            error: "Challenge admin store unavailable. Try again later.",
+            code: err.code
+          });
+        }
         return res.status(status).json({ error: err.message, code: err.code });
       }
       console.error(`[challenge:admin] ${context} failed:`, err);
@@ -1189,9 +1246,19 @@ function createAdminRouter(deps) {
       try {
         const body = req.body || {};
         enforceEnvCaps(body);
-        const sessions = await challengeResultsStore.getSnapshot();
-        const hasResults = sessions.sessions.some((s) => s.challengeId === req.params.id);
+        // Move the hasResults check INSIDE the slot. Reading sessions
+        // outside the slot lets a /api/challenges/:id/start invocation
+        // race in between this read and the config update — it could
+        // create the first session for the challenge during that
+        // window. The update() then sees hasResults=false (the snapshot
+        // value) and performs an immutable-fields edit that the store
+        // contract forbids once any session exists. Locking the
+        // observation under the same slot the mutation uses closes
+        // that TOCTOU (createSession also runs under withSlot, so they
+        // serialize against each other through the slot).
         const updated = await withSlot(async () => {
+          const sessions = await challengeResultsStore.getSnapshot();
+          const hasResults = sessions.sessions.some((s) => s.challengeId === req.params.id);
           return challengeConfigStore.update(req.params.id, body, { hasResults });
         });
         webhookAudit("challenge.update", {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -147,6 +147,7 @@ function createAdminRouter(deps) {
     challengeConfigStore,
     challengeResultsStore,
     challengeEngine,
+    withChallengeAdminUserMutex,
     ChallengeConfigStoreError,
     ChallengeResultsStoreError,
     challengeModeEnabled,
@@ -1253,21 +1254,21 @@ function createAdminRouter(deps) {
       try {
         const body = req.body || {};
         enforceEnvCaps(body);
-        // Move the hasResults check INSIDE the slot. Reading sessions
-        // outside the slot lets a /api/challenges/:id/start invocation
-        // race in between this read and the config update — it could
-        // create the first session for the challenge during that
-        // window. The update() then sees hasResults=false (the snapshot
-        // value) and performs an immutable-fields edit that the store
-        // contract forbids once any session exists. Locking the
-        // observation under the same slot the mutation uses closes
-        // that TOCTOU (createSession also runs under withSlot, so they
-        // serialize against each other through the slot).
-        const updated = await withSlot(async () => {
+        // The hasResults observation and the config update must be
+        // serialized against /api/challenges/:id/start so an
+        // immutable-fields edit can't slip through while the first
+        // session is being created. The backup/restore slot is a
+        // counter (multiple writers OK), so it doesn't serialize
+        // here on its own — withChallengeAdminUserMutex is a
+        // dedicated promise-chain mutex shared with the user-side
+        // start route. We still claim the backup/restore slot too
+        // because the underlying writes go to data/, and that's the
+        // slot's job (busy-check during backup).
+        const updated = await withChallengeAdminUserMutex(() => withSlot(async () => {
           const sessions = await challengeResultsStore.getSnapshot();
           const hasResults = sessions.sessions.some((s) => s.challengeId === req.params.id);
           return challengeConfigStore.update(req.params.id, body, { hasResults });
-        });
+        }));
         webhookAudit("challenge.update", {
           actor: actorFingerprint(req),
           id: updated.id

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -224,6 +224,7 @@ function createBackupRouter(deps) {
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     providerImportEnqueueActiveRef,
+    webhookEmitInFlightRef,
     dataMutationLockRef,
     restoreInProgressRef,
     directDataWriteActiveRef,
@@ -314,6 +315,7 @@ function createBackupRouter(deps) {
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
       || providerImportEnqueueActiveRef?.value
+      || (webhookEmitInFlightRef && webhookEmitInFlightRef.count > 0)
       || dataMutationLockRef?.value
       || restoreInProgressRef?.value
       || (directDataWriteActiveRef && directDataWriteActiveRef.value > 0)
@@ -509,6 +511,7 @@ function createBackupRouter(deps) {
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
       || providerImportEnqueueActiveRef?.value
+      || (webhookEmitInFlightRef && webhookEmitInFlightRef.count > 0)
       || dataMutationLockRef?.value
       || restoreInProgressRef?.value
       || (directDataWriteActiveRef && directDataWriteActiveRef.value > 0)
@@ -577,6 +580,7 @@ function createBackupRouter(deps) {
       providerImportQueueActiveRef?.value
       || providerImportSyncActiveRef?.value
       || providerImportEnqueueActiveRef?.value
+      || (webhookEmitInFlightRef && webhookEmitInFlightRef.count > 0)
     ) {
       restoreInProgressRef.value = false;
       try {

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -18,6 +18,7 @@ function createChallengesRouter(deps) {
   const {
     challengeConfigStore,
     challengeResultsStore,
+    withChallengeAdminUserMutex,
     ChallengeConfigStoreError,
     ChallengeResultsStoreError,
     getDictionary,
@@ -177,60 +178,87 @@ function createChallengesRouter(deps) {
           code: "LANG_UNAVAILABLE"
         });
       }
-      // Resume an in-flight session if one exists for this (challenge,
-      // profile). Settle on timeout first so the resume path doesn't
-      // hand back a stale "in-progress" snapshot for a session whose
-      // budget already expired.
-      let session = await challengeResultsStore.findInFlight(challenge.id, profile.profileId);
-      if (session) {
-        session = await settleIfTimedOut(session, challenge, now);
-        if (session.status === "in-progress" || session.status === "pending") {
-          const projected = projectForResponse(session, challenge, now);
-          return res.status(200).json({ ok: true, session: projected, resumed: true });
+      // The find-or-create critical section runs under the cross-route
+      // mutex shared with PUT /api/admin/challenges/:id. Without that
+      // mutex, an admin edit can read hasResults=false (no sessions
+      // yet), then we create the first session here, then the admin's
+      // update commits with hasResults=false and lets through an
+      // immutable-fields edit that the store's contract forbids once
+      // any session exists. Wrapping createSession (and the in-flight
+      // / replay-policy checks that gate it) in the same mutex closes
+      // that TOCTOU. Returns either a resume payload or a created one;
+      // the wrapper unwraps the discriminated result for us.
+      const result = await withChallengeAdminUserMutex(async () => {
+        // Resume an in-flight session if one exists for this
+        // (challenge, profile). Settle on timeout first so the resume
+        // path doesn't hand back a stale "in-progress" snapshot for a
+        // session whose budget already expired.
+        let session = await challengeResultsStore.findInFlight(challenge.id, profile.profileId);
+        if (session) {
+          session = await settleIfTimedOut(session, challenge, now);
+          if (session.status === "in-progress" || session.status === "pending") {
+            return { kind: "resumed", session };
+          }
+          // Otherwise fall through and create a new session per replay policy.
         }
-        // Otherwise fall through and create a new session per replay policy.
-      }
-      // Replay-policy gate.
-      const past = (await challengeResultsStore.findCompletedForChallenge(challenge.id))
-        .filter((s) => s.profileId === profile.profileId);
-      const replayCheck = challengeEngine.checkReplayAllowed({
-        challenge, pastSessions: past, profileId: profile.profileId
+        // Replay-policy gate.
+        const past = (await challengeResultsStore.findCompletedForChallenge(challenge.id))
+          .filter((s) => s.profileId === profile.profileId);
+        const replayCheck = challengeEngine.checkReplayAllowed({
+          challenge, pastSessions: past, profileId: profile.profileId
+        });
+        if (replayCheck) {
+          return { kind: "replay-blocked", code: replayCheck };
+        }
+        // Build server-side puzzles and persist.
+        let puzzles;
+        try {
+          puzzles = buildPuzzlesForChallenge(challenge);
+        } catch (err) {
+          if (err.code === "LANG_UNAVAILABLE") {
+            return { kind: "lang-unavailable", message: err.message };
+          }
+          throw err;
+        }
+        // createSession returns `{ session, resumed }` because it
+        // re-checks the in-flight invariant atomically inside its
+        // commit. A racing concurrent /start for the same (challengeId,
+        // profileId) gets the existing in-flight session back as a
+        // resume rather than creating a duplicate — matches what
+        // findInFlight above would have caught if the timing had been
+        // serial. The outer mutex serializes against admin's update,
+        // not against itself: createSession's own #commit lock handles
+        // user-vs-user concurrency.
+        return {
+          kind: "created",
+          ...await challengeResultsStore.createSession({
+            challengeId: challenge.id,
+            profileId: profile.profileId,
+            profileName: profile.profileName,
+            startedAt: now.toISOString(),
+            puzzles
+          })
+        };
       });
-      if (replayCheck) {
+      if (result.kind === "resumed") {
+        const projected = projectForResponse(result.session, challenge, now);
+        return res.status(200).json({ ok: true, session: projected, resumed: true });
+      }
+      if (result.kind === "replay-blocked") {
         return res.status(409).json({
           error: "Replay not allowed for this challenge under its replay policy.",
-          code: replayCheck
+          code: result.code
         });
       }
-      // Build server-side puzzles and persist.
-      let puzzles;
-      try {
-        puzzles = buildPuzzlesForChallenge(challenge);
-      } catch (err) {
-        if (err.code === "LANG_UNAVAILABLE") {
-          return res.status(503).json({ error: err.message, code: "LANG_UNAVAILABLE" });
-        }
-        throw err;
+      if (result.kind === "lang-unavailable") {
+        return res.status(503).json({ error: result.message, code: "LANG_UNAVAILABLE" });
       }
-      // createSession returns `{ session, resumed }` because it
-      // re-checks the in-flight invariant atomically inside its
-      // commit. A racing concurrent /start for the same (challengeId,
-      // profileId) gets the existing in-flight session back as a
-      // resume rather than creating a duplicate — matches what
-      // findInFlight above would have caught if the timing had been
-      // serial.
-      const { session: created, resumed: createdResumed } = await challengeResultsStore.createSession({
-        challengeId: challenge.id,
-        profileId: profile.profileId,
-        profileName: profile.profileName,
-        startedAt: now.toISOString(),
-        puzzles
-      });
-      const projected = projectForResponse(created, challenge, now);
-      return res.status(createdResumed ? 200 : 201).json({
+      // result.kind === "created" — has session + resumed flag.
+      const projected = projectForResponse(result.session, challenge, now);
+      return res.status(result.resumed ? 200 : 201).json({
         ok: true,
         session: projected,
-        resumed: createdResumed
+        resumed: result.resumed
       });
     } catch (err) {
       return challengeError(res, err, "start");

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -54,7 +54,7 @@ function createChallengesRouter(deps) {
     if (err instanceof ChallengeConfigStoreError || err instanceof ChallengeResultsStoreError) {
       const status = err.code === "INVALID_REQUEST" ? 400
         : err.code === "CHALLENGE_NOT_FOUND" || err.code === "SESSION_NOT_FOUND" ? 404
-        : err.code === "CONFIG_LOCKED" || err.code === "DUPLICATE_ID" ? 409
+        : err.code === "CONFIG_LOCKED" || err.code === "DUPLICATE_ID" || err.code === "SESSION_COMPLETE" ? 409
         : 503;
       return res.status(status).json({ error: err.message, code: err.code });
     }
@@ -211,7 +211,14 @@ function createChallengesRouter(deps) {
         }
         throw err;
       }
-      const created = await challengeResultsStore.createSession({
+      // createSession returns `{ session, resumed }` because it
+      // re-checks the in-flight invariant atomically inside its
+      // commit. A racing concurrent /start for the same (challengeId,
+      // profileId) gets the existing in-flight session back as a
+      // resume rather than creating a duplicate — matches what
+      // findInFlight above would have caught if the timing had been
+      // serial.
+      const { session: created, resumed: createdResumed } = await challengeResultsStore.createSession({
         challengeId: challenge.id,
         profileId: profile.profileId,
         profileName: profile.profileName,
@@ -219,7 +226,11 @@ function createChallengesRouter(deps) {
         puzzles
       });
       const projected = projectForResponse(created, challenge, now);
-      return res.status(201).json({ ok: true, session: projected, resumed: false });
+      return res.status(createdResumed ? 200 : 201).json({
+        ok: true,
+        session: projected,
+        resumed: createdResumed
+      });
     } catch (err) {
       return challengeError(res, err, "start");
     }
@@ -306,45 +317,60 @@ function createChallengesRouter(deps) {
         });
       }
       const feedback = evaluateGuess(rawGuess, active.word);
-      const updatedPuzzles = session.puzzles.map((p) => {
-        if (p.index !== active.index) return p;
-        const guesses = (p.guesses || []).concat(rawGuess);
-        const solved = rawGuess === p.word;
-        return {
-          ...p,
-          guesses,
-          solved
-        };
-      });
-      let nextStatus = session.status;
-      // Auto-complete if every puzzle is solved or exhausted (last
-      // guess was either the answer or the maxGuesses-th attempt).
-      const allDone = updatedPuzzles.every(
-        (p) => p.solved || (p.guesses?.length || 0) >= challenge.maxGuesses
-      );
-      let scoreFinal;
-      let elapsedFinal;
-      if (allDone) {
-        const now = new Date();
-        elapsedFinal = Math.max(
-          0,
-          Math.floor((now.getTime() - Date.parse(session.startedAt)) / 1000)
+      // Mutate atomically inside the store's commit lock. The earlier
+      // version computed updatedPuzzles outside the commit and then
+      // sent the whole array as a patch — two concurrent /guess
+      // requests would both compute from the same stale snapshot and
+      // the second commit's puzzles array would overwrite the first
+      // guess. Reading the latest session inside the mutator (via
+      // transactionalUpdate) closes that race.
+      const updated = await challengeResultsStore.transactionalUpdate(session.id, (latest) => {
+        // Re-derive the active puzzle from the LATEST persisted state.
+        // This handles the case where another /guess has already
+        // landed: we'll see its updated puzzle, find the new active
+        // puzzle (or none), and append our guess to that one. The
+        // length check above used `active.word.length`, which is
+        // immutable for a given puzzle index, so the request body's
+        // length validation still holds for the latest active puzzle.
+        const latestActive = latest.puzzles.find(
+          (p) => !p.solved && (p.guesses?.length || 0) < challenge.maxGuesses
         );
-        elapsedFinal = Math.min(elapsedFinal, challenge.timeBudgetSeconds);
-        scoreFinal = challengeEngine.computeScore({
-          challenge,
-          puzzles: updatedPuzzles,
-          elapsedSeconds: elapsedFinal
+        if (!latestActive) {
+          throw new ChallengeResultsStoreError(
+            "SESSION_COMPLETE",
+            "All puzzles in this session are complete."
+          );
+        }
+        const updatedPuzzles = latest.puzzles.map((p) => {
+          if (p.index !== latestActive.index) return p;
+          const guesses = (p.guesses || []).concat(rawGuess);
+          const solved = rawGuess === p.word;
+          return { ...p, guesses, solved };
         });
-        nextStatus = "completed";
-      }
-      const patch = { puzzles: updatedPuzzles, status: nextStatus };
-      if (allDone) {
-        patch.finishedAt = new Date().toISOString();
-        patch.elapsedSeconds = elapsedFinal;
-        patch.score = scoreFinal;
-      }
-      const updated = await challengeResultsStore.update(session.id, patch);
+        const merged = { ...latest, puzzles: updatedPuzzles };
+        const allDone = updatedPuzzles.every(
+          (p) => p.solved || (p.guesses?.length || 0) >= challenge.maxGuesses
+        );
+        if (allDone) {
+          const now = new Date();
+          let elapsedFinal = Math.max(
+            0,
+            Math.floor((now.getTime() - Date.parse(latest.startedAt)) / 1000)
+          );
+          elapsedFinal = Math.min(elapsedFinal, challenge.timeBudgetSeconds);
+          merged.finishedAt = now.toISOString();
+          merged.elapsedSeconds = elapsedFinal;
+          merged.score = challengeEngine.computeScore({
+            challenge,
+            puzzles: updatedPuzzles,
+            elapsedSeconds: elapsedFinal
+          });
+          merged.status = "completed";
+        } else {
+          merged.status = latest.status;
+        }
+        return merged;
+      });
       const projected = projectForResponse(updated, challenge);
       // Submit score to the leaderboard projection on completion.
       // Surface the per-guess feedback row that the client renders.

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -54,7 +54,8 @@ function createChallengesRouter(deps) {
     if (err instanceof ChallengeConfigStoreError || err instanceof ChallengeResultsStoreError) {
       const status = err.code === "INVALID_REQUEST" ? 400
         : err.code === "CHALLENGE_NOT_FOUND" || err.code === "SESSION_NOT_FOUND" ? 404
-        : err.code === "CONFIG_LOCKED" || err.code === "DUPLICATE_ID" || err.code === "SESSION_COMPLETE" ? 409
+        : err.code === "CONFIG_LOCKED" || err.code === "DUPLICATE_ID"
+          || err.code === "SESSION_COMPLETE" || err.code === "SESSION_NOT_ACTIVE" ? 409
         : 503;
       return res.status(status).json({ error: err.message, code: err.code });
     }
@@ -316,7 +317,6 @@ function createChallengesRouter(deps) {
           code: "INVALID_GUESS"
         });
       }
-      const feedback = evaluateGuess(rawGuess, active.word);
       // Mutate atomically inside the store's commit lock. The earlier
       // version computed updatedPuzzles outside the commit and then
       // sent the whole array as a patch — two concurrent /guess
@@ -324,7 +324,29 @@ function createChallengesRouter(deps) {
       // the second commit's puzzles array would overwrite the first
       // guess. Reading the latest session inside the mutator (via
       // transactionalUpdate) closes that race.
+      //
+      // Compute feedback INSIDE the mutator too. The pre-transaction
+      // `active` puzzle and its `active.word` could be stale by the
+      // time the lock is acquired (a concurrent /guess for the same
+      // session may have solved or exhausted it), and `latestActive`
+      // can refer to a different puzzle entirely. Returning feedback
+      // computed from `active.word` would then color the wrong row in
+      // the client. Capture both feedback and the post-mutation status
+      // via outer-scope locals so the response reflects what was
+      // actually applied.
+      let appliedFeedback = null;
       const updated = await challengeResultsStore.transactionalUpdate(session.id, (latest) => {
+        // Latest-status TOCTOU: a concurrent /finish or settle-on-
+        // timeout could have transitioned this session to terminal
+        // since the route's pre-transaction read. Re-check inside the
+        // commit so we never apply a guess to a completed/timed-out/
+        // abandoned session.
+        if (latest.status !== "in-progress" && latest.status !== "pending") {
+          throw new ChallengeResultsStoreError(
+            "SESSION_NOT_ACTIVE",
+            `Session is ${latest.status}; no further guesses accepted.`
+          );
+        }
         // Re-derive the active puzzle from the LATEST persisted state.
         // This handles the case where another /guess has already
         // landed: we'll see its updated puzzle, find the new active
@@ -341,6 +363,12 @@ function createChallengesRouter(deps) {
             "All puzzles in this session are complete."
           );
         }
+        // Feedback is now derived from the puzzle that actually
+        // receives the guess. With concurrent /guess invocations,
+        // latestActive can be a different puzzle than the
+        // pre-transaction `active`; computing here ensures the
+        // returned colors match the persisted update.
+        appliedFeedback = evaluateGuess(rawGuess, latestActive.word);
         const updatedPuzzles = latest.puzzles.map((p) => {
           if (p.index !== latestActive.index) return p;
           const guesses = (p.guesses || []).concat(rawGuess);
@@ -377,7 +405,7 @@ function createChallengesRouter(deps) {
       return res.json({
         ok: true,
         session: projected,
-        feedback
+        feedback: appliedFeedback
       });
     } catch (err) {
       return challengeError(res, err, "guess");

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -160,23 +160,18 @@ function createChallengesRouter(deps) {
       return res.status(400).json({ error: "profileId is required.", code: "INVALID_REQUEST" });
     }
     try {
-      const challenge = await challengeConfigStore.findById(req.params.id);
-      if (!challenge || challenge.deleted) {
-        return res.status(404).json({ error: translateForRequest(req, "serverError.challengeNotFound"), code: "CHALLENGE_NOT_FOUND" });
-      }
-      // Window check.
       const now = new Date();
-      if (challenge.startTime && Date.parse(challenge.startTime) > now.getTime()) {
-        return res.status(409).json({ error: "Challenge has not started yet.", code: "CHALLENGE_NOT_OPEN" });
-      }
-      if (challenge.endTime && Date.parse(challenge.endTime) <= now.getTime()) {
-        return res.status(409).json({ error: "Challenge has ended.", code: "CHALLENGE_CLOSED" });
-      }
-      if (!isLanguageAvailable(challenge.lang)) {
-        return res.status(503).json({
-          error: `Language ${challenge.lang} is not currently available.`,
-          code: "LANG_UNAVAILABLE"
-        });
+      // Pre-mutex existence check is just for fast-failing 404s. The
+      // authoritative read happens INSIDE the mutex below — without
+      // the inner re-read, a concurrent admin edit that wins the
+      // mutex first could change immutable fields (wordLength,
+      // puzzleCount, timeBudgetSeconds) while we still hold a stale
+      // snapshot, then we'd persist the first session under the OLD
+      // config while subsequent reads see the NEW config — guaranteed
+      // mismatch.
+      const initialChallenge = await challengeConfigStore.findById(req.params.id);
+      if (!initialChallenge || initialChallenge.deleted) {
+        return res.status(404).json({ error: translateForRequest(req, "serverError.challengeNotFound"), code: "CHALLENGE_NOT_FOUND" });
       }
       // The find-or-create critical section runs under the cross-route
       // mutex shared with PUT /api/admin/challenges/:id. Without that
@@ -185,10 +180,35 @@ function createChallengesRouter(deps) {
       // update commits with hasResults=false and lets through an
       // immutable-fields edit that the store's contract forbids once
       // any session exists. Wrapping createSession (and the in-flight
-      // / replay-policy checks that gate it) in the same mutex closes
-      // that TOCTOU. Returns either a resume payload or a created one;
-      // the wrapper unwraps the discriminated result for us.
+      // / replay-policy / config-read checks that gate it) in the
+      // same mutex closes that TOCTOU. Returns a discriminated
+      // kind:"resumed"/"replay-blocked"/"lang-unavailable"/"window"/
+      // "not-found"/"created" so the response shaping stays out of
+      // the lock.
       const result = await withChallengeAdminUserMutex(async () => {
+        // Re-read the challenge from the authoritative store now that
+        // we hold the mutex. If admin's PUT won the lock first, this
+        // sees the NEW config; the session about to be created uses
+        // the same config that future reads will see. If user wins,
+        // admin's hasResults check on its turn observes the just-
+        // committed session and rejects forbidden edits.
+        const challenge = await challengeConfigStore.findById(req.params.id);
+        if (!challenge || challenge.deleted) {
+          return { kind: "not-found" };
+        }
+        // Window + lang checks against the post-mutex config.
+        if (challenge.startTime && Date.parse(challenge.startTime) > now.getTime()) {
+          return { kind: "window", code: "CHALLENGE_NOT_OPEN", message: "Challenge has not started yet." };
+        }
+        if (challenge.endTime && Date.parse(challenge.endTime) <= now.getTime()) {
+          return { kind: "window", code: "CHALLENGE_CLOSED", message: "Challenge has ended." };
+        }
+        if (!isLanguageAvailable(challenge.lang)) {
+          return {
+            kind: "lang-unavailable",
+            message: `Language ${challenge.lang} is not currently available.`
+          };
+        }
         // Resume an in-flight session if one exists for this
         // (challenge, profile). Settle on timeout first so the resume
         // path doesn't hand back a stale "in-progress" snapshot for a
@@ -197,7 +217,7 @@ function createChallengesRouter(deps) {
         if (session) {
           session = await settleIfTimedOut(session, challenge, now);
           if (session.status === "in-progress" || session.status === "pending") {
-            return { kind: "resumed", session };
+            return { kind: "resumed", session, challenge };
           }
           // Otherwise fall through and create a new session per replay policy.
         }
@@ -229,19 +249,23 @@ function createChallengesRouter(deps) {
         // serial. The outer mutex serializes against admin's update,
         // not against itself: createSession's own #commit lock handles
         // user-vs-user concurrency.
-        return {
-          kind: "created",
-          ...await challengeResultsStore.createSession({
-            challengeId: challenge.id,
-            profileId: profile.profileId,
-            profileName: profile.profileName,
-            startedAt: now.toISOString(),
-            puzzles
-          })
-        };
+        const createResult = await challengeResultsStore.createSession({
+          challengeId: challenge.id,
+          profileId: profile.profileId,
+          profileName: profile.profileName,
+          startedAt: now.toISOString(),
+          puzzles
+        });
+        return { kind: "created", session: createResult.session, resumed: createResult.resumed, challenge };
       });
+      if (result.kind === "not-found") {
+        return res.status(404).json({ error: translateForRequest(req, "serverError.challengeNotFound"), code: "CHALLENGE_NOT_FOUND" });
+      }
+      if (result.kind === "window") {
+        return res.status(409).json({ error: result.message, code: result.code });
+      }
       if (result.kind === "resumed") {
-        const projected = projectForResponse(result.session, challenge, now);
+        const projected = projectForResponse(result.session, result.challenge, now);
         return res.status(200).json({ ok: true, session: projected, resumed: true });
       }
       if (result.kind === "replay-blocked") {
@@ -253,8 +277,11 @@ function createChallengesRouter(deps) {
       if (result.kind === "lang-unavailable") {
         return res.status(503).json({ error: result.message, code: "LANG_UNAVAILABLE" });
       }
-      // result.kind === "created" — has session + resumed flag.
-      const projected = projectForResponse(result.session, challenge, now);
+      // result.kind === "created" — has session, resumed flag, and
+      // the challenge config that was current under the mutex (used
+      // here so the projection sees the same fields the session was
+      // built with).
+      const projected = projectForResponse(result.session, result.challenge, now);
       return res.status(result.resumed ? 200 : 201).json({
         ok: true,
         session: projected,

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -57,8 +57,22 @@ function createNotificationsRouter(deps) {
       });
     } catch (err) {
       if (err instanceof PushSubscriptionStoreError) {
-        const status = err.code === "INVALID_REQUEST" ? 400 : 503;
-        return res.status(status).json({ error: err.message, code: err.code });
+        if (err.code === "INVALID_REQUEST") {
+          // INVALID_REQUEST messages are author-curated and safe — they
+          // describe the offending field shape, not server-side state.
+          return res.status(400).json({ error: err.message, code: err.code });
+        }
+        // STORE_READ_FAILED / STORE_WRITE_FAILED / STORE_PARSE_FAILED
+        // messages may include the absolute store path on disk
+        // (push-subscription-store wraps fs errors with a "Failed to
+        // read/persist subscriptions store at <path>." message). Mask
+        // those for the public endpoint and log the raw error
+        // server-side. The error code is generic enough to keep.
+        console.error(`[notify] subscribe ${err.code}:`, err);
+        return res.status(503).json({
+          error: "Subscription failed. Try again later.",
+          code: err.code
+        });
       }
       console.error("[notify] subscribe failed:", err);
       return res.status(503).json({
@@ -74,8 +88,16 @@ function createNotificationsRouter(deps) {
       return res.status(204).send();
     } catch (err) {
       if (err instanceof PushSubscriptionStoreError) {
-        const status = err.code === "INVALID_REQUEST" ? 400 : 503;
-        return res.status(status).json({ error: err.message, code: err.code });
+        if (err.code === "INVALID_REQUEST") {
+          return res.status(400).json({ error: err.message, code: err.code });
+        }
+        // Same masking as subscribe — STORE_* messages carry the
+        // store filepath and shouldn't reach unauthenticated callers.
+        console.error(`[notify] unsubscribe ${err.code}:`, err);
+        return res.status(503).json({
+          error: "Unsubscribe failed. Try again later.",
+          code: err.code
+        });
       }
       console.error("[notify] unsubscribe failed:", err);
       return res.status(503).json({

--- a/server.js
+++ b/server.js
@@ -326,9 +326,13 @@ const ENV_WEBHOOK_GLOBAL_INFLIGHT_LIMIT = clampEnvBounded(
 );
 
 // Web Push notifications. Disabled at the runtime level via the
-// notifications.enabled config flag (operator-controlled at runtime
-// via the admin Notifications tab). The PUSH_NOTIFICATIONS_ENABLED env
-// var only seeds the default config on first boot.
+// notifications.enabled config flag, set through `PUT
+// /api/admin/runtime-config` (admin Runtime Settings tab) — NOT via
+// the admin Notifications tab, which today only shows status,
+// subscriber count, and the "Send broadcast" / dry-run controls. The
+// PUSH_NOTIFICATIONS_ENABLED env var only seeds the default config on
+// first boot; once a runtime override has been written, the override
+// wins until explicitly cleared. See docs/notifications.md.
 const ENV_PUSH_NOTIFICATIONS_ENABLED_DEFAULT =
   String(process.env.PUSH_NOTIFICATIONS_ENABLED || "true").toLowerCase() !== "false";
 const ENV_PUSH_DAILY_FIRE_LOCAL_TIME_DEFAULT = (() => {
@@ -2786,29 +2790,34 @@ async function startProviderImportQueueIfNeeded() {
         await adminJobsStore.markFailed(job.id, failure);
       } finally {
         await cleanupManualUploadStaging(job.request?.manualUpload).catch(() => {});
-        // Best-effort emit. Failures here are logged but never block the
-        // queue — the job's persisted status is the source of truth.
-        try {
-          if (result) {
-            await webhookService.emit("provider.import.completed", {
-              jobId: job.id,
-              variant: result.variant,
-              commit: result.commit,
-              sourceType: result.sourceType,
-              filterMode: result.filterMode,
-              counts: result.counts,
-              artifacts: result.artifacts
-            });
-          } else if (failure) {
-            await webhookService.emit("provider.import.failed", {
-              jobId: job.id,
-              variant: job.request?.variant || null,
-              sourceType: job.request?.sourceType || null,
-              error: failure
-            });
-          }
-        } catch (emitErr) {
-          console.error("[webhook] emit failed for provider import:", emitErr);
+        // True fire-and-forget emit so a slow/contended commitQueue can't
+        // block the next job in the import queue. Earlier code awaited
+        // emit() but the comment claimed "never block the queue" —
+        // emit() persists to disk through the same commit serialization
+        // path as deliveries, so awaiting it pinned the queue to disk
+        // I/O (and to whichever delivery is currently being persisted).
+        // Detach via .catch on a non-awaited promise; failures still log.
+        if (result) {
+          webhookService.emit("provider.import.completed", {
+            jobId: job.id,
+            variant: result.variant,
+            commit: result.commit,
+            sourceType: result.sourceType,
+            filterMode: result.filterMode,
+            counts: result.counts,
+            artifacts: result.artifacts
+          }).catch((emitErr) => {
+            console.error("[webhook] emit failed for provider.import.completed:", emitErr);
+          });
+        } else if (failure) {
+          webhookService.emit("provider.import.failed", {
+            jobId: job.id,
+            variant: job.request?.variant || null,
+            sourceType: job.request?.sourceType || null,
+            error: failure
+          }).catch((emitErr) => {
+            console.error("[webhook] emit failed for provider.import.failed:", emitErr);
+          });
         }
       }
     }
@@ -3194,8 +3203,10 @@ app.use(
     parseBulkNames,
     UTF8_BOM,
     normalizeLang,
+    resolveLang,
     getLocalDateString,
     aggregateAnalytics,
+    getCurrentWordData: () => wordDataCache || null,
     analyticsCacheTtlMs: ENV_ANALYTICS_CACHE_TTL_MS,
     analyticsTimezone: ENV_ANALYTICS_TIMEZONE,
     scheduleStore,

--- a/server.js
+++ b/server.js
@@ -1616,6 +1616,18 @@ const providerImportSyncActiveRef = { value: false };
 // staged upload + queued job orphaned. The restore busy check
 // observes this ref and 409s the restore in that window.
 const providerImportEnqueueActiveRef = { value: false };
+// Counter for fire-and-forget webhook emits started from the import
+// queue's finally block. The emit() call goes through the webhook
+// store's commitQueue (disk persistence), so awaiting it would re-
+// introduce the queue stall we documented when this code was
+// awaiting. Detaching the await fixes throughput but opens a window
+// where providerImportQueueActiveRef can drop to false before the
+// delivery row is durably enqueued — a restore racing in that window
+// would roll the import back, then the late emit fires for a
+// reverted job. The restore busy-check observes this counter to
+// keep the import "busy" for as long as any emits are still
+// in-flight, closing the gap.
+const webhookEmitInFlightRef = { count: 0 };
 // Promise-barrier for restoreInProgressRef so direct writers can
 // `await` for the restore to release without busy-spinning on a
 // resolved data-lock barrier (the data lock isn't held during the
@@ -2796,9 +2808,24 @@ async function startProviderImportQueueIfNeeded() {
         // emit() persists to disk through the same commit serialization
         // path as deliveries, so awaiting it pinned the queue to disk
         // I/O (and to whichever delivery is currently being persisted).
-        // Detach via .catch on a non-awaited promise; failures still log.
+        // Detach via .catch on a non-awaited promise; failures still
+        // log. Track the in-flight emit so the restore busy-check
+        // can keep the import "busy" until the delivery is durably
+        // enqueued — without that, a restore can roll the app back
+        // before the late emit lands and the persisted delivery
+        // would describe an import the operator just reverted.
+        function emitDetached(event, payload) {
+          webhookEmitInFlightRef.count += 1;
+          webhookService.emit(event, payload)
+            .catch((emitErr) => {
+              console.error(`[webhook] emit failed for ${event}:`, emitErr);
+            })
+            .finally(() => {
+              webhookEmitInFlightRef.count -= 1;
+            });
+        }
         if (result) {
-          webhookService.emit("provider.import.completed", {
+          emitDetached("provider.import.completed", {
             jobId: job.id,
             variant: result.variant,
             commit: result.commit,
@@ -2806,17 +2833,13 @@ async function startProviderImportQueueIfNeeded() {
             filterMode: result.filterMode,
             counts: result.counts,
             artifacts: result.artifacts
-          }).catch((emitErr) => {
-            console.error("[webhook] emit failed for provider.import.completed:", emitErr);
           });
         } else if (failure) {
-          webhookService.emit("provider.import.failed", {
+          emitDetached("provider.import.failed", {
             jobId: job.id,
             variant: job.request?.variant || null,
             sourceType: job.request?.sourceType || null,
             error: failure
-          }).catch((emitErr) => {
-            console.error("[webhook] emit failed for provider.import.failed:", emitErr);
           });
         }
       }
@@ -3126,6 +3149,7 @@ app.use(
     providerImportQueueActiveRef,
     providerImportSyncActiveRef,
     providerImportEnqueueActiveRef,
+    webhookEmitInFlightRef,
     dataMutationLockRef,
     restoreInProgressRef,
     directDataWriteActiveRef,

--- a/server.js
+++ b/server.js
@@ -1432,6 +1432,24 @@ const challengeResultsStore = new ChallengeResultsStore({
   logger: console,
   claimDirectDataWriteSlot
 });
+// Cross-route mutex for challenge config-vs-session ops. claimDirectDataWriteSlot
+// is a counter (multiple writers can hold it at once — that's how the
+// backup/restore busy-check sees concurrent activity), so it's NOT an
+// exclusive lock. The admin PUT path needs to read challengeResultsStore
+// (hasResults check) and then write challengeConfigStore atomically with
+// respect to user POSTs that create the FIRST session — otherwise the
+// hasResults snapshot can lie. The two stores have separate commit
+// queues, so neither queue alone can serialize them. This Promise-chain
+// mutex ties admin update + user start together so the immutable-fields
+// check is observed under the same lock the mutation runs under.
+let challengeAdminUserMutex = Promise.resolve();
+function withChallengeAdminUserMutex(fn) {
+  const next = challengeAdminUserMutex.then(fn, fn);
+  // Swallow rejection on the chain so one failed op doesn't poison
+  // the next; the caller still gets the original promise's outcome.
+  challengeAdminUserMutex = next.then(() => undefined, () => undefined);
+  return next;
+}
 // Resolve runtime notifications config from app-config overrides (live)
 // with env-var seed fallbacks. Called every time scheduler/service
 // needs the config so admin edits take effect without restart.
@@ -3250,6 +3268,7 @@ app.use(
     challengeConfigStore,
     challengeResultsStore,
     challengeEngine,
+    withChallengeAdminUserMutex,
     ChallengeConfigStoreError,
     ChallengeResultsStoreError,
     challengeModeEnabled: ENV_CHALLENGE_MODE_ENABLED,
@@ -3348,6 +3367,7 @@ app.use(
   createChallengesRouter({
     challengeConfigStore,
     challengeResultsStore,
+    withChallengeAdminUserMutex,
     ChallengeConfigStoreError,
     ChallengeResultsStoreError,
     getDictionary,

--- a/tests/admin-webhook-routes.test.js
+++ b/tests/admin-webhook-routes.test.js
@@ -247,9 +247,11 @@ describe("GET /api/admin/webhooks/:id/deliveries", () => {
       .post("/api/admin/webhooks")
       .send({ url: "https://example.com/x", events: ["webhook.test"] });
     const id = created.body.subscription.id;
-    // Trigger a test delivery so there's something in the store. The
-    // actual fetch will fail (we don't have a server listening at
-    // example.com/x in tests), but the delivery row will exist.
+    // Trigger a test delivery so there's something in the store.
+    // `globalThis.fetch` is stubbed to a 200 response in `beforeEach`,
+    // so this delivery succeeds and the row is persisted under the
+    // subscription. We don't assert the success status here — only
+    // that a delivery row exists for the GET to enumerate.
     await supertest(app).post(`/api/admin/webhooks/${encodeURIComponent(id)}/test`);
     const res = await supertest(app).get(`/api/admin/webhooks/${encodeURIComponent(id)}/deliveries`);
     expect(res.status).toBe(200);

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -461,6 +461,80 @@ describe("validateArchive rejection cases", () => {
       code: "ARCHIVE_TOO_LARGE"
     });
   });
+
+  test("ACCEPTS archive missing backwards-compatible files (e.g. schedule.json)", async () => {
+    // Pre-scheduler archives don't declare data/schedule.json (or any of
+    // the other features added after the initial backup spec shipped).
+    // The MANIFEST_INCOMPLETE check must skip these "added later" files
+    // so old archives stay restorable; otherwise every prior backup
+    // becomes non-restorable the moment a new feature lands. This is
+    // the canary regression test for the backwards-compat allowlist.
+    const projectRoot = await tempProject();
+    const { archivePath } = await exportArchiveToFile(projectRoot);
+    const yauzl = require("yauzl");
+    const archiver = require("archiver");
+    const tamperedPath = `${archivePath}.bc`;
+    const entries = await new Promise((resolve, reject) => {
+      yauzl.open(archivePath, { lazyEntries: true, autoClose: false }, (err, zip) => {
+        if (err) return reject(err);
+        const out = [];
+        zip.on("entry", (entry) => {
+          zip.openReadStream(entry, (e, rs) => {
+            if (e) return reject(e);
+            const chunks = [];
+            rs.on("data", (c) => chunks.push(c));
+            rs.on("end", () => {
+              out.push({ name: entry.fileName, buf: Buffer.concat(chunks) });
+              zip.readEntry();
+            });
+            rs.on("error", reject);
+          });
+        });
+        zip.on("end", () => {
+          zip.close();
+          resolve(out);
+        });
+        zip.readEntry();
+      });
+    });
+    // Drop schedule.json + other backwards-compat files from the
+    // manifest AND from the archive itself. We keep the required-only
+    // set (leaderboard, languages, admin-jobs, app-config, classes,
+    // word) so the manifest-incomplete branch fires only for the
+    // backwards-compat files. After our fix that branch should pass.
+    const archive = archiver("zip");
+    const out = fs.createWriteStream(tamperedPath);
+    archive.pipe(out);
+    const BACKWARDS_COMPAT = new Set([
+      "data/schedule.json",
+      "data/webhooks.json",
+      "data/webhook-deliveries.json",
+      "data/push-subscriptions.json",
+      "data/challenges.json",
+      "data/challenge-results.json"
+    ]);
+    for (const entry of entries) {
+      if (entry.name === "manifest.json") {
+        const manifest = JSON.parse(entry.buf.toString("utf8"));
+        manifest.files = manifest.files.filter((f) => !BACKWARDS_COMPAT.has(f.path));
+        archive.append(`${JSON.stringify(manifest, null, 2)}\n`, { name: "manifest.json" });
+      } else if (BACKWARDS_COMPAT.has(entry.name)) {
+        // skip — emulating an older archive that never had these
+      } else {
+        archive.append(entry.buf, { name: entry.name });
+      }
+    }
+    await archive.finalize();
+    await new Promise((resolve) => out.on("close", resolve));
+
+    const result = await validateArchive(tamperedPath, { projectRoot });
+    expect(result.manifest.manifestVersion).toBeDefined();
+    // Sanity: manifest doesn't declare any of the backwards-compat files.
+    const declared = new Set(result.manifest.files.map((f) => f.path));
+    for (const compatPath of BACKWARDS_COMPAT) {
+      expect(declared.has(compatPath)).toBe(false);
+    }
+  });
 });
 
 describe("validateArchive security guards", () => {

--- a/tests/backup-store.test.js
+++ b/tests/backup-store.test.js
@@ -8,6 +8,7 @@ const {
   BackupError,
   MANIFEST_VERSION,
   IN_SCOPE_FILES,
+  BACKWARDS_COMPATIBLE_FILES,
   buildManifest,
   createArchive,
   validateArchive,
@@ -505,20 +506,17 @@ describe("validateArchive rejection cases", () => {
     const archive = archiver("zip");
     const out = fs.createWriteStream(tamperedPath);
     archive.pipe(out);
-    const BACKWARDS_COMPAT = new Set([
-      "data/schedule.json",
-      "data/webhooks.json",
-      "data/webhook-deliveries.json",
-      "data/push-subscriptions.json",
-      "data/challenges.json",
-      "data/challenge-results.json"
-    ]);
+    // Pull the allowlist from the module under test so this regression
+    // stays in sync with production. Hardcoding it would let the test
+    // pass against an outdated set.
+    const compatSet = new Set(BACKWARDS_COMPATIBLE_FILES);
+    expect(compatSet.size).toBeGreaterThan(0);
     for (const entry of entries) {
       if (entry.name === "manifest.json") {
         const manifest = JSON.parse(entry.buf.toString("utf8"));
-        manifest.files = manifest.files.filter((f) => !BACKWARDS_COMPAT.has(f.path));
+        manifest.files = manifest.files.filter((f) => !compatSet.has(f.path));
         archive.append(`${JSON.stringify(manifest, null, 2)}\n`, { name: "manifest.json" });
-      } else if (BACKWARDS_COMPAT.has(entry.name)) {
+      } else if (compatSet.has(entry.name)) {
         // skip — emulating an older archive that never had these
       } else {
         archive.append(entry.buf, { name: entry.name });
@@ -531,7 +529,7 @@ describe("validateArchive rejection cases", () => {
     expect(result.manifest.manifestVersion).toBeDefined();
     // Sanity: manifest doesn't declare any of the backwards-compat files.
     const declared = new Set(result.manifest.files.map((f) => f.path));
-    for (const compatPath of BACKWARDS_COMPAT) {
+    for (const compatPath of compatSet) {
       expect(declared.has(compatPath)).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary

Sweep of unresolved review-thread items left behind after the campaign PRs (#98–#104) landed. Triage agents identified **29 distinct items** across 4 PRs that described real bugs or doc/comment drift; this PR addresses every one. PRs #98 (backup) and #99 (analytics) had **zero genuine-fix items** — every active thread there was already addressed by the time of merge. PR #104 (i18n) was fully cleaned up at merge time.

## Highlights — bugs (not just nits)

- **Backup backwards-compat (P1)**: `validateArchive` rejected any archive missing data/schedule.json, data/webhooks.json, etc. — making every pre-feature backup non-restorable. Added `BACKWARDS_COMPATIBLE_FILES` allowlist + regression test.
- **Webhook double-send race**: `executeOnce` accepted both "queued" and "running" — a duplicate timer could launch a concurrent send and double-increment attempts. Now only "queued" is eligible.
- **Webhook 3xx retry burn**: With `redirect: "manual"` a 3xx is terminal misconfiguration; classifyHttpStatus now marks it non-retriable instead of burning the retry budget.
- **Provider import queue stall**: `await webhookService.emit(...)` blocked the import queue on disk commit. Replaced with detached `.catch()` to match the comment.
- **Challenge createSession double-start race**: Two concurrent /start calls for the same (challengeId, profileId) could both bypass `findInFlight` and create duplicate in-flight sessions. Atomic re-check inside the commit serializes them.
- **Challenge /guess overwrite**: Two concurrent /guess calls computed `updatedPuzzles` from the same stale snapshot; the second commit overwrote the first guess. New `transactionalUpdate` runs the patch builder inside the store's commit lock.
- **Challenge admin TOCTOU**: `hasResults` was read outside the slot; concurrent /start could create the first session between read and config-update, letting an immutable-fields edit slip through.
- **Notification broadcast short-circuit**: `sendOne` throwing PAYLOAD_TOO_LARGE inside Promise.all rejected the whole batch and lost in-flight worker updates. Pre-flight + per-worker try/catch.
- **Notification overrides un-resettable**: `replaceOverridesSync` always preserved previous notifications. Now keyed on whether caller mentioned the field via hasOwnProperty.
- **Schedule lang validation**: Routes accepted any LANG_PATTERN-valid lang; reconciler then served DEFAULT_LANG silently. Added `resolveLang()` gate.
- **Auto-rotate fallback**: `pickAutoRotateWord` now falls back to defaultLang if preferredLang is missing/disabled.
- **Challenge-config slot bypass**: `#loadInternal` wrote on ENOENT outside the slot, racing backup/restore.
- **Challenge admin lock leak**: Lock-then-unlock briefly showed pre-lock challenge data; now scrubbed with the rest of the per-tab state.
- **Challenge keyboard unstyled**: `.kb-row`/`.kb-key` had no CSS — keyboard rendered as unstyled stacked buttons. Switched to existing `.key-row`/`.key`. Backspace + Enter now have aria-labels.
- **Replay-best tie order**: Score-only comparison was insertion-order-dependent. Now uses full leaderboard comparator (score → elapsed → finishedAt).

## Hardening / hygiene

- `routes/notifications.js`: subscribe + unsubscribe mask `STORE_*` error messages (filepath leak).
- `routes/admin.js`: `challengeAdminError` same masking pattern.
- `lib/challenge-results-store.js`: `update()` throws INVALID_REQUEST on bad `profileName` (was silently ignored).
- `lib/vapid-store.js`: error message field-name correction.
- `THIRD_PARTY_NOTICES.md`: web-push license MPL-2.0 (was MIT).
- `docs/scheduler.md`, `docs/notifications.md`, `docs/challenge-mode.md`, `server.js` comment block: doc/comment accuracy fixes.

## Test plan

- [x] `npm run check` clean (lint + schema + i18n + nit-guardrails + 682 tests passing — added one new regression test for the backup backwards-compat fix)
- [ ] CI green (test, CodeQL, CodeRabbit, Copilot Review Trigger)
- [ ] No new unresolved review threads after Copilot/CodeRabbit run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timed challenges now reliably resume existing sessions and return appropriate status for resumed vs new attempts

* **Bug Fixes**
  * Deterministic leaderboard tie-breaking
  * Reduced race conditions in challenge sessions and guesses
  * Improved admin session lock/refresh to avoid stale challenge UI
  * Notifications send now handles batch failures without aborting remaining deliveries
  * Backup/restore now blocks when imports/webhook emissions are in flight

* **Documentation**
  * Clarified anti-cheat rules, scheduler override semantics, notification troubleshooting, and third‑party license/source-disclosure notes

* **Tests**
  * Added coverage for backup backwards‑compatibility handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/105)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->