### PR TITLE
fix(scripts): pr:nits honors GitHub's isResolved thread flag

### DIFF
--- a/scripts/lib/pr-review-utils.js
+++ b/scripts/lib/pr-review-utils.js
@@ -28,7 +28,17 @@ function buildReviewThreads(comments) {
 function listActionableThreads(threads, viewerLogin) {
   const actionable = [];
 
-  threads.forEach(({ root, replies }) => {
+  threads.forEach(({ root, replies, isResolved }) => {
+    // Skip threads the reviewer (or owner) has explicitly marked
+    // resolved on the GitHub UI. The REST `/pulls/N/comments`
+    // endpoint that `buildReviewThreads` consumes does not surface
+    // this flag, so older callers won't set it — pr-nits-report.js
+    // populates it from the GraphQL `reviewThreads { isResolved }`
+    // path. Default `undefined` is falsy → behavior unchanged for
+    // existing REST callers.
+    if (isResolved) {
+      return;
+    }
     const threadComments = [root, ...replies].sort(
       (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
     );

--- a/scripts/pr-nits-report.js
+++ b/scripts/pr-nits-report.js
@@ -49,8 +49,16 @@ const me = ghText(["api", "user", "--jq", ".login"]);
 // bot-reviewer ack that resolves a thread in the UI looked
 // "unresolved" to this script, and pr:nits flagged threads we had
 // already finished with. See the follow-up task spawned from PR #109.
-const GRAPHQL_QUERY = `
-  query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String, $commentCursor: String) {
+// First-page query: fetch a page of review threads, each with up to
+// 50 comments + a hasNextPage flag for the inner comment connection.
+// If any thread reports hasNextPage=true we follow up with
+// THREAD_COMMENTS_QUERY against that thread's relay `id`. This pattern
+// — separate outer + inner pagination queries — keeps the code linear
+// and avoids the complexity of nested cursors in a single query that
+// only paginates one connection at a time anyway. Codex + Copilot
+// flagged the missing inner pagination on PR #110.
+const THREADS_QUERY = `
+  query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String) {
     repository(owner: $owner, name: $name) {
       pullRequest(number: $pr) {
         reviewThreads(first: 50, after: $threadCursor) {
@@ -58,9 +66,10 @@ const GRAPHQL_QUERY = `
           nodes {
             id
             isResolved
-            comments(first: 50, after: $commentCursor) {
+            comments(first: 50) {
               pageInfo { hasNextPage endCursor }
               nodes {
+                id
                 databaseId
                 author { login }
                 path
@@ -78,27 +87,81 @@ const GRAPHQL_QUERY = `
   }
 `;
 
-function fetchReviewThreads() {
-  // Pagination: GitHub caps reviewThreads at 100/page. We use 50 to
-  // stay well clear of the per-call point budget and paginate
-  // explicitly. Comments-per-thread also paginate, but >50 comments
-  // on one review thread is rare; if we ever hit it we'll see
-  // hasNextPage=true and add inner pagination then. (Today no
-  // observed thread exceeds 10 comments — round 3 of #106 was the
-  // worst at 8.)
-  const all = [];
+// Inner pagination for one specific thread's comment connection. The
+// outer query handed us the thread's relay `id`; we request additional
+// comment pages until hasNextPage is false.
+const THREAD_COMMENTS_QUERY = `
+  query($threadId: ID!, $commentCursor: String) {
+    node(id: $threadId) {
+      ... on PullRequestReviewThread {
+        comments(first: 50, after: $commentCursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            databaseId
+            author { login }
+            path
+            body
+            createdAt
+            line
+            originalLine
+            url
+          }
+        }
+      }
+    }
+  }
+`;
+
+function fetchAdditionalThreadComments(threadId) {
+  // Called when an outer-query thread reported comments.pageInfo.hasNextPage.
+  // Returns the FULL list of comments past the first 50.
+  const extra = [];
   let cursor = null;
-  let safetyCounter = 0;
-  // Hard cap: 20 page fetches = up to 1000 review threads. A PR with
-  // more review threads than that has bigger problems than this
-  // script.
-  while (safetyCounter < 20) {
-    safetyCounter += 1;
+  let safety = 0;
+  // 20 inner pages × 50 comments = 1000 comments per thread. Anything
+  // beyond that exits the loop to avoid runaway paging.
+  while (safety < 20) {
+    safety += 1;
     const args = [
       "api",
       "graphql",
       "-f",
-      `query=${GRAPHQL_QUERY}`,
+      `query=${THREAD_COMMENTS_QUERY}`,
+      "-F",
+      `threadId=${threadId}`
+    ];
+    if (cursor) {
+      args.push("-F", `commentCursor=${cursor}`);
+    }
+    const response = ghJson(args);
+    const conn = response?.data?.node?.comments;
+    if (!conn) break;
+    extra.push(...conn.nodes);
+    if (!conn.pageInfo.hasNextPage) break;
+    cursor = conn.pageInfo.endCursor;
+  }
+  return extra;
+}
+
+function fetchReviewThreads() {
+  // Outer pagination: GitHub caps reviewThreads at 100/page. We use 50.
+  // For each thread, if the inner comments connection has more pages,
+  // call fetchAdditionalThreadComments() to follow them — otherwise
+  // the latest-commenter check could read stale data and pr:nits would
+  // miss the most recent reply.
+  const all = [];
+  let cursor = null;
+  let safety = 0;
+  // Hard cap: 20 outer pages = up to 1000 review threads. A PR with
+  // more review threads than that has bigger problems than this script.
+  while (safety < 20) {
+    safety += 1;
+    const args = [
+      "api",
+      "graphql",
+      "-f",
+      `query=${THREADS_QUERY}`,
       "-F",
       `owner=${repoOwner}`,
       "-F",
@@ -112,6 +175,19 @@ function fetchReviewThreads() {
     const response = ghJson(args);
     const reviewThreads = response?.data?.repository?.pullRequest?.reviewThreads;
     if (!reviewThreads) break;
+
+    // For each thread on this outer page, fill in any missing comments
+    // via the inner-pagination follow-up. Mutating each node so the
+    // caller sees one complete tree.
+    for (const node of reviewThreads.nodes) {
+      const inner = node?.comments;
+      if (inner?.pageInfo?.hasNextPage && node?.id) {
+        const extra = fetchAdditionalThreadComments(node.id);
+        inner.nodes = [...(inner.nodes || []), ...extra];
+        inner.pageInfo.hasNextPage = false;
+      }
+    }
+
     all.push(...reviewThreads.nodes);
     if (!reviewThreads.pageInfo.hasNextPage) break;
     cursor = reviewThreads.pageInfo.endCursor;
@@ -119,14 +195,19 @@ function fetchReviewThreads() {
   return all;
 }
 
-// Normalize a GraphQL review-thread comment to the shape the
-// existing helpers expect (REST-style `user.login`, `id`,
-// `original_line`, `created_at`, `html_url`). Keeps
-// `listActionableThreads` and `formatCommentSummary` callable
-// without API changes.
+// Normalize a GraphQL review-thread comment to the shape the existing
+// helpers expect (REST-style `user.login`, `id`, `original_line`,
+// `created_at`, `html_url`). Keeps `listActionableThreads` and
+// `formatCommentSummary` callable without API changes.
+//
+// `id` falls back from databaseId (the historical REST int id) to the
+// relay `id` (always non-null) when GitHub returns null for databaseId.
+// Copilot flagged the unguarded databaseId on PR #110 — in practice
+// every real comment has a non-null databaseId, but defensive default
+// is cheap.
 function normalizeComment(comment) {
   return {
-    id: comment.databaseId,
+    id: comment.databaseId ?? comment.id ?? null,
     user: comment.author ? { login: comment.author.login } : null,
     path: comment.path,
     body: comment.body,
@@ -139,14 +220,16 @@ function normalizeComment(comment) {
 
 function buildThreadsFromGraphQL(reviewThreadNodes) {
   // Output shape matches what `buildReviewThreads` produced for the
-  // REST path: a Map keyed by root-comment databaseId, with values
-  // `{ root, replies, isResolved }`. The isResolved field is new
-  // and is consumed by `listActionableThreads` to filter out
-  // already-resolved threads.
+  // REST path: a Map with `{ root, replies, isResolved }` values. The
+  // KEY is now the thread's relay `id` (always non-null), not the
+  // root comment's databaseId — the latter is technically nullable
+  // in GitHub's schema and would risk collapsing multiple threads
+  // under a `null` key. Codex/Copilot caught this on PR #110.
   const threads = new Map();
   for (const node of reviewThreadNodes) {
     const comments = node?.comments?.nodes;
     if (!Array.isArray(comments) || comments.length === 0) continue;
+    if (!node.id) continue; // defensive — relay id should always exist
     const normalized = comments
       .slice()
       .sort(
@@ -154,7 +237,7 @@ function buildThreadsFromGraphQL(reviewThreadNodes) {
       )
       .map(normalizeComment);
     const [root, ...replies] = normalized;
-    threads.set(root.id, {
+    threads.set(node.id, {
       root,
       replies,
       isResolved: Boolean(node.isResolved)

--- a/scripts/pr-nits-report.js
+++ b/scripts/pr-nits-report.js
@@ -2,7 +2,6 @@
 
 const { execFileSync } = require("node:child_process");
 const {
-  buildReviewThreads,
   listActionableThreads
 } = require("./lib/pr-review-utils");
 
@@ -40,19 +39,135 @@ if (!prRaw || !/^\d+$/.test(prRaw)) {
 }
 
 const prNumber = Number(prRaw);
-const repo = ghJson(["repo", "view", "--json", "nameWithOwner"]).nameWithOwner;
+const repoFullName = ghJson(["repo", "view", "--json", "nameWithOwner"]).nameWithOwner;
+const [repoOwner, repoName] = repoFullName.split("/");
 const me = ghText(["api", "user", "--jq", ".login"]);
 
-const comments = ghJson([
-  "api",
-  `repos/${repo}/pulls/${prNumber}/comments`,
-  "--paginate"
-]);
+// Fetch via GraphQL `reviewThreads` so we can honor the `isResolved`
+// flag set by the GitHub UI (or by us via `resolveReviewThread`). The
+// older REST `/pulls/N/comments` endpoint omits this — meaning a
+// bot-reviewer ack that resolves a thread in the UI looked
+// "unresolved" to this script, and pr:nits flagged threads we had
+// already finished with. See the follow-up task spawned from PR #109.
+const GRAPHQL_QUERY = `
+  query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String, $commentCursor: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 50, after: $threadCursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            comments(first: 50, after: $commentCursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                databaseId
+                author { login }
+                path
+                body
+                createdAt
+                line
+                originalLine
+                url
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
 
-const threads = buildReviewThreads(comments);
+function fetchReviewThreads() {
+  // Pagination: GitHub caps reviewThreads at 100/page. We use 50 to
+  // stay well clear of the per-call point budget and paginate
+  // explicitly. Comments-per-thread also paginate, but >50 comments
+  // on one review thread is rare; if we ever hit it we'll see
+  // hasNextPage=true and add inner pagination then. (Today no
+  // observed thread exceeds 10 comments — round 3 of #106 was the
+  // worst at 8.)
+  const all = [];
+  let cursor = null;
+  let safetyCounter = 0;
+  // Hard cap: 20 page fetches = up to 1000 review threads. A PR with
+  // more review threads than that has bigger problems than this
+  // script.
+  while (safetyCounter < 20) {
+    safetyCounter += 1;
+    const args = [
+      "api",
+      "graphql",
+      "-f",
+      `query=${GRAPHQL_QUERY}`,
+      "-F",
+      `owner=${repoOwner}`,
+      "-F",
+      `name=${repoName}`,
+      "-F",
+      `pr=${prNumber}`
+    ];
+    if (cursor) {
+      args.push("-F", `threadCursor=${cursor}`);
+    }
+    const response = ghJson(args);
+    const reviewThreads = response?.data?.repository?.pullRequest?.reviewThreads;
+    if (!reviewThreads) break;
+    all.push(...reviewThreads.nodes);
+    if (!reviewThreads.pageInfo.hasNextPage) break;
+    cursor = reviewThreads.pageInfo.endCursor;
+  }
+  return all;
+}
+
+// Normalize a GraphQL review-thread comment to the shape the
+// existing helpers expect (REST-style `user.login`, `id`,
+// `original_line`, `created_at`, `html_url`). Keeps
+// `listActionableThreads` and `formatCommentSummary` callable
+// without API changes.
+function normalizeComment(comment) {
+  return {
+    id: comment.databaseId,
+    user: comment.author ? { login: comment.author.login } : null,
+    path: comment.path,
+    body: comment.body,
+    line: comment.line,
+    original_line: comment.originalLine,
+    html_url: comment.url,
+    created_at: comment.createdAt
+  };
+}
+
+function buildThreadsFromGraphQL(reviewThreadNodes) {
+  // Output shape matches what `buildReviewThreads` produced for the
+  // REST path: a Map keyed by root-comment databaseId, with values
+  // `{ root, replies, isResolved }`. The isResolved field is new
+  // and is consumed by `listActionableThreads` to filter out
+  // already-resolved threads.
+  const threads = new Map();
+  for (const node of reviewThreadNodes) {
+    const comments = node?.comments?.nodes;
+    if (!Array.isArray(comments) || comments.length === 0) continue;
+    const normalized = comments
+      .slice()
+      .sort(
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      )
+      .map(normalizeComment);
+    const [root, ...replies] = normalized;
+    threads.set(root.id, {
+      root,
+      replies,
+      isResolved: Boolean(node.isResolved)
+    });
+  }
+  return threads;
+}
+
+const reviewThreadNodes = fetchReviewThreads();
+const threads = buildThreadsFromGraphQL(reviewThreadNodes);
 const actionable = listActionableThreads(threads, me);
 
-console.log(`PR #${prNumber} nit report for ${repo}`);
+console.log(`PR #${prNumber} nit report for ${repoFullName}`);
 console.log(`Open threads requiring repo-owner response: ${actionable.length}`);
 
 if (!actionable.length) {

--- a/tests/pr-review-utils.test.js
+++ b/tests/pr-review-utils.test.js
@@ -1,0 +1,151 @@
+"use strict";
+
+// Unit tests for scripts/lib/pr-review-utils.js.
+//
+// Spawned from PR #109 follow-up: the previous implementation only
+// checked "is the latest commenter me?" and missed GitHub's
+// `isResolved` flag, causing pr:nits to flag threads that had
+// already been resolved by a bot reviewer's ack. These tests pin
+// the filtering contract.
+
+const {
+  buildReviewThreads,
+  listActionableThreads
+} = require("../scripts/lib/pr-review-utils");
+
+function comment({ id, replyTo = null, login, createdAt, body = "" }) {
+  return {
+    id,
+    in_reply_to_id: replyTo,
+    user: { login },
+    body,
+    path: "tests/example.test.js",
+    line: 10,
+    original_line: 10,
+    html_url: `https://github.com/example/repo/pull/1#discussion_r${id}`,
+    created_at: createdAt
+  };
+}
+
+describe("listActionableThreads: latest-commenter filter (legacy REST behavior)", () => {
+  test("flags threads where the latest commenter is NOT the viewer", () => {
+    const threads = buildReviewThreads([
+      comment({ id: 1, login: "bot", createdAt: "2026-05-10T10:00:00Z" }),
+      comment({ id: 2, replyTo: 1, login: "viewer", createdAt: "2026-05-10T10:05:00Z" }),
+      comment({ id: 3, replyTo: 1, login: "bot", createdAt: "2026-05-10T10:10:00Z" })
+    ]);
+    const actionable = listActionableThreads(threads, "viewer");
+    expect(actionable).toHaveLength(1);
+    expect(actionable[0].author).toBe("bot");
+  });
+
+  test("skips threads where the viewer is the latest commenter", () => {
+    const threads = buildReviewThreads([
+      comment({ id: 1, login: "bot", createdAt: "2026-05-10T10:00:00Z" }),
+      comment({ id: 2, replyTo: 1, login: "viewer", createdAt: "2026-05-10T10:05:00Z" })
+    ]);
+    expect(listActionableThreads(threads, "viewer")).toEqual([]);
+  });
+
+  test("REST input without isResolved still flags (backward compat)", () => {
+    // buildReviewThreads produces entries without isResolved. The
+    // listActionableThreads filter must treat missing/undefined
+    // isResolved as falsy → continue to legacy behavior.
+    const threads = buildReviewThreads([
+      comment({ id: 1, login: "bot", createdAt: "2026-05-10T10:00:00Z" })
+    ]);
+    expect(threads.get(1).isResolved).toBeUndefined();
+    const actionable = listActionableThreads(threads, "viewer");
+    expect(actionable).toHaveLength(1);
+  });
+});
+
+describe("listActionableThreads: isResolved filter (new GraphQL behavior)", () => {
+  function graphqlThread({ rootId, comments, isResolved }) {
+    const sorted = [...comments].sort(
+      (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    );
+    const [root, ...replies] = sorted;
+    return { rootId, value: { root, replies, isResolved } };
+  }
+
+  function buildMap(threadList) {
+    const map = new Map();
+    for (const t of threadList) map.set(t.rootId, t.value);
+    return map;
+  }
+
+  test("skips threads with isResolved=true even when the latest commenter is a bot", () => {
+    // Real-world example: CodeRabbit replies "thanks for the fix"
+    // and marks the thread resolved in the UI. Before this fix
+    // pr:nits flagged it; after, the GraphQL response carries
+    // isResolved=true and listActionableThreads skips it.
+    const threads = buildMap([
+      graphqlThread({
+        rootId: 1,
+        isResolved: true,
+        comments: [
+          comment({ id: 1, login: "bot", createdAt: "2026-05-10T10:00:00Z" }),
+          comment({ id: 2, replyTo: 1, login: "viewer", createdAt: "2026-05-10T10:05:00Z", body: "Addressed in abc123" }),
+          comment({ id: 3, replyTo: 1, login: "bot", createdAt: "2026-05-10T10:10:00Z", body: "Confirmed — good fix" })
+        ]
+      })
+    ]);
+    expect(listActionableThreads(threads, "viewer")).toEqual([]);
+  });
+
+  test("isResolved=false threads still flagged by latest-commenter rule", () => {
+    const threads = buildMap([
+      graphqlThread({
+        rootId: 1,
+        isResolved: false,
+        comments: [
+          comment({ id: 1, login: "bot", createdAt: "2026-05-10T10:00:00Z" })
+        ]
+      })
+    ]);
+    const actionable = listActionableThreads(threads, "viewer");
+    expect(actionable).toHaveLength(1);
+    expect(actionable[0].author).toBe("bot");
+  });
+
+  test("isResolved=false but viewer is latest → still skipped (legacy rule applies)", () => {
+    const threads = buildMap([
+      graphqlThread({
+        rootId: 1,
+        isResolved: false,
+        comments: [
+          comment({ id: 1, login: "bot", createdAt: "2026-05-10T10:00:00Z" }),
+          comment({ id: 2, replyTo: 1, login: "viewer", createdAt: "2026-05-10T10:05:00Z" })
+        ]
+      })
+    ]);
+    expect(listActionableThreads(threads, "viewer")).toEqual([]);
+  });
+
+  test("mixed thread set: only the unresolved bot-latest one is flagged", () => {
+    const threads = buildMap([
+      graphqlThread({
+        rootId: 1,
+        isResolved: true,
+        comments: [comment({ id: 1, login: "bot", createdAt: "2026-05-10T10:00:00Z" })]
+      }),
+      graphqlThread({
+        rootId: 2,
+        isResolved: false,
+        comments: [comment({ id: 2, login: "bot", createdAt: "2026-05-10T10:00:00Z" })]
+      }),
+      graphqlThread({
+        rootId: 3,
+        isResolved: false,
+        comments: [
+          comment({ id: 3, login: "bot", createdAt: "2026-05-10T10:00:00Z" }),
+          comment({ id: 4, replyTo: 3, login: "viewer", createdAt: "2026-05-10T10:05:00Z" })
+        ]
+      })
+    ]);
+    const actionable = listActionableThreads(threads, "viewer");
+    expect(actionable).toHaveLength(1);
+    expect(actionable[0].id).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/pr-nits-report.js` previously over-reported "open threads" because it fetched via REST `/pulls/N/comments` (no `isResolved` field) and `listActionableThreads` only checked latest-commenter. When a bot reviewer (CodeRabbit) replied with a positive ack and marked the thread resolved in the UI, pr:nits kept flagging it. Reproduced on PR #109: 4 threads were `isResolved: true` but pr:nits reported 4 open.

Fix: switch to GraphQL's `reviewThreads` (exposes `isResolved`), normalize comments to the existing REST-shape so `listActionableThreads`/`formatCommentSummary` stay unchanged, and short-circuit on `isResolved: true` in `listActionableThreads`. The missing-isResolved (REST-shaped) input path still works because `undefined` is falsy.

Spawned as a follow-up task from PR #109 round 3.

## Test plan
- [x] `npm run pr:nits -- --pr 109` drops from 4 → 0
- [x] `npm run pr:nits -- --pr 106` returns 0 (all 19 threads are isResolved=true)
- [x] New unit tests pin every filter branch — legacy-latest-commenter, isResolved=true override, isResolved=false + bot-latest, viewer-latest skips, mixed-set isolation
- [x] `npm run check` green: 743 tests, 42 suites
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved review threads are now properly excluded from PR review reports, ensuring only actionable items are highlighted.

* **Tests**
  * Added comprehensive test coverage for review thread filtering logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/110)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->