### PR TITLE
test(concurrency): C6 — extend fixture to remaining stores (closes #132)

### DIFF
--- a/tests/admin-jobs-store.concurrency.test.js
+++ b/tests/admin-jobs-store.concurrency.test.js
@@ -1,0 +1,220 @@
+"use strict";
+
+// Concurrency-stress tests for lib/admin-jobs-store.js.
+//
+// AdminJobsStore serializes via per-store `writeQueue` (`#enqueueWrite`).
+// What this file pins:
+//
+//   1. Parallel `enqueueProviderImportJob` calls — every job lands;
+//      ids are unique; no lost writes.
+//   2. SINGLE-CLAIM invariant: N parallel `claimNextQueuedJob` against
+//      a queue of M < N jobs returns at most M distinct jobs; the
+//      remaining (N - M) callers return null (no claim to make). No
+//      job is claimed twice.
+//   3. Parallel `markSucceeded` / `markFailed` on different running
+//      jobs converges; each terminal commit lands.
+//
+// Filed as #132 (Epic C: Test Coverage & Fault Injection).
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const { AdminJobsStore } = require("../lib/admin-jobs-store");
+
+const { runConcurrencyScenario } = require("./helpers/concurrency-fixture");
+
+function tempFilePath() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-admin-jobs-concurrency-"));
+  return { dir, filePath: path.join(dir, "admin-jobs.json") };
+}
+
+function frozenNow(iso = "2026-05-11T00:00:00.000Z") {
+  return () => new Date(iso);
+}
+
+async function cleanupDir(dir) {
+  await fsp.rm(dir, { recursive: true, force: true });
+}
+
+function sampleRequest(i) {
+  return {
+    provider: "test-provider",
+    language: "en",
+    variant: `variant-${i}`
+  };
+}
+
+describe("admin-jobs-store: writeQueue serializes parallel enqueue", () => {
+  test("N parallel enqueueProviderImportJob: every job persists with a unique id", async () => {
+    await runConcurrencyScenario({
+      name: "admin-jobs-store: parallel enqueueProviderImportJob",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new AdminJobsStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        return { store, dir };
+      },
+      operation: async ({ store }, i) =>
+        store.enqueueProviderImportJob(sampleRequest(i)),
+      invariants: [
+        async ({ store }, { results, parallelism }) => {
+          const ids = new Set(results.map((j) => j.id));
+          if (ids.size !== parallelism) {
+            throw new Error(
+              `expected ${parallelism} unique job ids from results; got ${ids.size}`
+            );
+          }
+          const snap = await store.getSnapshot();
+          const storeIds = new Set(snap.jobs.map((j) => j.id));
+          for (const id of ids) {
+            if (!storeIds.has(id)) {
+              throw new Error(`job ${id} returned from enqueue() but missing from store snapshot`);
+            }
+          }
+          // Total in store should equal parallelism (no extras, no losses).
+          if (snap.jobs.length !== parallelism) {
+            throw new Error(
+              `expected ${parallelism} jobs in store; got ${snap.jobs.length}`
+            );
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});
+
+describe("admin-jobs-store: claimNextQueuedJob is exclusive", () => {
+  test("N parallel claims against M queued jobs: at most M distinct claims, rest return null", async () => {
+    // The single-claim invariant: claimNextQueuedJob serializes
+    // through #enqueueWrite, so each commit sees the prior commits'
+    // effects. The first M callers each claim a different queued
+    // job; the rest see an empty queue and return null. No job is
+    // claimed twice.
+    const M_JOBS = 5;
+    const PARALLEL_CLAIMS = 20;
+    await runConcurrencyScenario({
+      name: "admin-jobs-store: parallel claimNextQueuedJob",
+      parallelism: PARALLEL_CLAIMS,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new AdminJobsStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        // Seed M_JOBS queued jobs.
+        for (let i = 0; i < M_JOBS; i += 1) {
+          await store.enqueueProviderImportJob(sampleRequest(i));
+        }
+        return { store, dir };
+      },
+      operation: async ({ store }) => store.claimNextQueuedJob(),
+      invariants: [
+        async ({ store }, { results }) => {
+          const claimed = results.filter((r) => r !== null);
+          const nulls = results.filter((r) => r === null);
+          if (claimed.length !== M_JOBS) {
+            throw new Error(
+              `expected ${M_JOBS} claims; got ${claimed.length} ` +
+                `(at most-once invariant broken)`
+            );
+          }
+          if (nulls.length !== PARALLEL_CLAIMS - M_JOBS) {
+            throw new Error(
+              `expected ${PARALLEL_CLAIMS - M_JOBS} null returns; got ${nulls.length}`
+            );
+          }
+          // Each claim is a unique job (no double-claim).
+          const claimedIds = new Set(claimed.map((j) => j.id));
+          if (claimedIds.size !== M_JOBS) {
+            throw new Error(
+              `expected ${M_JOBS} unique claimed ids; got ${claimedIds.size} ` +
+                `(same job claimed twice — exclusivity broken)`
+            );
+          }
+          // Every claimed job has status="running".
+          for (const job of claimed) {
+            if (job.status !== "running") {
+              throw new Error(`claimed job ${job.id} has unexpected status ${job.status}`);
+            }
+          }
+          // Store snapshot: M_JOBS running, 0 queued.
+          const snap = await store.getSnapshot();
+          const running = snap.jobs.filter((j) => j.status === "running");
+          const queued = snap.jobs.filter((j) => j.status === "queued");
+          if (running.length !== M_JOBS) {
+            throw new Error(
+              `expected ${M_JOBS} running jobs in store; got ${running.length}`
+            );
+          }
+          if (queued.length !== 0) {
+            throw new Error(
+              `expected 0 queued jobs after exhausting via parallel claims; got ${queued.length}`
+            );
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});
+
+describe("admin-jobs-store: parallel terminal updates", () => {
+  test("parallel markSucceeded on the same running job is idempotent under the writeQueue", async () => {
+    // Test the per-job terminal-state invariant: once succeeded,
+    // subsequent markSucceeded calls re-stamp updatedAt but don't
+    // corrupt the job. With writeQueue serialization, each call
+    // sees the previous one's state.
+    await runConcurrencyScenario({
+      name: "admin-jobs-store: parallel markSucceeded same job",
+      parallelism: 10,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new AdminJobsStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        const enqueued = await store.enqueueProviderImportJob(sampleRequest(0));
+        // Claim so the job is in "running" state and markSucceeded
+        // will accept it.
+        await store.claimNextQueuedJob();
+        return { store, jobId: enqueued.id, dir };
+      },
+      operation: async ({ store, jobId }, i) =>
+        store.markSucceeded(jobId, { artifacts: { iteration: i } }),
+      acceptableErrors: ["INVALID_JOB_STATE"],
+      // First call succeeds; subsequent ones may reject because the job
+      // is already in a terminal state (not "running"). Either path
+      // is fine — we just want no corruption.
+      expectedSuccesses: (summary) => summary.parallelism - summary.errors.length,
+      invariants: [
+        async ({ store, jobId }) => {
+          const snap = await store.getSnapshot();
+          const matches = snap.jobs.filter((j) => j.id === jobId);
+          if (matches.length !== 1) {
+            throw new Error(`expected exactly 1 job row; got ${matches.length}`);
+          }
+          if (matches[0].status !== "succeeded") {
+            throw new Error(`expected status="succeeded"; got ${matches[0].status}`);
+          }
+          // finishedAt and updatedAt must be set.
+          if (!matches[0].finishedAt) {
+            throw new Error("finishedAt not set after succeeded");
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});

--- a/tests/admin-jobs-store.concurrency.test.js
+++ b/tests/admin-jobs-store.concurrency.test.js
@@ -154,7 +154,13 @@ describe("admin-jobs-store: claimNextQueuedJob is exclusive", () => {
               throw new Error(`claimed job ${job.id} has unexpected status ${job.status}`);
             }
           }
-          // (5) Store snapshot: SEEDED_JOBS running, 0 queued.
+          // (5) Store snapshot: `expectedClaimed` running, the rest
+          // (SEEDED_JOBS - expectedClaimed) still queued. When
+          // parallelism >= SEEDED_JOBS this collapses to "all
+          // running, 0 queued"; when env CONCURRENCY_PARALLELISM
+          // is set below SEEDED_JOBS the unclaimed remainder
+          // stays queued (Codex P2 + Copilot caught the prior
+          // hardcoded `queued.length === 0` on PR #134 round 2).
           const snap = await store.getSnapshot();
           const running = snap.jobs.filter((j) => j.status === "running");
           const queued = snap.jobs.filter((j) => j.status === "queued");
@@ -163,9 +169,10 @@ describe("admin-jobs-store: claimNextQueuedJob is exclusive", () => {
               `expected ${expectedClaimed} running jobs in store; got ${running.length}`
             );
           }
-          if (queued.length !== 0) {
+          const expectedQueued = SEEDED_JOBS - expectedClaimed;
+          if (queued.length !== expectedQueued) {
             throw new Error(
-              `expected 0 queued jobs after exhausting via parallel claims; got ${queued.length}`
+              `expected ${expectedQueued} queued jobs after parallel claims; got ${queued.length}`
             );
           }
         }

--- a/tests/admin-jobs-store.concurrency.test.js
+++ b/tests/admin-jobs-store.concurrency.test.js
@@ -98,11 +98,14 @@ describe("admin-jobs-store: claimNextQueuedJob is exclusive", () => {
     // effects. The first M callers each claim a different queued
     // job; the rest see an empty queue and return null. No job is
     // claimed twice.
-    const M_JOBS = 5;
-    const PARALLEL_CLAIMS = 20;
+    // Seed M jobs, fire parallel claims. Some claimers get a job;
+    // the rest get null. The invariant derives expected counts from
+    // store state so it's tolerant of env-driven parallelism
+    // changes (CONCURRENCY_PARALLELISM=200 just adds more nulls).
+    const SEEDED_JOBS = 5;
     await runConcurrencyScenario({
       name: "admin-jobs-store: parallel claimNextQueuedJob",
-      parallelism: PARALLEL_CLAIMS,
+      parallelism: 20,
       setup: async () => {
         const { dir, filePath } = tempFilePath();
         const store = new AdminJobsStore({
@@ -111,49 +114,53 @@ describe("admin-jobs-store: claimNextQueuedJob is exclusive", () => {
           logger: { warn: () => {}, error: () => {} }
         });
         await store.load();
-        // Seed M_JOBS queued jobs.
-        for (let i = 0; i < M_JOBS; i += 1) {
+        for (let i = 0; i < SEEDED_JOBS; i += 1) {
           await store.enqueueProviderImportJob(sampleRequest(i));
         }
         return { store, dir };
       },
       operation: async ({ store }) => store.claimNextQueuedJob(),
       invariants: [
-        async ({ store }, { results }) => {
+        async ({ store }, { results, parallelism }) => {
           const claimed = results.filter((r) => r !== null);
           const nulls = results.filter((r) => r === null);
-          if (claimed.length !== M_JOBS) {
+          // (1) Every caller got either a job or null.
+          if (nulls.length + claimed.length !== parallelism) {
             throw new Error(
-              `expected ${M_JOBS} claims; got ${claimed.length} ` +
-                `(at most-once invariant broken)`
+              `null + claimed (${nulls.length} + ${claimed.length}) != parallelism (${parallelism})`
             );
           }
-          if (nulls.length !== PARALLEL_CLAIMS - M_JOBS) {
+          // (2) Claim count equals min(SEEDED_JOBS, parallelism) —
+          // every seeded job got claimed (no leaks), and we didn't
+          // claim more than were seeded.
+          const expectedClaimed = Math.min(SEEDED_JOBS, parallelism);
+          if (claimed.length !== expectedClaimed) {
             throw new Error(
-              `expected ${PARALLEL_CLAIMS - M_JOBS} null returns; got ${nulls.length}`
+              `expected ${expectedClaimed} claims; got ${claimed.length} ` +
+                `(exclusivity broken or job not surfaced)`
             );
           }
-          // Each claim is a unique job (no double-claim).
+          // (3) Each claim is a unique job (no double-claim).
           const claimedIds = new Set(claimed.map((j) => j.id));
-          if (claimedIds.size !== M_JOBS) {
+          if (claimedIds.size !== claimed.length) {
             throw new Error(
-              `expected ${M_JOBS} unique claimed ids; got ${claimedIds.size} ` +
+              `expected ${claimed.length} unique claimed ids; got ${claimedIds.size} ` +
                 `(same job claimed twice — exclusivity broken)`
             );
           }
-          // Every claimed job has status="running".
+          // (4) Every claim has status="running".
           for (const job of claimed) {
             if (job.status !== "running") {
               throw new Error(`claimed job ${job.id} has unexpected status ${job.status}`);
             }
           }
-          // Store snapshot: M_JOBS running, 0 queued.
+          // (5) Store snapshot: SEEDED_JOBS running, 0 queued.
           const snap = await store.getSnapshot();
           const running = snap.jobs.filter((j) => j.status === "running");
           const queued = snap.jobs.filter((j) => j.status === "queued");
-          if (running.length !== M_JOBS) {
+          if (running.length !== expectedClaimed) {
             throw new Error(
-              `expected ${M_JOBS} running jobs in store; got ${running.length}`
+              `expected ${expectedClaimed} running jobs in store; got ${running.length}`
             );
           }
           if (queued.length !== 0) {
@@ -169,11 +176,16 @@ describe("admin-jobs-store: claimNextQueuedJob is exclusive", () => {
 });
 
 describe("admin-jobs-store: parallel terminal updates", () => {
-  test("parallel markSucceeded on the same running job is idempotent under the writeQueue", async () => {
-    // Test the per-job terminal-state invariant: once succeeded,
-    // subsequent markSucceeded calls re-stamp updatedAt but don't
-    // corrupt the job. With writeQueue serialization, each call
-    // sees the previous one's state.
+  test("parallel markSucceeded on the same job is idempotent (terminal-state convergence)", async () => {
+    // markSucceeded has no "must be running" precondition — every
+    // call sets status="succeeded" and stamps updatedAt. With
+    // writeQueue serialization, N parallel markSucceeded calls all
+    // succeed and the final state has status=succeeded with a
+    // single updatedAt timestamp (last writer wins). No corruption,
+    // no duplicate rows.
+    //
+    // Copilot caught the prior comment claiming a precondition error
+    // on PR #134 round 1 — corrected here.
     await runConcurrencyScenario({
       name: "admin-jobs-store: parallel markSucceeded same job",
       parallelism: 10,
@@ -186,18 +198,13 @@ describe("admin-jobs-store: parallel terminal updates", () => {
         });
         await store.load();
         const enqueued = await store.enqueueProviderImportJob(sampleRequest(0));
-        // Claim so the job is in "running" state and markSucceeded
-        // will accept it.
+        // Claim once so the job starts as "running"; subsequent
+        // markSucceeded calls all transition to "succeeded".
         await store.claimNextQueuedJob();
         return { store, jobId: enqueued.id, dir };
       },
       operation: async ({ store, jobId }, i) =>
         store.markSucceeded(jobId, { artifacts: { iteration: i } }),
-      acceptableErrors: ["INVALID_JOB_STATE"],
-      // First call succeeds; subsequent ones may reject because the job
-      // is already in a terminal state (not "running"). Either path
-      // is fine — we just want no corruption.
-      expectedSuccesses: (summary) => summary.parallelism - summary.errors.length,
       invariants: [
         async ({ store, jobId }) => {
           const snap = await store.getSnapshot();
@@ -208,7 +215,6 @@ describe("admin-jobs-store: parallel terminal updates", () => {
           if (matches[0].status !== "succeeded") {
             throw new Error(`expected status="succeeded"; got ${matches[0].status}`);
           }
-          // finishedAt and updatedAt must be set.
           if (!matches[0].finishedAt) {
             throw new Error("finishedAt not set after succeeded");
           }

--- a/tests/classes-store.concurrency.test.js
+++ b/tests/classes-store.concurrency.test.js
@@ -137,12 +137,17 @@ describe("classes-store: writeQueue serializes parallel createClass", () => {
 });
 
 describe("classes-store: membership mutations under concurrency", () => {
-  test("parallel addMembers + removeMember on the same class: no half-removed state", async () => {
-    // Seed one class, then alternately add and remove profiles.
-    // Each operation runs under writeQueue; the final state must
-    // be internally consistent.
+  test("parallel addMembers + removeMember on a shared id pool: no half-removed state", async () => {
+    // Codex P2 PR #134 round 1: the prior version added profile-i
+    // for even i and removed profile-i for odd i, so removes always
+    // failed with MEMBER_NOT_FOUND and never actually raced a
+    // successful add. We now seed a SHARED POOL of ids in setup
+    // and both halves operate on that pool — adds may be no-ops
+    // (id already present), removes may succeed OR fail. Either
+    // way the add+remove race is genuinely exercised.
+    const POOL_SIZE = 5; // ids picked deterministically per i
     await runConcurrencyScenario({
-      name: "classes-store: addMembers vs removeMember",
+      name: "classes-store: addMembers vs removeMember (shared pool)",
       parallelism: 20,
       setup: async () => {
         const { dir, filePath } = tempFilePath();
@@ -153,15 +158,21 @@ describe("classes-store: membership mutations under concurrency", () => {
         });
         await store.load();
         const created = await store.createClass("Mixed Class");
+        // Seed all POOL_SIZE ids so initial removes can succeed.
+        await store.addMembers(
+          created.id,
+          Array.from({ length: POOL_SIZE }, (_, k) => makeProfileId(k))
+        );
         return { store, classId: created.id, dir };
       },
       operation: async ({ store, classId }, i) => {
-        const profile = makeProfileId(i);
+        const profile = makeProfileId(i % POOL_SIZE);
         if (i % 2 === 0) {
-          // Add (no-op if already present)
+          // Add: re-add (no-op if still present) or restore after
+          // a prior remove won the race.
           return store.addMembers(classId, [profile]);
         }
-        // Remove may throw MEMBER_NOT_FOUND if never added.
+        // Remove: may succeed (id present) or fail (prior remove won).
         return store.removeMember(classId, profile);
       },
       acceptableErrors: ["MEMBER_NOT_FOUND"],

--- a/tests/classes-store.concurrency.test.js
+++ b/tests/classes-store.concurrency.test.js
@@ -42,17 +42,23 @@ async function cleanupDir(dir) {
 }
 
 // Build a profile id (1-64 chars, no whitespace per profileId rules
-// in the schema).
+// in the schema). Uses `toString()` not `padStart` so the id format
+// scales with i — Copilot caught the prior `padStart(3, "0")` would
+// have broken under env CONCURRENCY_PARALLELISM>=1000.
 function makeProfileId(i) {
-  return `profile-${String(i).padStart(3, "0")}`;
+  return `profile-${i}`;
 }
 
 describe("classes-store: writeQueue serializes parallel createClass", () => {
   test("N parallel createClass with distinct names: every class persists", async () => {
     await runConcurrencyScenario({
       name: "classes-store: parallel createClass (distinct names)",
-      // maxClasses default is 50; well above N.
+      // ClassesStore.DEFAULT_MAX_CLASSES is 200. `parallelismMax`
+      // clamps env stress mode so we don't trip
+      // MAX_CLASSES_REACHED (Copilot caught the wrong cap value
+      // in the prior comment on PR #134 round 1).
       parallelism: 20,
+      parallelismMax: 200,
       setup: async () => {
         const { dir, filePath } = tempFilePath();
         const store = new ClassesStore({
@@ -172,9 +178,9 @@ describe("classes-store: membership mutations under concurrency", () => {
               `duplicate profile ids in member list: ${JSON.stringify(ids)}`
             );
           }
-          // Every id matches the schema pattern (no torn writes).
+          // Every id matches the makeProfileId(i) format (no torn writes).
           for (const id of ids) {
-            if (!/^profile-\d{3}$/.test(id)) {
+            if (!/^profile-\d+$/.test(id)) {
               throw new Error(`malformed profile id in member list: ${id}`);
             }
           }

--- a/tests/classes-store.concurrency.test.js
+++ b/tests/classes-store.concurrency.test.js
@@ -1,0 +1,227 @@
+"use strict";
+
+// Concurrency-stress tests for lib/classes-store.js.
+//
+// ClassesStore serializes via per-store `writeQueue` (`#enqueueWrite`).
+// Same pattern as leaderboard-store and admin-jobs-store: every async
+// mutation chains onto the queue so two parallel writes never clone
+// the same baseline and clobber each other.
+//
+// What this file pins:
+//   1. Parallel `createClass` with distinct names — every class lands;
+//      no lost writes.
+//   2. Parallel `createClass` with the SAME name — exactly one wins;
+//      rest reject with DUPLICATE_NAME atomically (the duplicate
+//      check inside the commit closure must run on the prior-commit
+//      state, not a stale snapshot).
+//   3. Parallel `addMembers` + `removeMember` on the same class — no
+//      half-removed membership; final state is internally consistent.
+//
+// Filed as #132 (Epic C: Test Coverage & Fault Injection).
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const { ClassesStore } = require("../lib/classes-store");
+
+const { runConcurrencyScenario } = require("./helpers/concurrency-fixture");
+
+function tempFilePath() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-classes-concurrency-"));
+  return { dir, filePath: path.join(dir, "classes.json") };
+}
+
+function frozenNow(iso = "2026-05-11T00:00:00.000Z") {
+  return () => new Date(iso);
+}
+
+async function cleanupDir(dir) {
+  await fsp.rm(dir, { recursive: true, force: true });
+}
+
+// Build a profile id (1-64 chars, no whitespace per profileId rules
+// in the schema).
+function makeProfileId(i) {
+  return `profile-${String(i).padStart(3, "0")}`;
+}
+
+describe("classes-store: writeQueue serializes parallel createClass", () => {
+  test("N parallel createClass with distinct names: every class persists", async () => {
+    await runConcurrencyScenario({
+      name: "classes-store: parallel createClass (distinct names)",
+      // maxClasses default is 50; well above N.
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new ClassesStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        return { store, dir };
+      },
+      operation: async ({ store }, i) =>
+        store.createClass(`Class-${String.fromCharCode(65 + (i % 26))}-${i}`),
+      invariants: [
+        async ({ store }, { parallelism }) => {
+          const snap = await store.getSnapshot();
+          if (snap.classes.length !== parallelism) {
+            throw new Error(
+              `expected ${parallelism} classes; got ${snap.classes.length} ` +
+                `(lost-write race — writeQueue is not serializing)`
+            );
+          }
+          // Every id is unique.
+          const ids = new Set(snap.classes.map((c) => c.id));
+          if (ids.size !== parallelism) {
+            throw new Error(`expected ${parallelism} unique ids; got ${ids.size}`);
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+
+  test("N parallel createClass with the SAME name: exactly one wins, rest reject DUPLICATE_NAME", async () => {
+    // The duplicate-name check is inside the commit closure, so
+    // the second-and-later commits see the prior state with the
+    // class already present and reject. Without the writeQueue,
+    // two callers could both observe "no duplicate" and both push.
+    await runConcurrencyScenario({
+      name: "classes-store: parallel createClass (same name)",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new ClassesStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        return { store, dir };
+      },
+      operation: async ({ store }) => store.createClass("Shared Name"),
+      acceptableErrors: ["DUPLICATE_NAME"],
+      expectedSuccesses: 1,
+      invariants: [
+        async ({ store }, { errors, parallelism }) => {
+          if (errors.length !== parallelism - 1) {
+            throw new Error(
+              `expected ${parallelism - 1} losers with DUPLICATE_NAME; got ${errors.length}`
+            );
+          }
+          const snap = await store.getSnapshot();
+          const matches = snap.classes.filter(
+            (c) => c.name.toLowerCase() === "shared name"
+          );
+          if (matches.length !== 1) {
+            throw new Error(
+              `expected exactly 1 class with name "Shared Name"; got ${matches.length} ` +
+                `(duplicate-check race)`
+            );
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});
+
+describe("classes-store: membership mutations under concurrency", () => {
+  test("parallel addMembers + removeMember on the same class: no half-removed state", async () => {
+    // Seed one class, then alternately add and remove profiles.
+    // Each operation runs under writeQueue; the final state must
+    // be internally consistent.
+    await runConcurrencyScenario({
+      name: "classes-store: addMembers vs removeMember",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new ClassesStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        const created = await store.createClass("Mixed Class");
+        return { store, classId: created.id, dir };
+      },
+      operation: async ({ store, classId }, i) => {
+        const profile = makeProfileId(i);
+        if (i % 2 === 0) {
+          // Add (no-op if already present)
+          return store.addMembers(classId, [profile]);
+        }
+        // Remove may throw MEMBER_NOT_FOUND if never added.
+        return store.removeMember(classId, profile);
+      },
+      acceptableErrors: ["MEMBER_NOT_FOUND"],
+      expectedSuccesses: (summary) => summary.parallelism - summary.errors.length,
+      invariants: [
+        async ({ store, classId }) => {
+          const snap = await store.getSnapshot();
+          const cls = snap.classes.find((c) => c.id === classId);
+          if (!cls) throw new Error("class disappeared");
+          // No duplicate profile ids.
+          const ids = cls.memberProfileIds;
+          if (new Set(ids).size !== ids.length) {
+            throw new Error(
+              `duplicate profile ids in member list: ${JSON.stringify(ids)}`
+            );
+          }
+          // Every id matches the schema pattern (no torn writes).
+          for (const id of ids) {
+            if (!/^profile-\d{3}$/.test(id)) {
+              throw new Error(`malformed profile id in member list: ${id}`);
+            }
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});
+
+describe("classes-store: parallel updateClass converges", () => {
+  test("parallel updateClass on the same class: final state has one of the candidate names", async () => {
+    // Same class-of-bug as the challenge-config-store/schedule-store
+    // single-field replace tests: last-writer-wins is visible whether
+    // or not commits are serialized. We pin consistency here
+    // (exactly one class row remains, name matches a candidate); the
+    // strong commit-queue proof for this store lives in the
+    // "parallel createClass (distinct names)" test above.
+    await runConcurrencyScenario({
+      name: "classes-store: parallel updateClass",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new ClassesStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        const created = await store.createClass("Initial Name");
+        return { store, classId: created.id, dir };
+      },
+      operation: async ({ store, classId }, i) =>
+        store.updateClass(classId, { name: `Renamed ${String.fromCharCode(65 + (i % 26))}` }),
+      invariants: [
+        async ({ store, classId }) => {
+          const snap = await store.getSnapshot();
+          const cls = snap.classes.find((c) => c.id === classId);
+          if (!cls) throw new Error("class disappeared");
+          if (!/^Renamed [A-Z]$/.test(cls.name)) {
+            throw new Error(
+              `final name ${JSON.stringify(cls.name)} not one of the parallel-update candidates`
+            );
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});

--- a/tests/data-stores.direct.concurrency.test.js
+++ b/tests/data-stores.direct.concurrency.test.js
@@ -24,11 +24,13 @@ const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
-const nodeCrypto = require("node:crypto");
 
 const { WebhookStore } = require("../lib/webhook-store");
 const { WebhookDeliveryStore } = require("../lib/webhook-delivery-store");
-const { PushSubscriptionStore } = require("../lib/push-subscription-store");
+const {
+  PushSubscriptionStore,
+  endpointHashOf
+} = require("../lib/push-subscription-store");
 
 const { runConcurrencyScenario } = require("./helpers/concurrency-fixture");
 
@@ -142,11 +144,10 @@ describe("push-subscription-store: parallel upsert", () => {
       invariants: [
         async ({ store }) => {
           const snap = await store.getSnapshot();
-          const expectedHash = nodeCrypto
-            .createHash("sha256")
-            .update(fixedEndpoint)
-            .digest("hex")
-            .slice(0, 16);
+          // Use the store's exported helper so this test stays in
+          // sync if the hash algorithm/format ever changes (Copilot
+          // caught the inline re-implementation on PR #134 r1).
+          const expectedHash = endpointHashOf(fixedEndpoint);
           const matches = snap.subscriptions.filter(
             (s) => s.endpointHash === expectedHash
           );

--- a/tests/data-stores.direct.concurrency.test.js
+++ b/tests/data-stores.direct.concurrency.test.js
@@ -1,0 +1,199 @@
+"use strict";
+
+// Direct-store concurrency tests for the three async stores that
+// Phase 3's service-layer tests cover transitively:
+//   - WebhookStore (covered by tests/webhook-service.concurrency.test.js)
+//   - WebhookDeliveryStore (same)
+//   - PushSubscriptionStore (covered by
+//     tests/notification-service.concurrency.test.js)
+//
+// The service tests stress these stores via their producing services;
+// these tests stress the store's own surface API directly so a future
+// caller (e.g. a new admin route) using the store without the service
+// wrapper still has its race invariants pinned.
+//
+// Each store has writeQueue/commitQueue serialization — the invariants
+// are the same as Phase 3's: parallel mutators serialize through the
+// queue; lost-write races would be observable as missing/duplicate
+// rows. We add one heavy-contention test per store to keep the PR
+// scope tight; deeper coverage is a fast follow-up if needed.
+//
+// Filed as #132 (Epic C: Test Coverage & Fault Injection).
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const nodeCrypto = require("node:crypto");
+
+const { WebhookStore } = require("../lib/webhook-store");
+const { WebhookDeliveryStore } = require("../lib/webhook-delivery-store");
+const { PushSubscriptionStore } = require("../lib/push-subscription-store");
+
+const { runConcurrencyScenario } = require("./helpers/concurrency-fixture");
+
+function tempFilePath(name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-direct-concurrency-"));
+  return { dir, filePath: path.join(dir, name) };
+}
+
+async function cleanupDir(dir) {
+  await fsp.rm(dir, { recursive: true, force: true });
+}
+
+function frozenNow(iso = "2026-05-11T00:00:00.000Z") {
+  return () => new Date(iso);
+}
+
+describe("webhook-store: parallel create/update/remove", () => {
+  test("N parallel create with distinct URLs: every subscription persists", async () => {
+    await runConcurrencyScenario({
+      name: "webhook-store: parallel create",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath("webhooks.json");
+        const store = new WebhookStore({ filePath, now: frozenNow() });
+        await store.load();
+        return { store, dir };
+      },
+      operation: async ({ store }, i) =>
+        store.create({
+          url: `https://example.com/hook-${i}`,
+          events: ["daily.posted"],
+          enabled: true
+        }),
+      invariants: [
+        async ({ store }, { results, parallelism }) => {
+          const ids = new Set(results.map((s) => s.id));
+          if (ids.size !== parallelism) {
+            throw new Error(`expected ${parallelism} unique subscription ids; got ${ids.size}`);
+          }
+          const snap = await store.getSnapshot();
+          if (snap.subscriptions.length !== parallelism) {
+            throw new Error(
+              `expected ${parallelism} subscriptions in store; got ${snap.subscriptions.length} ` +
+                `(lost-write race — commitQueue is not serializing)`
+            );
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});
+
+describe("webhook-delivery-store: parallel enqueue", () => {
+  test("N parallel enqueue with distinct events: every delivery row persists", async () => {
+    await runConcurrencyScenario({
+      name: "webhook-delivery-store: parallel enqueue",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath("webhook-deliveries.json");
+        const store = new WebhookDeliveryStore({ filePath, now: frozenNow() });
+        await store.load();
+        return { store, dir };
+      },
+      operation: async ({ store }, i) =>
+        store.enqueue({
+          subscriptionId: "sub-test",
+          event: `daily.posted-${i}`,
+          url: "https://example.com/sink",
+          payload: { i }
+        }),
+      invariants: [
+        async ({ store }, { results, parallelism }) => {
+          const ids = new Set(results.map((d) => d.id));
+          if (ids.size !== parallelism) {
+            throw new Error(`expected ${parallelism} unique delivery ids; got ${ids.size}`);
+          }
+          const snap = await store.getSnapshot();
+          if (snap.deliveries.length !== parallelism) {
+            throw new Error(
+              `expected ${parallelism} deliveries in store; got ${snap.deliveries.length}`
+            );
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});
+
+describe("push-subscription-store: parallel upsert", () => {
+  test("N parallel upsert with the SAME endpoint converges to one row (upsert semantics)", async () => {
+    // Push subscriptions are keyed by endpointHash; concurrent upserts
+    // of the same endpoint should converge to exactly one row, not
+    // duplicate. The atomic re-check inside #commit guarantees this.
+    const fixedEndpoint = "https://push.example.com/abcdef";
+    await runConcurrencyScenario({
+      name: "push-subscription-store: parallel upsert (same endpoint)",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath("push-subscriptions.json");
+        const store = new PushSubscriptionStore({ filePath, now: frozenNow() });
+        await store.load();
+        return { store, dir };
+      },
+      operation: async ({ store }) =>
+        store.upsert({
+          endpoint: fixedEndpoint,
+          keys: { p256dh: "B".repeat(87), auth: "a".repeat(22) }
+        }),
+      invariants: [
+        async ({ store }) => {
+          const snap = await store.getSnapshot();
+          const expectedHash = nodeCrypto
+            .createHash("sha256")
+            .update(fixedEndpoint)
+            .digest("hex")
+            .slice(0, 16);
+          const matches = snap.subscriptions.filter(
+            (s) => s.endpointHash === expectedHash
+          );
+          if (matches.length !== 1) {
+            throw new Error(
+              `expected exactly 1 subscription for the shared endpoint; got ${matches.length} ` +
+                `(duplicate upsert landed)`
+            );
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+
+  test("N parallel upsert with DISTINCT endpoints: every subscription persists", async () => {
+    await runConcurrencyScenario({
+      name: "push-subscription-store: parallel upsert (distinct endpoints)",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath("push-subscriptions.json");
+        const store = new PushSubscriptionStore({ filePath, now: frozenNow() });
+        await store.load();
+        return { store, dir };
+      },
+      operation: async ({ store }, i) =>
+        store.upsert({
+          endpoint: `https://push.example.com/sub-${i}`,
+          keys: { p256dh: "B".repeat(87), auth: "a".repeat(22) }
+        }),
+      invariants: [
+        async ({ store }, { parallelism }) => {
+          const snap = await store.getSnapshot();
+          if (snap.subscriptions.length !== parallelism) {
+            throw new Error(
+              `expected ${parallelism} subscriptions; got ${snap.subscriptions.length} ` +
+                `(lost-write race — commitQueue is not serializing)`
+            );
+          }
+          // All endpointHashes unique.
+          const hashes = new Set(snap.subscriptions.map((s) => s.endpointHash));
+          if (hashes.size !== parallelism) {
+            throw new Error(`expected ${parallelism} unique hashes; got ${hashes.size}`);
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});

--- a/tests/leaderboard-store.concurrency.test.js
+++ b/tests/leaderboard-store.concurrency.test.js
@@ -76,7 +76,11 @@ describe("leaderboard-store: writeQueue serializes parallel mutators", () => {
     await runConcurrencyScenario({
       name: "leaderboard-store: parallel mutate (distinct profiles)",
       parallelism: 20,
-      // Profile cap is 200 by default — well above our N.
+      // LeaderboardStore.DEFAULT_MAX_PROFILES is 50. `parallelismMax`
+      // clamps env stress mode (CONCURRENCY_PARALLELISM=200) so we
+      // don't trip the schema's pruning code path — codex/Copilot
+      // caught this on PR #134 round 1.
+      parallelismMax: 50,
       setup: async () => {
         const { dir, filePath } = tempFilePath();
         const store = new LeaderboardStore({
@@ -146,7 +150,8 @@ describe("leaderboard-store: writeQueue serializes parallel mutators", () => {
                 `(replace is not atomic)`
             );
           }
-          // The profile must be one of the candidates (id like "p-000".."p-019").
+          // The profile must be one of the candidates (id like
+          // "p-a", "p-b", ..., from indexToAlphaSuffix).
           if (!/^p-[a-z]+$/.test(snap.profiles[0].id)) {
             throw new Error(`final profile id ${snap.profiles[0].id} doesn't match expected pattern`);
           }

--- a/tests/leaderboard-store.concurrency.test.js
+++ b/tests/leaderboard-store.concurrency.test.js
@@ -1,0 +1,289 @@
+"use strict";
+
+// Concurrency-stress tests for lib/leaderboard-store.js.
+//
+// LeaderboardStore serializes via per-store `writeQueue` (a Promise
+// chain in `#enqueueWrite`). Without that queue, two near-simultaneous
+// mutations would each clone the same in-memory baseline, apply their
+// own changes, and whichever atomic-rename lands last would silently
+// drop the other.
+//
+// What this file pins:
+//   1. Parallel `mutate` against distinct profile ids — every commit
+//      lands; no lost writes.
+//   2. Parallel `replace` calls converge to a single consistent state
+//      (last-writer-wins on disk; no half-written file).
+//   3. Parallel `mutate` + `deleteProfile` on the same profile — the
+//      delete either wins (profile absent) or loses (profile still
+//      present) but the store never ends up with a half-removed row.
+//   4. Parallel `mutate` on the SAME profile (concurrent score
+//      updates) — every mutation runs in order; the final state
+//      reflects whichever mutation landed last.
+//
+// Filed as #132 (Epic C: Test Coverage & Fault Injection).
+// See `tests/helpers/concurrency-fixture.js` for the harness contract.
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  LeaderboardStore,
+  createEmptyLeaderboardState
+} = require("../lib/leaderboard-store");
+
+const { runConcurrencyScenario } = require("./helpers/concurrency-fixture");
+
+function tempFilePath() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-leaderboard-concurrency-"));
+  return { dir, filePath: path.join(dir, "leaderboard.json") };
+}
+
+function frozenNow(iso = "2026-05-11T00:00:00.000Z") {
+  return () => new Date(iso);
+}
+
+async function cleanupDir(dir) {
+  await fsp.rm(dir, { recursive: true, force: true });
+}
+
+// Build a profile with a schema-valid name. Schema:
+//   `^[A-Za-z][A-Za-z '\\-]*$` (max 24 chars). No digits.
+// We map i to a unique alphabetic-only suffix (a, b, ..., aa, ab, ...).
+function indexToAlphaSuffix(i) {
+  let out = "";
+  let n = i;
+  do {
+    out = String.fromCharCode("a".charCodeAt(0) + (n % 26)) + out;
+    n = Math.floor(n / 26) - 1;
+  } while (n >= 0);
+  return out;
+}
+
+function makeProfile(i) {
+  const suffix = indexToAlphaSuffix(i);
+  return {
+    id: `p-${suffix}`,
+    name: `Tester-${suffix}`,
+    createdAt: "2026-05-11T00:00:00.000Z",
+    updatedAt: "2026-05-11T00:00:00.000Z"
+  };
+}
+
+describe("leaderboard-store: writeQueue serializes parallel mutators", () => {
+  test("N parallel mutate calls adding distinct profiles: all profiles persist", async () => {
+    await runConcurrencyScenario({
+      name: "leaderboard-store: parallel mutate (distinct profiles)",
+      parallelism: 20,
+      // Profile cap is 200 by default — well above our N.
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new LeaderboardStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        return { store, dir };
+      },
+      operation: async ({ store }, i) =>
+        store.mutate((draft) => {
+          draft.profiles.push(makeProfile(i));
+        }),
+      invariants: [
+        async ({ store }, { parallelism }) => {
+          const snap = await store.getSnapshot();
+          if (snap.profiles.length !== parallelism) {
+            throw new Error(
+              `expected ${parallelism} profiles; got ${snap.profiles.length} ` +
+                `(lost-write race — writeQueue is not serializing)`
+            );
+          }
+          // Every parallel index should be represented exactly once.
+          const ids = snap.profiles.map((p) => p.id).sort();
+          const expected = Array.from({ length: parallelism }, (_, i) => makeProfile(i).id).sort();
+          if (JSON.stringify(ids) !== JSON.stringify(expected)) {
+            throw new Error(
+              `profile id set mismatch:\n  got      ${JSON.stringify(ids)}\n  expected ${JSON.stringify(expected)}`
+            );
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+
+  test("parallel replace: consistent final state, no half-written file", async () => {
+    // Each replace overwrites the entire state with a different
+    // profile list. Last-writer-wins is acceptable (no specific
+    // winner is correct); what matters is that the final state
+    // matches one of the candidates exactly (not a torn write).
+    await runConcurrencyScenario({
+      name: "leaderboard-store: parallel replace",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new LeaderboardStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        return { store, filePath, dir };
+      },
+      operation: async ({ store }, i) => {
+        const next = createEmptyLeaderboardState();
+        next.profiles.push(makeProfile(i));
+        return store.replace(next);
+      },
+      invariants: [
+        async ({ store, filePath }) => {
+          const snap = await store.getSnapshot();
+          if (snap.profiles.length !== 1) {
+            throw new Error(
+              `expected exactly 1 profile after parallel replace; got ${snap.profiles.length} ` +
+                `(replace is not atomic)`
+            );
+          }
+          // The profile must be one of the candidates (id like "p-000".."p-019").
+          if (!/^p-[a-z]+$/.test(snap.profiles[0].id)) {
+            throw new Error(`final profile id ${snap.profiles[0].id} doesn't match expected pattern`);
+          }
+          // On-disk content must parse + match the in-memory snapshot
+          // (no partially-written file).
+          const onDisk = JSON.parse(await fsp.readFile(filePath, "utf8"));
+          if (onDisk.profiles.length !== 1 || onDisk.profiles[0].id !== snap.profiles[0].id) {
+            throw new Error("on-disk state diverges from in-memory snapshot");
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});
+
+describe("leaderboard-store: mutate races with deleteProfile", () => {
+  test("parallel mutate + deleteProfile on the same id: no half-removed state", async () => {
+    // Half the operations re-add a profile, half delete it. The
+    // commitQueue ensures every commit sees the previous one's
+    // effect. The final state must be EITHER "profile present"
+    // (last op was a mutate-add) OR "profile absent" (last op was
+    // a delete). It must never be "profile present but corrupt".
+    const TARGET_ID = "target";
+    await runConcurrencyScenario({
+      name: "leaderboard-store: mutate vs deleteProfile",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new LeaderboardStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        await store.mutate((draft) => {
+          draft.profiles.push({
+            id: TARGET_ID,
+            name: "Target",
+            createdAt: "2026-05-11T00:00:00.000Z",
+            updatedAt: "2026-05-11T00:00:00.000Z"
+          });
+        });
+        return { store, dir };
+      },
+      operation: async ({ store }, i) => {
+        if (i % 2 === 0) {
+          // Re-add (or no-op if already present). Use mutate so we
+          // don't trip a single-target constraint.
+          return store.mutate((draft) => {
+            if (!draft.profiles.some((p) => p.id === TARGET_ID)) {
+              draft.profiles.push({
+                id: TARGET_ID,
+                name: "Target",
+                createdAt: "2026-05-11T00:00:00.000Z",
+                updatedAt: "2026-05-11T00:00:00.000Z"
+              });
+            }
+          });
+        }
+        // Delete; may throw PROFILE_NOT_FOUND if prior delete already ran.
+        return store.deleteProfile(TARGET_ID);
+      },
+      acceptableErrors: ["PROFILE_NOT_FOUND"],
+      expectedSuccesses: (summary) => summary.parallelism - summary.errors.length,
+      invariants: [
+        async ({ store }) => {
+          const snap = await store.getSnapshot();
+          const matches = snap.profiles.filter((p) => p.id === TARGET_ID);
+          if (matches.length > 1) {
+            throw new Error(
+              `expected 0 or 1 target rows; got ${matches.length} (duplicate landed)`
+            );
+          }
+          if (matches.length === 1 && matches[0].name !== "Target") {
+            throw new Error(`profile corrupted: name = ${matches[0].name}`);
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});
+
+describe("leaderboard-store: same-profile concurrent mutate", () => {
+  test("N parallel mutate on the same profile name: every commit chains, final consistent", async () => {
+    // Each mutation updates the profile's `name` to a unique value.
+    // Without writeQueue serialization, multiple mutations would
+    // clone the same baseline and one would clobber the others.
+    // With it, the final state has exactly one profile with a name
+    // matching one of the candidates.
+    await runConcurrencyScenario({
+      name: "leaderboard-store: parallel mutate same profile",
+      parallelism: 20,
+      setup: async () => {
+        const { dir, filePath } = tempFilePath();
+        const store = new LeaderboardStore({
+          filePath,
+          now: frozenNow(),
+          logger: { warn: () => {}, error: () => {} }
+        });
+        await store.load();
+        await store.mutate((draft) => {
+          draft.profiles.push({
+            id: "alpha",
+            name: "Initial",
+            createdAt: "2026-05-11T00:00:00.000Z",
+            updatedAt: "2026-05-11T00:00:00.000Z"
+          });
+        });
+        return { store, dir };
+      },
+      operation: async ({ store }, i) =>
+        store.mutate((draft) => {
+          const profile = draft.profiles.find((p) => p.id === "alpha");
+          if (profile) {
+            // Schema allows only letters/spaces/hyphens/quotes in names
+            // (no digits) — alphabetic-only suffix keeps every commit
+            // schema-valid.
+            profile.name = `Updated-${indexToAlphaSuffix(i)}`;
+          }
+        }),
+      invariants: [
+        async ({ store }) => {
+          const snap = await store.getSnapshot();
+          const matches = snap.profiles.filter((p) => p.id === "alpha");
+          if (matches.length !== 1) {
+            throw new Error(`expected exactly 1 profile; got ${matches.length}`);
+          }
+          if (!/^Updated-[a-z]+$/.test(matches[0].name)) {
+            throw new Error(
+              `final name ${JSON.stringify(matches[0].name)} not one of the parallel-update candidates`
+            );
+          }
+        }
+      ],
+      teardown: async ({ dir }) => cleanupDir(dir)
+    });
+  }, 60000);
+});

--- a/tests/sync-stores.concurrency.test.js
+++ b/tests/sync-stores.concurrency.test.js
@@ -1,0 +1,79 @@
+"use strict";
+
+// Concurrency-fixture coverage NOTE for the synchronous-API stores
+// listed in #132 (Epic C6).
+//
+// `app-config-store`, `language-registry-store`, and `vapid-store`
+// expose sync-only APIs:
+//   - `loadSync`, `reloadSync`, `getSnapshotSync`
+//   - `replaceOverridesSync`, `updateSync`, `setLanguageEnabledSync`
+//   - `ensureKeysSync`, `getKeysSync`
+//
+// Sync functions on Node.js's single-threaded event loop never
+// interleave at instruction granularity — once a sync call starts,
+// no other JS runs until it returns. Two callers invoking
+// `replaceOverridesSync` "in parallel" actually serialize at the
+// language level. There is no commit-queue / lock primitive to
+// stress because there is no async window to race.
+//
+// What CAN go wrong (and is covered by example-based unit tests in
+// the per-store test files):
+//   - Caller misuse: two callers reading a snapshot, both mutating
+//     locally, then both calling the sync write — last-writer-wins,
+//     but that's a caller-responsibility pattern, not a concurrency
+//     invariant the store itself promises to enforce.
+//   - File-system races with an external process (out of scope).
+//
+// Verification that the sync-API has no observable race: this file
+// exercises `app-config-store` in a tight loop and confirms there's
+// no observable reentrancy or shared-state bug. The same logic
+// applies to `language-registry-store` and `vapid-store` —
+// reciprocal tests for each are not added because the language-
+// level "no interleave" guarantee is the same, and per-store
+// example-based unit tests in
+// `tests/{language-registry,vapid-store}.test.js` (if added) would
+// cover their specific shape.
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const { AppConfigStore } = require("../lib/app-config-store");
+
+function tempFilePath(name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-sync-concurrency-"));
+  return { dir, filePath: path.join(dir, name) };
+}
+
+async function cleanupDir(dir) {
+  await fsp.rm(dir, { recursive: true, force: true });
+}
+
+describe("sync stores: no concurrency window to stress", () => {
+  test("app-config-store: 100 sequential replaceOverridesSync calls converge to last patch", async () => {
+    const { dir, filePath } = tempFilePath("app-config.json");
+    try {
+      const store = new AppConfigStore({ filePath });
+      store.loadSync();
+      let lastResult;
+      for (let i = 0; i < 100; i += 1) {
+        // leaderboardMaxProfiles is bounded 1..1000 by normalizeLimits.
+        lastResult = store.replaceOverridesSync({
+          limits: { leaderboardMaxProfiles: 100 + i }
+        });
+      }
+      // Final state reflects the last patch (no torn writes, no
+      // observable corruption from 100 sync calls in a row).
+      const expectedMax = 100 + 99;
+      expect(lastResult.overrides.limits.leaderboardMaxProfiles).toBe(expectedMax);
+      // Re-load from disk to confirm the on-disk state matches.
+      const reloaded = new AppConfigStore({ filePath });
+      reloaded.loadSync();
+      const snap = reloaded.getSnapshotSync();
+      expect(snap.overrides.limits.leaderboardMaxProfiles).toBe(expectedMax);
+    } finally {
+      await cleanupDir(dir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds direct-store concurrency coverage for the 9 stores listed in Epic C #132. Split by API style:

**ASYNC stores newly covered** (full fixture-driven suites):
- `tests/leaderboard-store.concurrency.test.js` (4 tests) — parallel `mutate` distinct profiles, parallel `replace`, `mutate` vs `deleteProfile`, same-profile concurrent `mutate`
- `tests/classes-store.concurrency.test.js` (4 tests) — parallel `createClass` distinct names, same-name `DUPLICATE_NAME` race, `addMembers` vs `removeMember`, parallel `updateClass`
- `tests/admin-jobs-store.concurrency.test.js` (3 tests) — parallel `enqueueProviderImportJob`, `claimNextQueuedJob` exclusivity invariant (N callers, M jobs → exactly M distinct claims), parallel `markSucceeded` idempotence on terminal state

**ASYNC stores covered transitively by Phase 3** (also covered directly now for callers that bypass the service wrapper):
- `tests/data-stores.direct.concurrency.test.js` (4 tests) — `webhook-store` parallel create, `webhook-delivery-store` parallel enqueue, `push-subscription-store` parallel `upsert` same-endpoint (single-row convergence) + distinct-endpoints

**SYNC stores** (`app-config`, `language-registry`, `vapid`):
- `tests/sync-stores.concurrency.test.js` (1 test) — `app-config-store` 100× sequential `replaceOverridesSync` converges. File header documents why sync-only APIs have no concurrency window to stress (Node's single-threaded event loop), and notes the same applies to `language-registry-store` and `vapid-store`.

## C epic ordering

Per the memory order C1 → C6 → C3 → C2 → A4/A5 → A/B → C4/C5. C1 (property tests) merged as e202844; this is C6.

## Test plan
- [x] All 16 new tests pass at default parallelism
- [x] `CONCURRENCY_REPEAT=100` across the 4 async suites = 15 fixture-driven tests × 100 iters = 1500 scenario executions, zero flakes (11.5s total runtime)
- [x] Full `npm run check` green: 783 tests, 48 suites (was 767 → +16)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)