### PR TITLE
docs(readme): reflect campaign features (#98–#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,21 +100,26 @@ The header has a language switcher (English, Spanish). Selection persists in the
 
 By default, `npm start` runs **open** — `node server.js` doesn't load `.env`, `ADMIN_KEY` is empty, and the admin gate falls through. Fine for a local game on `localhost`; not fine if you're exposing the server beyond your machine.
 
-Two ways to load env vars and turn the gate on:
+Set the key **before** starting the server. `server.js` reads `ADMIN_KEY` and `REQUIRE_ADMIN_KEY` once at boot, and both `docker compose`'s `env_file` and Node's `--env-file` flag are evaluated at process startup — editing `.env` after launch leaves the running process using whatever values were in place when it started (notably the `change-me` placeholder from `.env.example`). If you need to rotate the key on a running server, edit `.env` then restart.
 
 ```bash
-# Option A — Docker (Compose loads .env automatically via env_file)
 cp .env.example .env
+# Edit .env now — set ADMIN_KEY to a long random value.
+```
+
+Then load it with one of:
+
+```bash
+# Option A — Docker (Compose reads .env automatically via env_file)
 docker compose up --build
 
 # Option B — Node 20+'s built-in --env-file flag (no dotenv dependency)
-cp .env.example .env
 node --env-file=.env server.js
 ```
 
-Then edit `.env` and **set `ADMIN_KEY` to a long random value**. The gate covers `/api/admin/*` (the API the admin console talks to). The `/admin` HTML page itself is served unauthenticated — so an unauthenticated visitor can see the unlock form, but every read or write the form makes goes through the gate.
+The gate covers `/api/admin/*` (the API the admin console talks to). The `/admin` HTML page itself is served unauthenticated — so an unauthenticated visitor can see the unlock form, but every read or write the form makes goes through the gate.
 
-After locking down, requests to admin endpoints need the header:
+Once locked down, requests to admin endpoints need the header:
 
 ```bash
 curl -X POST http://localhost:3000/api/word \

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ Open `http://localhost:3000`.
 
 ### 3. (Optional) Set a daily word
 
-If you want everyone using your install to play the same word at `/daily`:
+To make everyone using your install play the same word at `/daily`:
+
+> **Docker / `--env-file` users**, read this first: those paths inherit `REQUIRE_ADMIN_KEY=true` from `.env.example`, so the curl below will 401 unless you add `-H 'x-admin-key: YOUR_ADMIN_KEY'` (use `change-me` if you haven't edited `.env`). See [Locking it down](#locking-it-down) for the full picture. The default `npm start` runs open and the curl works as-is.
 
 ```bash
 curl -X POST http://localhost:3000/api/word \
   -H 'Content-Type: application/json' \
   -d '{"word":"CRANE","lang":"en"}'
 ```
-
-If you locked the server down — including the Docker path above, which loads `.env` and so honors the `REQUIRE_ADMIN_KEY=true` default in `.env.example` — add `-H 'x-admin-key: YOUR_ADMIN_KEY'` to the request. Details: [Locking it down](#locking-it-down).
 
 Visit `http://localhost:3000/daily`. The first time a player plays the daily word, they pick a profile name; results show on the family leaderboard automatically — no account or password.
 
@@ -101,7 +101,7 @@ The header has a language switcher (English, Spanish). Selection persists in the
 
 By default, `npm start` runs **open** — `node server.js` doesn't load `.env`, `ADMIN_KEY` is empty, and the admin gate falls through. Fine for a local game on `localhost`; not fine if you're exposing the server beyond your machine.
 
-Set the key **before** starting the server. `server.js` reads `ADMIN_KEY` and `REQUIRE_ADMIN_KEY` once at boot, and both `docker compose`'s `env_file` and Node's `--env-file` flag are evaluated at process startup — editing `.env` after launch leaves the running process using whatever values were in place when it started (notably the `change-me` placeholder from `.env.example`). If you need to rotate the key on a running server, edit `.env` then restart.
+Set the key **before** starting the server. `server.js` reads `ADMIN_KEY` and `REQUIRE_ADMIN_KEY` once at boot, and both `docker compose`'s `env_file` and Node's `--env-file` flag are evaluated at process startup — editing `.env` after launch leaves the running process using whatever values were in place when it started (notably the `change-me` placeholder from `.env.example`). To rotate on a running server: edit `.env`, then **restart for `--env-file`** (`Ctrl+C` and re-run the `node` command), or **recreate for Docker Compose** (`docker compose up --build` after `down`, or `docker compose up --build --force-recreate` — `docker restart` alone keeps the existing env vars because Compose bakes them into the container at creation time).
 
 ```bash
 cp .env.example .env
@@ -240,7 +240,7 @@ Daily word endpoints remain available:
 - Nothing loads at `http://localhost:3000`: confirm the server is running and your port is free.
 - Daily link says no puzzle set: set one via `POST /api/word` (Quick Start step 3). If you locked the server down, pass `x-admin-key` — see [Locking it down](#locking-it-down).
 - Share link doesn't work: make sure the link wasn't truncated and is from the Create screen.
-- `/challenges` link is missing from the header: no challenges are configured. The admin Challenges tab can create one.
+- `/challenges` link is missing from the header: either no challenges are configured (the admin Challenges tab can create one), **or** challenge mode is disabled at the deploy level (`CHALLENGE_MODE_ENABLED=false` in the environment, which makes `/api/challenges` return `CHALLENGE_MODE_DISABLED` and the client hides the link).
 - Notifications toggle is hidden: page is loaded over plain HTTP, or the browser lacks `PushManager` / Service Worker. Use HTTPS (or `localhost`) and a modern browser.
 - Notifications toggle is disabled with "Notifications blocked": browser permission was denied. Open browser site permissions, allow notifications, then reload.
 - Webhook deliveries are stuck `queued`: confirm `WEBHOOKS_ENABLED=true` and that no other admin operation is holding the data lock; recovery on boot also requeues stale `running` rows.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ Node 20+ (matches CI and the bundled Docker image):
 
 ```bash
 npm install
-cp .env.example .env
 npm start
 ```
 
-…or Docker (also needs `.env` first — `docker-compose.yml` declares it as `env_file`):
+…or Docker (the bundled Compose file declares `.env` as `env_file`, so create one first):
 
 ```bash
 cp .env.example .env
@@ -37,7 +36,13 @@ docker compose up --build
 
 Open `http://localhost:3000`.
 
-> **Heads up:** `.env.example` ships with `ADMIN_KEY=change-me` and `REQUIRE_ADMIN_KEY=true`. That's fine on a private LAN/Tailscale, but **change `ADMIN_KEY` to a long random value before exposing the server publicly** — admin endpoints accept the value verbatim and have no rate-limit protection beyond the global per-IP limiter.
+> **Local-vs-Docker, important caveat:** `npm start` is `node server.js` and does **not** load `.env` on its own. With nothing in the environment, `ADMIN_KEY` is empty and admin endpoints (`/admin`, `POST /api/word`) run **open** (no key required). That's fine for a quick local game on `localhost`. If you need real auth — for the steps below, or before exposing the server beyond your machine — either use the Docker path (which loads `.env`) **or** start with Node's `--env-file` flag after creating `.env`:
+>
+> ```bash
+> cp .env.example .env
+> # Edit .env: set ADMIN_KEY to a long random value before exposing publicly.
+> node --env-file=.env server.js
+> ```
 
 ### 2. Create and share a puzzle
 
@@ -55,11 +60,19 @@ If you want everyone on the host to play the same word at `/daily`:
 ```bash
 curl -X POST http://localhost:3000/api/word \
   -H 'Content-Type: application/json' \
-  -H 'x-admin-key: change-me' \
   -d '{"word":"CRANE","lang":"en"}'
 ```
 
-`POST /api/word` is admin-gated; pass your `ADMIN_KEY` in the `x-admin-key` header (`change-me` is the value from `.env.example` — change it). The same gate also covers the admin console at `/admin`.
+This works as-is on the default `npm start` (no `--env-file`) because admin endpoints run open in that mode. **If you locked the server down** (Docker path, or `node --env-file=.env server.js`), add your `ADMIN_KEY` to the request:
+
+```bash
+curl -X POST http://localhost:3000/api/word \
+  -H 'Content-Type: application/json' \
+  -H 'x-admin-key: YOUR_ADMIN_KEY' \
+  -d '{"word":"CRANE","lang":"en"}'
+```
+
+The same gate also covers the admin console at `/admin`.
 
 Visit `http://localhost:3000/daily`. The first time a player plays the daily word, they pick a profile name; results show on the family leaderboard automatically — no account or password.
 
@@ -200,7 +213,7 @@ Daily word endpoints remain available:
 ## Troubleshooting
 
 - Nothing loads at `http://localhost:3000`: confirm the server is running and your port is free.
-- Daily link says no puzzle set: set one via `POST /api/word` (admin-gated — pass your `ADMIN_KEY` in the `x-admin-key` header).
+- Daily link says no puzzle set: set one via `POST /api/word`. On the default `npm start` the endpoint runs open; on the Docker path or `node --env-file=.env`, pass your `ADMIN_KEY` in the `x-admin-key` header.
 - Share link doesn't work: make sure the link wasn't truncated and is from the Create screen.
 - `/challenges` link is missing from the header: no challenges are configured. The admin Challenges tab can create one.
 - Notifications toggle is hidden: page is loaded over plain HTTP, or the browser lacks `PushManager` / Service Worker. Use HTTPS (or `localhost`) and a modern browser.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ curl -X POST http://localhost:3000/api/word \
 
 English (`en`) ships baked in. To go beyond that, the **Providers** tab is your **BYOD** entry point — bring your own Hunspell-format word/affix files (`.dic` + `.aff`) and the runtime turns them into the guess and answer dictionaries the game uses, without a server restart or any CLI work. Currently supported language variants: `en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`.
 
+**Where to get `.dic` + `.aff` files:** the canonical source is the LibreOffice dictionaries repo — [github.com/LibreOffice/dictionaries](https://github.com/LibreOffice/dictionaries) — which ships maintained Hunspell pairs for every supported English variant under [`/en/`](https://github.com/LibreOffice/dictionaries/tree/master/en) (e.g. `en_GB.dic` + `en_GB.aff`). The same files power LibreOffice and OpenOffice's spell-checkers, so they're stable, license-clear, and well-tested. The Providers tab's remote-fetch path is pre-configured for this repo (`providerId: libreoffice-dictionaries`); the manual-upload path accepts any conformant Hunspell pair if you'd rather use a custom dictionary. See [docs/provider-import-contract.md](docs/provider-import-contract.md) for the full provider descriptor and pinning rules.
+
 What the Providers tab can do:
 
 - **Import / re-import** a variant. Two paths: remote fetch (pinned commit + required SHA-256 checksums for the `.dic` and `.aff`), or manual upload (drop a `.dic` + `.aff` pair into the form). Re-import is how you pick up upstream updates.

--- a/README.md
+++ b/README.md
@@ -2,60 +2,110 @@
 
 Local, privacy-first Wordle you can run anywhere.
 
-For families, classrooms, and friend groups who want a simple, self-hosted Wordle.
+For families, classrooms, and friend groups who want a simple, self-hosted Wordle — with daily words, classroom rosters, timed challenges, opt-in notifications, and UI in English or Spanish.
 
 ## How To Use
 1. Open the site in your browser.
-2. Create a puzzle.
+2. Create a puzzle, play the daily word, or join a timed challenge.
 3. Share the link.
 4. Play it together.
 
-Want a daily puzzle? Visit `/daily` after you’ve set one (see below).
+Want a daily puzzle? Visit `/daily` after you've set one (see below).
+Want timed multi-puzzle runs? Visit `/challenges` after the admin enables one.
 
-## Quickstart (Local)
-Download this repo (or clone it), then run:
+## Quick Start
+
+A two-minute walkthrough from `git clone` to playing your first puzzle. **No admin setup required** — everything below works against an out-of-the-box install.
+
+### 1. Install and run
+
+Node 18+ (local):
 
 ```bash
 npm install
 cp .env.example .env
 npm start
 ```
-Open `http://localhost:3000`.
 
-## Quickstart (Docker)
-If you don’t use Docker, skip this section.
+…or Docker:
 
-```bash
-docker build -t local-hosted-wordle .
-docker run --rm -p 3000:3000 --env-file .env local-hosted-wordle
-```
-Or with Compose:
 ```bash
 docker compose up --build
 ```
 
-## Advanced Settings (Optional)
-If you want admin controls or are hosting behind a VPN/proxy, see `advanced-settings.md`.
+Open `http://localhost:3000`.
 
-## Create & Share
-- Create a puzzle on the Create screen.
-- Share links are encoded for convenience, not security.
+### 2. Create and share a puzzle
+
+1. On the home page, type a word into **Word** (3–12 letters, A–Z), or click **Random word**.
+2. Optional: tweak **Length** or **Guesses**. The form auto-syncs `Length` to your word.
+3. Click **Start puzzle**. The play screen shows a **Share link** at the bottom.
+4. Copy the link and send it. Anyone who opens it plays the same word — no login required.
+
+> Share links encode the word for convenience, not security. Don't share links to puzzles you don't want decoded.
+
+### 3. (Optional) Set a daily word
+
+If you want everyone on the host to play the same word at `/daily`:
+
+```bash
+curl -X POST http://localhost:3000/api/word \
+  -H 'Content-Type: application/json' \
+  -d '{"word":"CRANE","lang":"en"}'
+```
+
+Visit `http://localhost:3000/daily`. The first time a player plays the daily word, they pick a profile name; results show on the family leaderboard automatically — no account or password.
+
+### 4. (Optional) Switch the UI language
+
+The header has a language switcher (English, Spanish). Selection persists in the browser.
+
+### What next?
+
+- **More player features** — timed challenges, notifications, classroom rosters: see [Highlights](#highlights).
+- **Operator controls** — provider imports, scheduled words, backups, webhooks, analytics: see [Admin Console](#admin-console).
+- **Hosting beyond defaults** — env vars, proxies, Tailscale: see [`advanced-settings.md`](advanced-settings.md).
+
+## Highlights
+- **Custom puzzles**: create-and-share links, no login.
+- **Daily word** with optional admin-managed schedule + auto-rotate from the active answer pool.
+- **Timed challenges** — solve N puzzles inside a server-authoritative time budget; per-challenge leaderboard.
+- **Classroom mode** — admin manages classes, rosters, and CSV reports (`docs/classroom-mode.md`).
+- **Opt-in browser push notifications** when the daily puzzle is ready (`docs/notifications.md`).
+- **Outbound webhooks** with HMAC-signed deliveries, retry queue, and recovery on boot (`docs/webhooks.md`).
+- **Backup / restore** — versioned, schema-checked archives applied atomically (`docs/backup-restore.md`).
+- **Usage analytics** — admin dashboard with offline charting (`docs/admin-analytics.md`).
+- **UI internationalization** — English + Spanish at strict per-key parity, switchable from the header (`docs/i18n.md`).
+
+## Other Goodies (Optional)
 - For English puzzles, a local meaning is shown when a game ends (solve or final reveal), when available.
 - Theme controls include `System`, `Dark`, and `Light`; `System` follows your OS/browser color scheme when available.
+- Hosting behind a proxy or running with admin features? See [`advanced-settings.md`](advanced-settings.md).
 
 ## Admin Console
-- Visit `/admin` for the provider admin shell.
+- Visit `/admin` for the operator console.
 - Unlock uses `x-admin-key` semantics and keeps the key session-scoped in memory (no browser storage persistence).
-- Provider workflows are built in:
-  - import/re-import (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) via either remote fetch (pinned commit + required SHA-256 checksums) or manual `.dic` + `.aff` upload fallback
-  - async import queue with persisted job history under `data/admin-jobs.json`
-  - check upstream updates on demand with status outcomes (`up-to-date`, `update-available`, `unknown`, `error`)
-  - enable/disable imported variants without CLI usage
-- Import uses `denylist-only` (default) or `allowlist-required` family filter modes.
 - Admin platform architecture contracts (schemas, config precedence, queue semantics): `docs/admin-platform-architecture-contract.md`.
-- Runtime settings tab edits only hot-refresh-safe overrides (`data/app-config.json`); env-defined security/infrastructure values remain read-only.
-- Data tab: download a versioned, schema-checked backup archive and restore it atomically. Operator runbook: `docs/backup-restore.md`.
-- Schedule tab: queue words against specific dates or turn on auto-rotate from the active answer pool; the runtime owns `data/word.json` from then on. Operator runbook: `docs/scheduler.md`.
+
+### Provider workflows
+- import/re-import (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) via either remote fetch (pinned commit + required SHA-256 checksums) or manual `.dic` + `.aff` upload fallback.
+- async import queue with persisted job history under `data/admin-jobs.json`.
+- check upstream updates on demand with status outcomes (`up-to-date`, `update-available`, `unknown`, `error`).
+- enable/disable imported variants without CLI usage.
+- Import uses `denylist-only` (default) or `allowlist-required` family filter modes.
+
+### Tabs
+- **Providers** — provider/dictionary lifecycle (above).
+- **Import Queue** — live status of async import jobs.
+- **Runtime Settings** — edits only hot-refresh-safe overrides (`data/app-config.json`); env-defined security/infrastructure values remain read-only.
+- **Profiles** — leaderboard profile management.
+- **Classes** — classroom rosters, bulk-add by names/CSV, participation reports (`docs/classroom-mode.md`).
+- **Data** — download a versioned, schema-checked backup archive and restore it atomically (`docs/backup-restore.md`).
+- **Analytics** — usage dashboard (active days, attempts distribution, language mix, hour-of-day) with offline-friendly charting (`docs/admin-analytics.md`).
+- **Schedule** — queue words against specific dates or turn on auto-rotate from the active answer pool; the runtime owns `data/word.json` from then on (`docs/scheduler.md`).
+- **Webhooks** — manage outbound subscriptions with per-event filters; view recent deliveries with status/attempts/latency. Deliveries are HMAC-signed, retried with exponential backoff, and recovered on boot (`docs/webhooks.md`).
+- **Notifications** — VAPID status, subscriber count, manual broadcast (with dry-run preview) for the daily puzzle (`docs/notifications.md`).
+- **Challenges** — define timed challenges (puzzle count, word length, time budget, max guesses, replay policy, scoring) and inspect per-challenge leaderboards (`docs/challenge-mode.md`).
 
 ## Daily Word (API)
 Daily word endpoints remain available:
@@ -99,6 +149,28 @@ Daily word endpoints remain available:
 - Rollout and cutover notes: `docs/server-leaderboard-rollout.md`
 - Data contract details: `docs/leaderboard-data-contract.md`
 
+## Timed Challenges
+- Visit `/challenges` to see the active list (the link is hidden until at least one challenge is configured).
+- Each challenge defines a fixed puzzle count, word length, time budget, max guesses per puzzle, and a replay policy (`unlimited`, `best`, or `first-only`).
+- The timer is **server-authoritative** — switching tabs, sleeping the device, or reloading does not pause the budget. The server settles a session if it expires before the player finishes.
+- Server-side per-letter feedback is computed on each guess; the client only renders, never decides.
+- Per-challenge leaderboards rank by score → fewer elapsed seconds → earlier finish.
+- Profile name is stored on this device (no login); used on the leaderboard.
+- Operator-facing details + replay policy mechanics: `docs/challenge-mode.md`.
+
+## Daily Puzzle Notifications
+- Optional opt-in browser push for the daily puzzle. Toggle in the header settings strip — the toggle is hidden if your browser doesn't support `PushManager` / Service Worker, or if the page is loaded over plain HTTP (notifications need HTTPS or `localhost`).
+- The daily fire is server-scheduled at the operator's configured local time (default `00:00`).
+- Subscriptions are pruned on `404`/`410` from the push service so dead endpoints don't accumulate.
+- VAPID keypair lives in `data/vapid-keys.json` (auto-generated on first boot, persisted thereafter).
+- Operator runbook: `docs/notifications.md`.
+
+## UI Languages
+- The header has a language switcher (English, Spanish). Selection persists per device.
+- Both the player and admin shells are translated; `npm run i18n:check` enforces strict per-key parity between locales in CI.
+- HTTP error JSON is also localized for the small set of routes wired through `lib/server-i18n.js` (`Accept-Language` aware).
+- Adding a new locale: drop a JSON file under `public/locales/` and update the small list of allowlists documented in `docs/i18n.md`.
+
 ## Security Notes
 - Rate limiting is enabled by default.
 - `TRUST_PROXY=true` is recommended behind proxies or Tailscale (`TRUST_PROXY_HOPS` defaults to `1`).
@@ -108,17 +180,21 @@ Daily word endpoints remain available:
 ## Troubleshooting
 - Nothing loads at `http://localhost:3000`: confirm the server is running and your port is free.
 - Daily link says no puzzle set: set one via `POST /api/word`.
-- Share link doesn’t work: make sure the link wasn’t truncated and is from the Create screen.
+- Share link doesn't work: make sure the link wasn't truncated and is from the Create screen.
+- `/challenges` link is missing from the header: no challenges are configured. The admin Challenges tab can create one.
+- Notifications toggle is hidden: page is loaded over plain HTTP, or the browser lacks `PushManager` / Service Worker. Use HTTPS (or `localhost`) and a modern browser.
+- Notifications toggle is disabled with "Notifications blocked": browser permission was denied. Open browser site permissions, allow notifications, then reload.
+- Webhook deliveries are stuck `queued`: confirm `WEBHOOKS_ENABLED=true` and that no other admin operation is holding the data lock; recovery on boot also requeues stale `running` rows.
+- UI keeps reverting to English: the language switcher writes to `localStorage`. Clearing browser storage clears the preference too.
 
-## Roadmap (Exploratory)
-We are evaluating exploratory tracks that are intentionally outside the current core scope:
-- Admin Platform expansion (Admin UI, dictionary lifecycle management, and selected runtime settings controls): https://github.com/curdriceaurora/wordle-local/issues/6
-- LibreOffice English variant sourcing (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) via Admin import flows, with Hunspell-based guess handling and curated answer policy: https://github.com/curdriceaurora/wordle-local/issues/17
+## Roadmap
 
-This second track is planned after foundational Admin Platform work in #6.
+The two original exploratory tracks shipped:
 
-Whether it ships next will depend on adoption signals and community feedback.
-Current priority remains a stable, simple local-hosted gameplay experience.
+- **Admin Platform expansion** ([#6](https://github.com/curdriceaurora/wordle-local/issues/6), closed) — Admin UI, runtime settings, classes, scheduler, analytics, backup/restore, webhooks, notifications, challenges.
+- **LibreOffice English variants** ([#17](https://github.com/curdriceaurora/wordle-local/issues/17), closed) — `en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA` via admin import flows, Hunspell-based guess handling, curated answer policy.
+
+Current priorities remain stability, low operational overhead, and a simple local-hosted gameplay experience. Contributions for additional UI locales (drop a JSON file under `public/locales/` per `docs/i18n.md`) and additional language variants are welcome.
 
 ## License
 CC0-1.0 public domain dedication. See `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ curl -X POST http://localhost:3000/api/word \
   -d '{"word":"CRANE","lang":"en"}'
 ```
 
-The same gate also covers the admin console at `/admin`.
+The same gate covers all `/api/admin/*` API routes that the admin console talks to. The `/admin` HTML page itself is served unauthenticated — the gate fires on the API calls the unlock form makes, so an unauthenticated visitor sees the unlock form but can't read or change anything until they enter the right key.
 
 Visit `http://localhost:3000/daily`. The first time a player plays the daily word, they pick a profile name; results show on the family leaderboard automatically — no account or password.
 
@@ -140,7 +140,7 @@ Daily word endpoints remain available:
 - `POST /api/word` — set daily word
   - Body: `{ "word": "CRANE", "lang": "en", "date": "YYYY-MM-DD" }`
   - If `date` is provided, it is interpreted in server local time.
-- The **scheduler** owns `data/word.json` at each local-midnight rollover when `data/schedule.json` exists. A manual `POST /api/word` overrides the schedule for the rest of the day; the next day the schedule wins again. To stop the scheduler from acting on `word.json`, delete `data/schedule.json` — the store recreates an empty default file but the reconciler then no-ops every tick (there's no separate "off" mode in v1). See [docs/scheduler.md](docs/scheduler.md) for the full contract.
+- The **scheduler** owns `data/word.json` at each local-midnight rollover when `data/schedule.json` exists. A manual `POST /api/word` overrides the schedule for the rest of the day; the next day the schedule wins again. To stop the scheduler from acting on `word.json`, delete `data/schedule.json` **and restart the server** — the in-memory schedule cache is loaded once at boot and is not invalidated by filesystem deletes, so the running process will keep reconciling against the cached schedule until restart. After restart, the store recreates an empty default file and the reconciler no-ops every tick (there's no separate "off" mode in v1). See [docs/scheduler.md](docs/scheduler.md) for the full contract.
 
 ## Languages & Dictionaries
 

--- a/README.md
+++ b/README.md
@@ -128,13 +128,17 @@ curl -X POST http://localhost:3000/api/word \
   -d '{"word":"CRANE","lang":"en"}'
 ```
 
-### Provider workflows
+### Provider workflows (dictionary imports)
 
-- import/re-import (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) via either remote fetch (pinned commit + required SHA-256 checksums) or manual `.dic` + `.aff` upload fallback.
-- async import queue with persisted job history under `data/admin-jobs.json`.
-- check upstream updates on demand with status outcomes (`up-to-date`, `update-available`, `unknown`, `error`).
-- enable/disable imported variants without CLI usage.
-- Import uses `denylist-only` (default) or `allowlist-required` family filter modes.
+A *provider* is a source of dictionary data — Hunspell-format word/affix files that the runtime turns into the guess and answer dictionaries used by the game. English (`en`) ships baked-in; the Providers tab lets an operator add or refresh additional language **variants** (currently `en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) without restarting the server or touching a CLI.
+
+What the Providers tab can do:
+
+- **Import / re-import** a language variant via either remote fetch (pinned commit + required SHA-256 checksums for the `.dic` and `.aff` files) or manual upload (drop a `.dic` + `.aff` pair into the form). Re-import is how you pick up upstream updates.
+- **Async import queue** so a long-running import doesn't block the request; job history is persisted under `data/admin-jobs.json` so an operator can audit recent imports across server restarts.
+- **Check for upstream updates on demand** — the tab pings each variant's pinned source and reports `up-to-date`, `update-available`, `unknown`, or `error` per variant.
+- **Enable / disable imported variants** — disabled variants disappear from the player UI's language picker without losing the imported data on disk.
+- **Family filter mode** — choose `denylist-only` (default — block known-bad words) or `allowlist-required` (only words on the allowlist are eligible) to scope what counts as a valid guess.
 
 ### Tabs
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Local, privacy-first Wordle you can run anywhere.
 For families, classrooms, and friend groups who want a simple, self-hosted Wordle — with daily words, classroom rosters, timed challenges, opt-in notifications, and UI in English or Spanish.
 
 ## How To Use
+
 1. Open the site in your browser.
 2. Create a puzzle, play the daily word, or join a timed challenge.
 3. Share the link.
@@ -67,6 +68,7 @@ The header has a language switcher (English, Spanish). Selection persists in the
 - **Hosting beyond defaults** — env vars, proxies, Tailscale: see [advanced-settings.md](advanced-settings.md).
 
 ## Highlights
+
 - **Custom puzzles**: create-and-share links, no login.
 - **Daily word** with optional admin-managed schedule + auto-rotate from the active answer pool.
 - **Timed challenges** — solve N puzzles inside a server-authoritative time budget; per-challenge leaderboard.
@@ -78,16 +80,19 @@ The header has a language switcher (English, Spanish). Selection persists in the
 - **UI internationalization** — English + Spanish at strict per-key parity, switchable from the header ([docs/i18n.md](docs/i18n.md)).
 
 ## Other Goodies (Optional)
+
 - For English puzzles, a local meaning is shown when a game ends (solve or final reveal), when available.
 - Theme controls include `System`, `Dark`, and `Light`; `System` follows your OS/browser color scheme when available.
 - Hosting behind a proxy or running with admin features? See [advanced-settings.md](advanced-settings.md).
 
 ## Admin Console
+
 - Visit `/admin` for the operator console.
 - Unlock uses `x-admin-key` semantics and keeps the key session-scoped in memory (no browser storage persistence).
 - Admin platform architecture contracts (schemas, config precedence, queue semantics): [docs/admin-platform-architecture-contract.md](docs/admin-platform-architecture-contract.md).
 
 ### Provider workflows
+
 - import/re-import (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) via either remote fetch (pinned commit + required SHA-256 checksums) or manual `.dic` + `.aff` upload fallback.
 - async import queue with persisted job history under `data/admin-jobs.json`.
 - check upstream updates on demand with status outcomes (`up-to-date`, `update-available`, `unknown`, `error`).
@@ -95,6 +100,7 @@ The header has a language switcher (English, Spanish). Selection persists in the
 - Import uses `denylist-only` (default) or `allowlist-required` family filter modes.
 
 ### Tabs
+
 - **Providers** — provider/dictionary lifecycle (above).
 - **Import Queue** — live status of async import jobs.
 - **Runtime Settings** — edits only hot-refresh-safe overrides (`data/app-config.json`); env-defined security/infrastructure values remain read-only.
@@ -108,6 +114,7 @@ The header has a language switcher (English, Spanish). Selection persists in the
 - **Challenges** — define timed challenges (puzzle count, word length, time budget, max guesses, replay policy, scoring) and inspect per-challenge leaderboards ([docs/challenge-mode.md](docs/challenge-mode.md)).
 
 ## Daily Word (API)
+
 Daily word endpoints remain available:
 
 - `GET /api/word` — read current daily word config
@@ -117,6 +124,7 @@ Daily word endpoints remain available:
 - The **scheduler** owns `data/word.json` at each local-midnight rollover when `data/schedule.json` exists. A manual `POST /api/word` overrides the schedule for the rest of the day; the next day the schedule wins again. To stop the scheduler from acting on `word.json`, delete `data/schedule.json` — the store recreates an empty default file but the reconciler then no-ops every tick (there's no separate "off" mode in v1). See [docs/scheduler.md](docs/scheduler.md) for the full contract.
 
 ## Languages & Dictionaries
+
 - English dictionary is baked in (`en`).
 - English meanings are baked in locally (`data/dictionaries/en-definitions.json`).
 - Language registry state is persisted in `data/languages.json`; missing/invalid registry data auto-recovers to baked defaults.
@@ -130,10 +138,12 @@ Daily word endpoints remain available:
 - For performance tuning, `DEFINITIONS_MODE` supports `memory`, `lazy`, and `indexed` (see [advanced-settings.md](advanced-settings.md)).
 
 ## Daily Link
+
 - Visit `/daily` to play the configured daily word.
 - If no daily word is set (or the date doesn’t match today), a friendly error page is shown.
 
 ## Family Profiles & Leaderboards
+
 - Daily mode prompts for a player name (no password; honor system for families).
 - Profiles and leaderboard stats are stored on the server in `data/leaderboard.json` and shared across devices on the same host.
 - Server retention limits are applied for performance:
@@ -150,6 +160,7 @@ Daily word endpoints remain available:
 - Data contract details: [docs/leaderboard-data-contract.md](docs/leaderboard-data-contract.md)
 
 ## Timed Challenges
+
 - Visit `/challenges` to see the active list (the link is hidden until at least one challenge is configured).
 - Each challenge defines a fixed puzzle count, word length, time budget, max guesses per puzzle, and a replay policy (`unlimited`, `best`, or `first-only`).
 - The timer is **server-authoritative** — switching tabs, sleeping the device, or reloading does not pause the budget. The server settles a session if it expires before the player finishes.
@@ -159,6 +170,7 @@ Daily word endpoints remain available:
 - Operator-facing details + replay policy mechanics: [docs/challenge-mode.md](docs/challenge-mode.md).
 
 ## Daily Puzzle Notifications
+
 - Optional opt-in browser push for the daily puzzle. Toggle in the header settings strip — the toggle is hidden if your browser doesn't support `PushManager` / Service Worker, or if the page is loaded over plain HTTP (notifications need HTTPS or `localhost`).
 - The daily fire is server-scheduled at the operator's configured local time (default `00:00`).
 - Subscriptions are pruned on `404`/`410` from the push service so dead endpoints don't accumulate.
@@ -166,18 +178,21 @@ Daily word endpoints remain available:
 - Operator runbook: [docs/notifications.md](docs/notifications.md).
 
 ## UI Languages
+
 - The header has a language switcher (English, Spanish). Selection persists per device.
 - Both the player and admin shells are translated; `npm run i18n:check` enforces strict per-key parity between locales in CI.
 - HTTP error JSON is also localized for the small set of routes wired through `lib/server-i18n.js` (`Accept-Language` aware).
 - Adding a new locale: drop a JSON file under `public/locales/` and update the small list of allowlists documented in [docs/i18n.md](docs/i18n.md).
 
 ## Security Notes
+
 - Rate limiting is enabled by default.
 - `TRUST_PROXY=true` is recommended behind proxies or Tailscale (`TRUST_PROXY_HOPS` defaults to `1`).
 - Container runs as a non-root user and includes `/api/health`.
 - For provider/admin releases, use [docs/admin-security-checklist.md](docs/admin-security-checklist.md) in addition to release gates.
 
 ## Troubleshooting
+
 - Nothing loads at `http://localhost:3000`: confirm the server is running and your port is free.
 - Daily link says no puzzle set: set one via `POST /api/word`.
 - Share link doesn't work: make sure the link wasn't truncated and is from the Create screen.
@@ -197,19 +212,24 @@ The two original exploratory tracks shipped:
 Current priorities remain stability, low operational overhead, and a simple local-hosted gameplay experience. Contributions for additional UI locales (drop a JSON file under `public/locales/` per [docs/i18n.md](docs/i18n.md)) and additional language variants are welcome.
 
 ## License
+
 CC0-1.0 public domain dedication. See `LICENSE`.
 Third-party assets (notably the English dictionary) are licensed separately. See `THIRD_PARTY_NOTICES.md`.
 
 ## Contributing
+
 See `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
 Release maintainers should also use [docs/release-checklist.md](docs/release-checklist.md).
 Provider/admin release changes should additionally follow [docs/provider-rollout-checklist.md](docs/provider-rollout-checklist.md).
 
 ## Disclaimer
+
 This project is provided “as is”, without warranty of any kind. See `DISCLAIMER.md`.
 
 ## Support
+
 No support or SLAs. See `SUPPORT.md`.
 
 ## Trademark
+
 Wordle is a trademark of The New York Times Company. This project is not affiliated with or endorsed by The New York Times.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Local, privacy-first Wordle you can run anywhere.
 
-For families, classrooms, and friend groups who want a simple, self-hosted Wordle — with daily words, classroom rosters, timed challenges, opt-in notifications, and UI in English or Spanish.
+For families, classrooms, and friend groups who want a self-hosted Wordle.
+Beyond the basics: daily words, timed challenges, classroom rosters, opt-in push notifications, and an English/Spanish UI.
 
 ## How To Use
 
@@ -11,12 +12,12 @@ For families, classrooms, and friend groups who want a simple, self-hosted Wordl
 3. Share the link.
 4. Play it together.
 
-Want a daily puzzle? Visit `/daily` after you've set one (see below).
-Want timed multi-puzzle runs? Visit `/challenges` after the admin enables one.
+Want a daily puzzle? Visit `/daily` after you've set one ([step 3 below](#3-optional-set-a-daily-word)).
+Want timed multi-puzzle runs? Visit `/challenges` once a challenge is configured (Admin Console → Challenges).
 
 ## Quick Start
 
-A two-minute walkthrough from `git clone` to playing your first puzzle. **No admin setup required** — everything below works against an out-of-the-box install.
+A two-minute walkthrough from install to your first puzzle. **No admin setup required** — everything below works against an out-of-the-box install on `localhost`.
 
 ### 1. Install and run
 
@@ -36,18 +37,12 @@ docker compose up --build
 
 Open `http://localhost:3000`.
 
-> **Local-vs-Docker, important caveat:** `npm start` is `node server.js` and does **not** load `.env` on its own. With nothing in the environment, `ADMIN_KEY` is empty and admin endpoints (`/admin`, `POST /api/word`) run **open** (no key required). That's fine for a quick local game on `localhost`. If you need real auth — for the steps below, or before exposing the server beyond your machine — either use the Docker path (which loads `.env`) **or** start with Node's `--env-file` flag after creating `.env`:
->
-> ```bash
-> cp .env.example .env
-> # Edit .env: set ADMIN_KEY to a long random value before exposing publicly.
-> node --env-file=.env server.js
-> ```
+> `npm start` doesn't load `.env`, so admin endpoints run **open** by default — fine for a local game on `localhost`. To lock the server down before exposing it beyond your machine, see [Locking it down](#locking-it-down) under Admin Console.
 
 ### 2. Create and share a puzzle
 
 1. On the home page, type a word into **Word** (3–12 letters, A–Z), or click **Random word**.
-2. Optional: tweak **Length** or **Guesses**. The form auto-syncs `Length` to your word.
+2. Optional: tweak **Length** or **Guesses**. The Length field updates automatically as you type.
 3. Click **Start puzzle**. The play screen shows a **Share link** at the bottom.
 4. Copy the link and send it. Anyone who opens it plays the same word — no login required.
 
@@ -55,7 +50,7 @@ Open `http://localhost:3000`.
 
 ### 3. (Optional) Set a daily word
 
-If you want everyone on the host to play the same word at `/daily`:
+If you want everyone using your install to play the same word at `/daily`:
 
 ```bash
 curl -X POST http://localhost:3000/api/word \
@@ -63,16 +58,7 @@ curl -X POST http://localhost:3000/api/word \
   -d '{"word":"CRANE","lang":"en"}'
 ```
 
-This works as-is on the default `npm start` (no `--env-file`) because admin endpoints run open in that mode. **If you locked the server down** (Docker path, or `node --env-file=.env server.js`), add your `ADMIN_KEY` to the request:
-
-```bash
-curl -X POST http://localhost:3000/api/word \
-  -H 'Content-Type: application/json' \
-  -H 'x-admin-key: YOUR_ADMIN_KEY' \
-  -d '{"word":"CRANE","lang":"en"}'
-```
-
-The same gate covers all `/api/admin/*` API routes that the admin console talks to. The `/admin` HTML page itself is served unauthenticated — the gate fires on the API calls the unlock form makes, so an unauthenticated visitor sees the unlock form but can't read or change anything until they enter the right key.
+If you locked the server down, add `-H 'x-admin-key: YOUR_ADMIN_KEY'` to the request. Details: [Locking it down](#locking-it-down).
 
 Visit `http://localhost:3000/daily`. The first time a player plays the daily word, they pick a profile name; results show on the family leaderboard automatically — no account or password.
 
@@ -109,6 +95,33 @@ The header has a language switcher (English, Spanish). Selection persists in the
 - Visit `/admin` for the operator console.
 - Unlock uses `x-admin-key` semantics and keeps the key session-scoped in memory (no browser storage persistence).
 - Admin platform architecture contracts (schemas, config precedence, queue semantics): [docs/admin-platform-architecture-contract.md](docs/admin-platform-architecture-contract.md).
+
+### Locking it down
+
+By default, `npm start` runs **open** — `node server.js` doesn't load `.env`, `ADMIN_KEY` is empty, and the admin gate falls through. Fine for a local game on `localhost`; not fine if you're exposing the server beyond your machine.
+
+Two ways to load env vars and turn the gate on:
+
+```bash
+# Option A — Docker (Compose loads .env automatically via env_file)
+cp .env.example .env
+docker compose up --build
+
+# Option B — Node 20+'s built-in --env-file flag (no dotenv dependency)
+cp .env.example .env
+node --env-file=.env server.js
+```
+
+Then edit `.env` and **set `ADMIN_KEY` to a long random value**. The gate covers `/api/admin/*` (the API the admin console talks to). The `/admin` HTML page itself is served unauthenticated — so an unauthenticated visitor can see the unlock form, but every read or write the form makes goes through the gate.
+
+After locking down, requests to admin endpoints need the header:
+
+```bash
+curl -X POST http://localhost:3000/api/word \
+  -H 'Content-Type: application/json' \
+  -H 'x-admin-key: YOUR_ADMIN_KEY' \
+  -d '{"word":"CRANE","lang":"en"}'
+```
 
 ### Provider workflows
 
@@ -213,7 +226,7 @@ Daily word endpoints remain available:
 ## Troubleshooting
 
 - Nothing loads at `http://localhost:3000`: confirm the server is running and your port is free.
-- Daily link says no puzzle set: set one via `POST /api/word`. On the default `npm start` the endpoint runs open; on the Docker path or `node --env-file=.env`, pass your `ADMIN_KEY` in the `x-admin-key` header.
+- Daily link says no puzzle set: set one via `POST /api/word` (Quick Start step 3). If you locked the server down, pass `x-admin-key` — see [Locking it down](#locking-it-down).
 - Share link doesn't work: make sure the link wasn't truncated and is from the Create screen.
 - `/challenges` link is missing from the header: no challenges are configured. The admin Challenges tab can create one.
 - Notifications toggle is hidden: page is loaded over plain HTTP, or the browser lacks `PushManager` / Service Worker. Use HTTPS (or `localhost`) and a modern browser.

--- a/README.md
+++ b/README.md
@@ -64,28 +64,28 @@ The header has a language switcher (English, Spanish). Selection persists in the
 
 - **More player features** — timed challenges, notifications, classroom rosters: see [Highlights](#highlights).
 - **Operator controls** — provider imports, scheduled words, backups, webhooks, analytics: see [Admin Console](#admin-console).
-- **Hosting beyond defaults** — env vars, proxies, Tailscale: see [`advanced-settings.md`](advanced-settings.md).
+- **Hosting beyond defaults** — env vars, proxies, Tailscale: see [advanced-settings.md](advanced-settings.md).
 
 ## Highlights
 - **Custom puzzles**: create-and-share links, no login.
 - **Daily word** with optional admin-managed schedule + auto-rotate from the active answer pool.
 - **Timed challenges** — solve N puzzles inside a server-authoritative time budget; per-challenge leaderboard.
-- **Classroom mode** — admin manages classes, rosters, and CSV reports (`docs/classroom-mode.md`).
-- **Opt-in browser push notifications** when the daily puzzle is ready (`docs/notifications.md`).
-- **Outbound webhooks** with HMAC-signed deliveries, retry queue, and recovery on boot (`docs/webhooks.md`).
-- **Backup / restore** — versioned, schema-checked archives applied atomically (`docs/backup-restore.md`).
-- **Usage analytics** — admin dashboard with offline charting (`docs/admin-analytics.md`).
-- **UI internationalization** — English + Spanish at strict per-key parity, switchable from the header (`docs/i18n.md`).
+- **Classroom mode** — admin manages classes, rosters, and CSV reports ([docs/classroom-mode.md](docs/classroom-mode.md)).
+- **Opt-in browser push notifications** when the daily puzzle is ready ([docs/notifications.md](docs/notifications.md)).
+- **Outbound webhooks** with HMAC-signed deliveries, retry queue, and recovery on boot ([docs/webhooks.md](docs/webhooks.md)).
+- **Backup / restore** — versioned, schema-checked archives applied atomically ([docs/backup-restore.md](docs/backup-restore.md)).
+- **Usage analytics** — admin dashboard with offline charting ([docs/admin-analytics.md](docs/admin-analytics.md)).
+- **UI internationalization** — English + Spanish at strict per-key parity, switchable from the header ([docs/i18n.md](docs/i18n.md)).
 
 ## Other Goodies (Optional)
 - For English puzzles, a local meaning is shown when a game ends (solve or final reveal), when available.
 - Theme controls include `System`, `Dark`, and `Light`; `System` follows your OS/browser color scheme when available.
-- Hosting behind a proxy or running with admin features? See [`advanced-settings.md`](advanced-settings.md).
+- Hosting behind a proxy or running with admin features? See [advanced-settings.md](advanced-settings.md).
 
 ## Admin Console
 - Visit `/admin` for the operator console.
 - Unlock uses `x-admin-key` semantics and keeps the key session-scoped in memory (no browser storage persistence).
-- Admin platform architecture contracts (schemas, config precedence, queue semantics): `docs/admin-platform-architecture-contract.md`.
+- Admin platform architecture contracts (schemas, config precedence, queue semantics): [docs/admin-platform-architecture-contract.md](docs/admin-platform-architecture-contract.md).
 
 ### Provider workflows
 - import/re-import (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) via either remote fetch (pinned commit + required SHA-256 checksums) or manual `.dic` + `.aff` upload fallback.
@@ -99,13 +99,13 @@ The header has a language switcher (English, Spanish). Selection persists in the
 - **Import Queue** — live status of async import jobs.
 - **Runtime Settings** — edits only hot-refresh-safe overrides (`data/app-config.json`); env-defined security/infrastructure values remain read-only.
 - **Profiles** — leaderboard profile management.
-- **Classes** — classroom rosters, bulk-add by names/CSV, participation reports (`docs/classroom-mode.md`).
-- **Data** — download a versioned, schema-checked backup archive and restore it atomically (`docs/backup-restore.md`).
-- **Analytics** — usage dashboard (active days, attempts distribution, language mix, hour-of-day) with offline-friendly charting (`docs/admin-analytics.md`).
-- **Schedule** — queue words against specific dates or turn on auto-rotate from the active answer pool; the runtime owns `data/word.json` from then on (`docs/scheduler.md`).
-- **Webhooks** — manage outbound subscriptions with per-event filters; view recent deliveries with status/attempts/latency. Deliveries are HMAC-signed, retried with exponential backoff, and recovered on boot (`docs/webhooks.md`).
-- **Notifications** — VAPID status, subscriber count, manual broadcast (with dry-run preview) for the daily puzzle (`docs/notifications.md`).
-- **Challenges** — define timed challenges (puzzle count, word length, time budget, max guesses, replay policy, scoring) and inspect per-challenge leaderboards (`docs/challenge-mode.md`).
+- **Classes** — classroom rosters, bulk-add by names/CSV, participation reports ([docs/classroom-mode.md](docs/classroom-mode.md)).
+- **Data** — download a versioned, schema-checked backup archive and restore it atomically ([docs/backup-restore.md](docs/backup-restore.md)).
+- **Analytics** — usage dashboard (active days, attempts distribution, language mix, hour-of-day) with offline-friendly charting ([docs/admin-analytics.md](docs/admin-analytics.md)).
+- **Schedule** — queue words against specific dates or turn on auto-rotate from the active answer pool; the runtime owns `data/word.json` from then on ([docs/scheduler.md](docs/scheduler.md)).
+- **Webhooks** — manage outbound subscriptions with per-event filters; view recent deliveries with status/attempts/latency. Deliveries are HMAC-signed, retried with exponential backoff, and recovered on boot ([docs/webhooks.md](docs/webhooks.md)).
+- **Notifications** — VAPID status, subscriber count, manual broadcast (with dry-run preview) for the daily puzzle ([docs/notifications.md](docs/notifications.md)).
+- **Challenges** — define timed challenges (puzzle count, word length, time budget, max guesses, replay policy, scoring) and inspect per-challenge leaderboards ([docs/challenge-mode.md](docs/challenge-mode.md)).
 
 ## Daily Word (API)
 Daily word endpoints remain available:
@@ -114,7 +114,7 @@ Daily word endpoints remain available:
 - `POST /api/word` — set daily word
   - Body: `{ "word": "CRANE", "lang": "en", "date": "YYYY-MM-DD" }`
   - If `date` is provided, it is interpreted in server local time.
-- The **scheduler** owns `data/word.json` at each local-midnight rollover when `data/schedule.json` exists. A manual `POST /api/word` overrides the schedule for the rest of the day; the next day the schedule wins again. To stop the scheduler from acting on `word.json`, delete `data/schedule.json` — the store recreates an empty default file but the reconciler then no-ops every tick (there's no separate "off" mode in v1). See `docs/scheduler.md` for the full contract.
+- The **scheduler** owns `data/word.json` at each local-midnight rollover when `data/schedule.json` exists. A manual `POST /api/word` overrides the schedule for the rest of the day; the next day the schedule wins again. To stop the scheduler from acting on `word.json`, delete `data/schedule.json` — the store recreates an empty default file but the reconciler then no-ops every tick (there's no separate "off" mode in v1). See [docs/scheduler.md](docs/scheduler.md) for the full contract.
 
 ## Languages & Dictionaries
 - English dictionary is baked in (`en`).
@@ -127,7 +127,7 @@ Daily word endpoints remain available:
 - Meanings are loaded from local files only; no external dictionary API calls are made at runtime.
 - To refresh local meanings from WordNet data (and rebuild indexed lookup artifacts): `npm run definitions:build`.
 - To rebuild only indexed lookup artifacts from the existing definitions file: `npm run definitions:index`.
-- For performance tuning, `DEFINITIONS_MODE` supports `memory`, `lazy`, and `indexed` (see `advanced-settings.md`).
+- For performance tuning, `DEFINITIONS_MODE` supports `memory`, `lazy`, and `indexed` (see [advanced-settings.md](advanced-settings.md)).
 
 ## Daily Link
 - Visit `/daily` to play the configured daily word.
@@ -146,8 +146,8 @@ Daily word endpoints remain available:
 - Streaks are tracked per profile based on consecutive winning daily entries.
 - No local import from historical browser `localStorage` stats is performed.
 - Pitfall: clearing browser storage no longer deletes server stats, but it can clear local UI state such as the active profile selection on that device.
-- Rollout and cutover notes: `docs/server-leaderboard-rollout.md`
-- Data contract details: `docs/leaderboard-data-contract.md`
+- Rollout and cutover notes: [docs/server-leaderboard-rollout.md](docs/server-leaderboard-rollout.md)
+- Data contract details: [docs/leaderboard-data-contract.md](docs/leaderboard-data-contract.md)
 
 ## Timed Challenges
 - Visit `/challenges` to see the active list (the link is hidden until at least one challenge is configured).
@@ -156,26 +156,26 @@ Daily word endpoints remain available:
 - Server-side per-letter feedback is computed on each guess; the client only renders, never decides.
 - Per-challenge leaderboards rank by score → fewer elapsed seconds → earlier finish.
 - Profile name is stored on this device (no login); used on the leaderboard.
-- Operator-facing details + replay policy mechanics: `docs/challenge-mode.md`.
+- Operator-facing details + replay policy mechanics: [docs/challenge-mode.md](docs/challenge-mode.md).
 
 ## Daily Puzzle Notifications
 - Optional opt-in browser push for the daily puzzle. Toggle in the header settings strip — the toggle is hidden if your browser doesn't support `PushManager` / Service Worker, or if the page is loaded over plain HTTP (notifications need HTTPS or `localhost`).
 - The daily fire is server-scheduled at the operator's configured local time (default `00:00`).
 - Subscriptions are pruned on `404`/`410` from the push service so dead endpoints don't accumulate.
 - VAPID keypair lives in `data/vapid-keys.json` (auto-generated on first boot, persisted thereafter).
-- Operator runbook: `docs/notifications.md`.
+- Operator runbook: [docs/notifications.md](docs/notifications.md).
 
 ## UI Languages
 - The header has a language switcher (English, Spanish). Selection persists per device.
 - Both the player and admin shells are translated; `npm run i18n:check` enforces strict per-key parity between locales in CI.
 - HTTP error JSON is also localized for the small set of routes wired through `lib/server-i18n.js` (`Accept-Language` aware).
-- Adding a new locale: drop a JSON file under `public/locales/` and update the small list of allowlists documented in `docs/i18n.md`.
+- Adding a new locale: drop a JSON file under `public/locales/` and update the small list of allowlists documented in [docs/i18n.md](docs/i18n.md).
 
 ## Security Notes
 - Rate limiting is enabled by default.
 - `TRUST_PROXY=true` is recommended behind proxies or Tailscale (`TRUST_PROXY_HOPS` defaults to `1`).
 - Container runs as a non-root user and includes `/api/health`.
-- For provider/admin releases, use `docs/admin-security-checklist.md` in addition to release gates.
+- For provider/admin releases, use [docs/admin-security-checklist.md](docs/admin-security-checklist.md) in addition to release gates.
 
 ## Troubleshooting
 - Nothing loads at `http://localhost:3000`: confirm the server is running and your port is free.
@@ -194,7 +194,7 @@ The two original exploratory tracks shipped:
 - **Admin Platform expansion** ([#6](https://github.com/curdriceaurora/wordle-local/issues/6), closed) — Admin UI, runtime settings, classes, scheduler, analytics, backup/restore, webhooks, notifications, challenges.
 - **LibreOffice English variants** ([#17](https://github.com/curdriceaurora/wordle-local/issues/17), closed) — `en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA` via admin import flows, Hunspell-based guess handling, curated answer policy.
 
-Current priorities remain stability, low operational overhead, and a simple local-hosted gameplay experience. Contributions for additional UI locales (drop a JSON file under `public/locales/` per `docs/i18n.md`) and additional language variants are welcome.
+Current priorities remain stability, low operational overhead, and a simple local-hosted gameplay experience. Contributions for additional UI locales (drop a JSON file under `public/locales/` per [docs/i18n.md](docs/i18n.md)) and additional language variants are welcome.
 
 ## License
 CC0-1.0 public domain dedication. See `LICENSE`.
@@ -202,8 +202,8 @@ Third-party assets (notably the English dictionary) are licensed separately. See
 
 ## Contributing
 See `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
-Release maintainers should also use `docs/release-checklist.md`.
-Provider/admin release changes should additionally follow `docs/provider-rollout-checklist.md`.
+Release maintainers should also use [docs/release-checklist.md](docs/release-checklist.md).
+Provider/admin release changes should additionally follow [docs/provider-rollout-checklist.md](docs/provider-rollout-checklist.md).
 
 ## Disclaimer
 This project is provided “as is”, without warranty of any kind. See `DISCLAIMER.md`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A two-minute walkthrough from `git clone` to playing your first puzzle. **No adm
 
 ### 1. Install and run
 
-Node 18+ (local):
+Node 20+ (matches CI and the bundled Docker image):
 
 ```bash
 npm install
@@ -28,13 +28,16 @@ cp .env.example .env
 npm start
 ```
 
-…or Docker:
+…or Docker (also needs `.env` first — `docker-compose.yml` declares it as `env_file`):
 
 ```bash
+cp .env.example .env
 docker compose up --build
 ```
 
 Open `http://localhost:3000`.
+
+> **Heads up:** `.env.example` ships with `ADMIN_KEY=change-me` and `REQUIRE_ADMIN_KEY=true`. That's fine on a private LAN/Tailscale, but **change `ADMIN_KEY` to a long random value before exposing the server publicly** — admin endpoints accept the value verbatim and have no rate-limit protection beyond the global per-IP limiter.
 
 ### 2. Create and share a puzzle
 
@@ -52,8 +55,11 @@ If you want everyone on the host to play the same word at `/daily`:
 ```bash
 curl -X POST http://localhost:3000/api/word \
   -H 'Content-Type: application/json' \
+  -H 'x-admin-key: change-me' \
   -d '{"word":"CRANE","lang":"en"}'
 ```
+
+`POST /api/word` is admin-gated; pass your `ADMIN_KEY` in the `x-admin-key` header (`change-me` is the value from `.env.example` — change it). The same gate also covers the admin console at `/admin`.
 
 Visit `http://localhost:3000/daily`. The first time a player plays the daily word, they pick a profile name; results show on the family leaderboard automatically — no account or password.
 
@@ -194,7 +200,7 @@ Daily word endpoints remain available:
 ## Troubleshooting
 
 - Nothing loads at `http://localhost:3000`: confirm the server is running and your port is free.
-- Daily link says no puzzle set: set one via `POST /api/word`.
+- Daily link says no puzzle set: set one via `POST /api/word` (admin-gated — pass your `ADMIN_KEY` in the `x-admin-key` header).
 - Share link doesn't work: make sure the link wasn't truncated and is from the Create screen.
 - `/challenges` link is missing from the header: no challenges are configured. The admin Challenges tab can create one.
 - Notifications toggle is hidden: page is loaded over plain HTTP, or the browser lacks `PushManager` / Service Worker. Use HTTPS (or `localhost`) and a modern browser.

--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ The header has a language switcher (English, Spanish). Selection persists in the
 ### What next?
 
 - **More player features** — timed challenges, notifications, classroom rosters: see [Highlights](#highlights).
-- **Operator controls** — provider imports, scheduled words, backups, webhooks, analytics: see [Admin Console](#admin-console).
+- **Operator controls** — BYOD (bring your own dictionary), scheduled words, backups, webhooks, analytics: see [Admin Console](#admin-console).
 - **Hosting beyond defaults** — env vars, proxies, Tailscale: see [advanced-settings.md](advanced-settings.md).
 
 ## Highlights
 
 - **Custom puzzles**: create-and-share links, no login.
+- **BYOD — Bring Your Own Dictionary** — import Hunspell `.dic` + `.aff` files for English variants (`en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) without a server restart or any CLI work.
 - **Daily word** with optional admin-managed schedule + auto-rotate from the active answer pool.
 - **Timed challenges** — solve N puzzles inside a server-authoritative time budget; per-challenge leaderboard.
 - **Classroom mode** — admin manages classes, rosters, and CSV reports ([docs/classroom-mode.md](docs/classroom-mode.md)).
@@ -128,13 +129,13 @@ curl -X POST http://localhost:3000/api/word \
   -d '{"word":"CRANE","lang":"en"}'
 ```
 
-### Provider workflows (dictionary imports)
+### BYOD — Bring Your Own Dictionary
 
-A *provider* is a source of dictionary data — Hunspell-format word/affix files that the runtime turns into the guess and answer dictionaries used by the game. English (`en`) ships baked-in; the Providers tab lets an operator add or refresh additional language **variants** (currently `en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`) without restarting the server or touching a CLI.
+English (`en`) ships baked in. To go beyond that, the **Providers** tab is your **BYOD** entry point — bring your own Hunspell-format word/affix files (`.dic` + `.aff`) and the runtime turns them into the guess and answer dictionaries the game uses, without a server restart or any CLI work. Currently supported language variants: `en-GB`, `en-US`, `en-CA`, `en-AU`, `en-ZA`.
 
 What the Providers tab can do:
 
-- **Import / re-import** a language variant via either remote fetch (pinned commit + required SHA-256 checksums for the `.dic` and `.aff` files) or manual upload (drop a `.dic` + `.aff` pair into the form). Re-import is how you pick up upstream updates.
+- **Import / re-import** a variant. Two paths: remote fetch (pinned commit + required SHA-256 checksums for the `.dic` and `.aff`), or manual upload (drop a `.dic` + `.aff` pair into the form). Re-import is how you pick up upstream updates.
 - **Async import queue** so a long-running import doesn't block the request; job history is persisted under `data/admin-jobs.json` so an operator can audit recent imports across server restarts.
 - **Check for upstream updates on demand** — the tab pings each variant's pinned source and reports `up-to-date`, `update-available`, `unknown`, or `error` per variant.
 - **Enable / disable imported variants** — disabled variants disappear from the player UI's language picker without losing the imported data on disk.
@@ -142,7 +143,7 @@ What the Providers tab can do:
 
 ### Tabs
 
-- **Providers** — provider/dictionary lifecycle (above).
+- **Providers** — BYOD: import / re-import / enable / disable Hunspell dictionaries (see above).
 - **Import Queue** — live status of async import jobs.
 - **Runtime Settings** — edits only hot-refresh-safe overrides (`data/app-config.json`); env-defined security/infrastructure values remain read-only.
 - **Profiles** — leaderboard profile management.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ curl -X POST http://localhost:3000/api/word \
   -d '{"word":"CRANE","lang":"en"}'
 ```
 
-If you locked the server down, add `-H 'x-admin-key: YOUR_ADMIN_KEY'` to the request. Details: [Locking it down](#locking-it-down).
+If you locked the server down — including the Docker path above, which loads `.env` and so honors the `REQUIRE_ADMIN_KEY=true` default in `.env.example` — add `-H 'x-admin-key: YOUR_ADMIN_KEY'` to the request. Details: [Locking it down](#locking-it-down).
 
 Visit `http://localhost:3000/daily`. The first time a player plays the daily word, they pick a profile name; results show on the family leaderboard automatically — no account or password.
 
@@ -117,7 +117,7 @@ docker compose up --build
 node --env-file=.env server.js
 ```
 
-The gate covers `/api/admin/*` (the API the admin console talks to). The `/admin` HTML page itself is served unauthenticated — so an unauthenticated visitor can see the unlock form, but every read or write the form makes goes through the gate.
+The gate covers `/api/admin/*` (the API the admin console talks to) **and** `GET`/`POST /api/word` (the daily-word read/write — the `/daily` page itself is unauthenticated and reads through cached state). The `/admin` HTML page is served unauthenticated — so an unauthenticated visitor can see the unlock form, but every read or write the form makes goes through the gate.
 
 Once locked down, requests to admin endpoints need the header:
 


### PR DESCRIPTION
## Summary

The README was last touched when only backup/restore and the scheduler had landed. The intervening campaign added 5 more operator surfaces and 3 player-facing features that the README didn't mention. This brings it back in sync — and adds a player-friendly Quick Start that lets a casual reader play their first puzzle without scrolling through admin content.

`+172 / -44`, markdown-only.

## Changes

- **Tagline + intro** — split the em-dash feature dump into two clean sentences. First sentence states the audience and self-hosted positioning; second sentence ("Beyond the basics: …") lists the breadth.
- **NEW: "Quick Start" section** — 4-step walkthrough from install to first puzzle, explicitly marked "No admin setup required":
  1. Install and run (npm OR Docker, with Node 20+ called out to match CI / the bundled image)
  2. Create and share a puzzle (concrete UI labels: Word / Length / Guesses / Random word / Start puzzle / Share link)
  3. (Optional) Set a daily word — single header-free `curl`, with a one-line pointer to "Locking it down" for operators
  4. (Optional) Switch the UI language
  - "What next?" links into Highlights / Admin Console / advanced-settings.md
- **"Other Goodies" subsection** — captures the leftovers from the old "Create & Share" (English meanings, theme controls) plus the pointer to advanced-settings.md.
- **Highlights section** — scannable overview of every shipped capability with clickable links to the matching operator runbook.
- **Admin Console reorganized**:
  - Purpose + unlock at the top.
  - **NEW: "Locking it down" subsection** — single home for the operator-mode details (npm-start-runs-open caveat, two ways to load `.env` (Docker / `node --env-file=.env`), ADMIN_KEY guidance, `/admin` gate scope explanation, `x-admin-key` curl example).
  - "Provider workflows" subsection.
  - "Tabs" subsection enumerating all 11 admin tabs with one-line descriptions + runbook links (was 4 flat bullets).
- **New player-facing sections** after Family Profiles:
  - Timed Challenges (`/challenges`, server-authoritative timer, replay policies)
  - Daily Puzzle Notifications (opt-in toggle, HTTPS requirement, VAPID persistence)
  - UI Languages (header switcher, parity gate, `Accept-Language`)
- **Roadmap reframed** — both original exploratory tracks (#6 Admin Platform expansion, #17 LibreOffice variants) closed during the campaign. Section now acknowledges what shipped + points contributors at additional UI locales / language variants.
- **Troubleshooting expanded** — 5 new entries (challenges link missing, push toggle hidden/disabled, webhook deliveries stuck, UI language reverts).
- **All doc references** (15 in total) converted from inline-code to clickable Markdown links.
- **MD022 clean** — every H2/H3 heading is surrounded by blank lines.

## Test plan

- [x] All 15 doc references in the README resolve to existing files (verified at PR open and again after each round).
- [x] Markdown-only change; pre-push correctly skipped `npm run check`.
- [x] Quick Start walkthrough verified against the actual UI labels.
- [x] `curl` example uses real `/api/word` shape from `routes/game.js`.
- [x] Node version (Node 20+) verified against `Dockerfile` (`node:20-alpine`) and the absence of `engines`/`.nvmrc`.
- [x] Default-mode auth behavior verified against `lib/admin-auth.js` (`isAuthorizedRequest` returns `true` when adminKey is empty AND requireAdminKey is false).
- [x] `/admin` gate scope verified against `routes/admin.js:278` (static HTML, no middleware) and `server.js:3084` (`/api/admin` mount with `requireAdminAccess`).
- [x] Schedule-delete-needs-restart verified against `lib/schedule-store.js` (load returns cached `this.state`).
- [x] Doc links converted to clickable Markdown form per Copilot review.
- [x] markdownlint MD022 (heading blank-line) clean per CodeRabbit review.
- [x] Tagline + Quick Start polished for "approachable but accurate" — Step 1 caveat shrunk from 6 lines to 1, Step 3 trimmed to a single curl, operator-mode details consolidated under "Locking it down".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured setup guide with improved local development and Docker deployment documentation
  * Added comprehensive API documentation for daily word scheduling and overrides
  * Documented UI language configuration and localization support
  * Expanded security and authentication notes for admin controls
  * Enhanced troubleshooting and operational guidance sections

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->