### PR TITLE
test(faults): C3 — fault-injection harness for I/O paths (closes #129)

### DIFF
--- a/tests/fs-faulty.test.js
+++ b/tests/fs-faulty.test.js
@@ -1,0 +1,157 @@
+"use strict";
+
+// Self-tests for tests/helpers/fs-faulty.js (#129). Verifies the
+// harness installs/restores spies correctly so downstream store
+// fault-injection tests don't accidentally pass on a broken
+// harness.
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const { installFaultyFs } = require("./helpers/fs-faulty");
+
+function tempPath(name = "test.txt") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-fs-faulty-self-"));
+  return { dir, filePath: path.join(dir, name) };
+}
+
+describe("fs-faulty: install/restore semantics", () => {
+  test("restore() returns fsp.writeFile to the real implementation", async () => {
+    const { dir, filePath } = tempPath();
+    try {
+      const before = fsp.writeFile;
+      const fault = installFaultyFs({
+        writeFile: { failAll: { code: "ENOSPC", message: "synthetic" } }
+      });
+      try {
+        expect(fsp.writeFile).not.toBe(before);
+        await expect(fsp.writeFile(filePath, "hello")).rejects.toMatchObject({
+          code: "ENOSPC",
+          message: "synthetic"
+        });
+      } finally {
+        fault.restore();
+      }
+      // Identity restored; real I/O works again.
+      expect(fsp.writeFile).toBe(before);
+      await fsp.writeFile(filePath, "world", "utf8");
+      expect(fs.readFileSync(filePath, "utf8")).toBe("world");
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("failOnce only fires on the first call; subsequent calls pass through", async () => {
+    const { dir, filePath } = tempPath();
+    const filePath2 = path.join(dir, "second.txt");
+    try {
+      const fault = installFaultyFs({
+        writeFile: { failOnce: { code: "EACCES", message: "blocked" } }
+      });
+      try {
+        await expect(fsp.writeFile(filePath, "x")).rejects.toMatchObject({
+          code: "EACCES"
+        });
+        // Second call passes through to real fsp.writeFile.
+        await fsp.writeFile(filePath2, "y", "utf8");
+        expect(fs.readFileSync(filePath2, "utf8")).toBe("y");
+      } finally {
+        fault.restore();
+      }
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("failIfPath only fails when the path matches", async () => {
+    const { dir } = tempPath();
+    const blockedPath = path.join(dir, "blocked.txt");
+    const allowedPath = path.join(dir, "allowed.txt");
+    try {
+      const fault = installFaultyFs({
+        writeFile: {
+          failIfPath: {
+            match: /blocked\.txt$/,
+            error: { code: "EACCES", message: "blocked path" }
+          }
+        }
+      });
+      try {
+        await expect(fsp.writeFile(blockedPath, "x")).rejects.toMatchObject({
+          code: "EACCES"
+        });
+        // Different path passes through.
+        await fsp.writeFile(allowedPath, "y", "utf8");
+        expect(fs.readFileSync(allowedPath, "utf8")).toBe("y");
+      } finally {
+        fault.restore();
+      }
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("delay slows the call but doesn't fail it", async () => {
+    const { dir, filePath } = tempPath();
+    try {
+      const fault = installFaultyFs({
+        writeFile: { delay: 80 }
+      });
+      try {
+        const start = Date.now();
+        await fsp.writeFile(filePath, "x", "utf8");
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeGreaterThanOrEqual(70); // 80ms with 10ms tolerance for timer skew
+      } finally {
+        fault.restore();
+      }
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("multiple methods can be installed in one call", async () => {
+    const { dir, filePath } = tempPath();
+    try {
+      const fault = installFaultyFs({
+        writeFile: { failAll: { code: "ENOSPC" } },
+        readFile: { failAll: { code: "EACCES" } }
+      });
+      try {
+        await expect(fsp.writeFile(filePath, "x")).rejects.toMatchObject({
+          code: "ENOSPC"
+        });
+        await expect(fsp.readFile(filePath)).rejects.toMatchObject({
+          code: "EACCES"
+        });
+      } finally {
+        fault.restore();
+      }
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("real Error objects pass through unchanged", async () => {
+    const { dir, filePath } = tempPath();
+    try {
+      const original = new Error("custom");
+      original.code = "EBUSY";
+      const fault = installFaultyFs({
+        writeFile: { failAll: original }
+      });
+      try {
+        const caught = await fsp
+          .writeFile(filePath, "x")
+          .catch((err) => err);
+        expect(caught).toBe(original);
+      } finally {
+        fault.restore();
+      }
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/fs-faulty.test.js
+++ b/tests/fs-faulty.test.js
@@ -134,6 +134,50 @@ describe("fs-faulty: install/restore semantics", () => {
     }
   });
 
+  test("rejects null/undefined/non-object input loudly", () => {
+    expect(() => installFaultyFs(null)).toThrow(/expected an object, got null/);
+    expect(() => installFaultyFs(undefined)).toThrow(/expected an object, got undefined/);
+    expect(() => installFaultyFs("oops")).toThrow(/expected an object, got string/);
+  });
+
+  test("rejects unknown method names in the fault config", () => {
+    // Typo'd method name would otherwise silently no-op — Codex/
+    // CodeRabbit asked for explicit validation on PR #135.
+    expect(() => installFaultyFs({ writefile: { failAll: { code: "X" } } }))
+      .toThrow(/unknown method 'writefile'/);
+  });
+
+  test("failIfPath with /g flag stays consistent across calls (no lastIndex drift)", async () => {
+    const { dir } = tempPath();
+    const blockedPath = path.join(dir, "blocked.txt");
+    try {
+      // A `/g`-flagged regex's `.test()` is stateful unless lastIndex
+      // is reset between calls. The harness defensively resets so
+      // multiple operations against the same path consistently
+      // match — without the guard, every other call would unexpectedly
+      // succeed because lastIndex would have rolled past the match.
+      const fault = installFaultyFs({
+        writeFile: {
+          failIfPath: {
+            match: /blocked\.txt$/g,
+            error: { code: "EACCES" }
+          }
+        }
+      });
+      try {
+        for (let i = 0; i < 5; i += 1) {
+          await expect(fsp.writeFile(blockedPath, "x")).rejects.toMatchObject({
+            code: "EACCES"
+          });
+        }
+      } finally {
+        fault.restore();
+      }
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("real Error objects pass through unchanged", async () => {
     const { dir, filePath } = tempPath();
     try {

--- a/tests/fs-faulty.test.js
+++ b/tests/fs-faulty.test.js
@@ -135,9 +135,13 @@ describe("fs-faulty: install/restore semantics", () => {
   });
 
   test("rejects null/undefined/non-object input loudly", () => {
-    expect(() => installFaultyFs(null)).toThrow(/expected an object, got null/);
-    expect(() => installFaultyFs(undefined)).toThrow(/expected an object, got undefined/);
-    expect(() => installFaultyFs("oops")).toThrow(/expected an object, got string/);
+    expect(() => installFaultyFs(null)).toThrow(/expected a plain object, got null/);
+    expect(() => installFaultyFs(undefined)).toThrow(/expected a plain object, got undefined/);
+    expect(() => installFaultyFs("oops")).toThrow(/expected a plain object, got string/);
+    // Arrays pass typeof === "object" but aren't valid configs;
+    // reject explicitly so the error message is clear (Copilot
+    // caught this on PR #135 round 2).
+    expect(() => installFaultyFs([])).toThrow(/expected a plain object, got array/);
   });
 
   test("rejects unknown method names in the fault config", () => {

--- a/tests/helpers/fs-faulty.js
+++ b/tests/helpers/fs-faulty.js
@@ -1,14 +1,19 @@
 "use strict";
 
-// Fault-injection harness for `node:fs/promises` (#129 — Epic C: Test
-// Coverage & Fault Injection).
+// Fault-injection harness for `node:fs/promises` and sync `node:fs`
+// (#129 — Epic C: Test Coverage & Fault Injection).
 //
-// The stores in `lib/` import `fs/promises` directly and don't accept
-// an injectable fs option. To test their behavior under filesystem
-// failures (ENOSPC, EACCES, partial reads, slow disk) without
-// refactoring every store, this helper installs jest spies on the
-// module-level fsp methods. The spies live for the duration of one
-// scenario and are torn down by the returned `restore()`.
+// The stores in `lib/` import `fs`/`fs/promises` directly and don't
+// accept an injectable fs option. To test their behavior under
+// filesystem failures (ENOSPC, EACCES, partial reads, slow disk)
+// without refactoring every store, this helper monkey-patches the
+// module-level methods on the cached node:fs and node:fs/promises
+// exports — replacing each target fn with a closure that consults
+// the fault config, then delegating to the saved original. The
+// patches live for the duration of one scenario and are torn down
+// by the returned `restore()`. (Originally drafted as "jest spies"
+// but we use direct assignment for simpler restore semantics —
+// Copilot caught the doc-vs-code mismatch on PR #135.)
 //
 // Usage:
 //   const fsp = require("node:fs/promises");
@@ -77,6 +82,19 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// `RegExp.prototype.test` advances `lastIndex` when the regex carries
+// the `g` or `y` flag — calling it twice on the same regex with the
+// same input can yield different answers (Copilot caught the
+// statefulness on PR #135). Reset lastIndex defensively before each
+// check so config regexes with sticky/global flags don't make the
+// harness behave inconsistently across calls.
+function matchesPath(regex, target) {
+  if (regex.global || regex.sticky) {
+    regex.lastIndex = 0;
+  }
+  return regex.test(target);
+}
+
 function buildAsyncSpyImpl(originalFn, owner, faultConfig) {
   // Closure-local state so each install gets its own "failOnce" gate.
   let onceFired = false;
@@ -86,7 +104,7 @@ function buildAsyncSpyImpl(originalFn, owner, faultConfig) {
     }
     if (faultConfig.failIfPath) {
       const target = String(args[0] || "");
-      if (faultConfig.failIfPath.match.test(target)) {
+      if (matchesPath(faultConfig.failIfPath.match, target)) {
         throw makeError(faultConfig.failIfPath.error);
       }
     }
@@ -108,7 +126,7 @@ function buildSyncSpyImpl(originalFn, owner, faultConfig) {
   return function spyImpl(...args) {
     if (faultConfig.failIfPath) {
       const target = String(args[0] || "");
-      if (faultConfig.failIfPath.match.test(target)) {
+      if (matchesPath(faultConfig.failIfPath.match, target)) {
         throw makeError(faultConfig.failIfPath.error);
       }
     }
@@ -124,6 +142,29 @@ function buildSyncSpyImpl(originalFn, owner, faultConfig) {
 }
 
 function installFaultyFs(faults) {
+  // Reject obviously bad input loudly rather than letting a typo'd
+  // call (`installFaultyFs()` with no args, or with `null`) fail
+  // deep inside the property loop with a confusing TypeError —
+  // Copilot caught this on PR #135.
+  if (faults === null || typeof faults !== "object") {
+    throw new TypeError(
+      `[fs-faulty] installFaultyFs(faults): expected an object, got ${
+        faults === null ? "null" : typeof faults
+      }`
+    );
+  }
+  // Warn on unknown keys so a typo like `writefile` (lowercase 'f')
+  // doesn't silently no-op — CodeRabbit caught this on PR #135.
+  const allKnown = new Set([...SUPPORTED_METHODS, ...SUPPORTED_SYNC_METHODS]);
+  for (const key of Object.keys(faults)) {
+    if (!allKnown.has(key)) {
+      throw new Error(
+        `[fs-faulty] unknown method '${key}' in fault config. Supported: ${
+          [...allKnown].join(", ")
+        }`
+      );
+    }
+  }
   const restores = [];
   // Async fsp methods.
   for (const method of SUPPORTED_METHODS) {

--- a/tests/helpers/fs-faulty.js
+++ b/tests/helpers/fs-faulty.js
@@ -33,8 +33,12 @@
 //     pass through to the real fsp.
 //   - `failAll: error` — every call throws `error`. Useful for "disk
 //     is permanently down" scenarios.
-//   - `delay: ms` — every call delays by ms before delegating. Useful
-//     for slow-disk timing tests.
+//   - `delay: ms` — every call sleeps for `ms` BEFORE the fault
+//     checks. Useful for slow-disk timing tests, including
+//     simulating slow-then-fail (combine with `failOnce`/`failAll`)
+//     where the call experiences latency before the error surfaces.
+//     The delay always applies regardless of whether the call
+//     would have otherwise thrown.
 //   - `failIfPath: { match: RegExp, error: Error }` — fail only when
 //     the first argument matches `match`. Useful for "this one file
 //     is unreadable" without affecting unrelated I/O.
@@ -146,11 +150,18 @@ function installFaultyFs(faults) {
   // call (`installFaultyFs()` with no args, or with `null`) fail
   // deep inside the property loop with a confusing TypeError —
   // Copilot caught this on PR #135.
-  if (faults === null || typeof faults !== "object") {
+  if (faults === null || typeof faults !== "object" || Array.isArray(faults)) {
+    // Arrays pass `typeof obj === "object"` so we reject them explicitly —
+    // without this, `installFaultyFs([1, 2])` would fall into the
+    // unknown-method-name check and confusingly complain about
+    // method '0'. Copilot caught this on PR #135 round 2.
+    const got = faults === null
+      ? "null"
+      : Array.isArray(faults)
+        ? "array"
+        : typeof faults;
     throw new TypeError(
-      `[fs-faulty] installFaultyFs(faults): expected an object, got ${
-        faults === null ? "null" : typeof faults
-      }`
+      `[fs-faulty] installFaultyFs(faults): expected a plain object, got ${got}`
     );
   }
   // Warn on unknown keys so a typo like `writefile` (lowercase 'f')

--- a/tests/helpers/fs-faulty.js
+++ b/tests/helpers/fs-faulty.js
@@ -1,0 +1,165 @@
+"use strict";
+
+// Fault-injection harness for `node:fs/promises` (#129 — Epic C: Test
+// Coverage & Fault Injection).
+//
+// The stores in `lib/` import `fs/promises` directly and don't accept
+// an injectable fs option. To test their behavior under filesystem
+// failures (ENOSPC, EACCES, partial reads, slow disk) without
+// refactoring every store, this helper installs jest spies on the
+// module-level fsp methods. The spies live for the duration of one
+// scenario and are torn down by the returned `restore()`.
+//
+// Usage:
+//   const fsp = require("node:fs/promises");
+//   const { installFaultyFs } = require("./helpers/fs-faulty");
+//
+//   const fault = installFaultyFs({
+//     writeFile: { failOnce: { code: "ENOSPC", message: "disk full" } }
+//   });
+//   try {
+//     await expect(store.addEntry(...)).rejects.toThrow(/disk full/);
+//   } finally {
+//     fault.restore();
+//   }
+//
+// Supported faults per method (writeFile, rename, readFile, mkdir, rm):
+//   - `failOnce: error` — first call throws `error`; subsequent calls
+//     pass through to the real fsp.
+//   - `failAll: error` — every call throws `error`. Useful for "disk
+//     is permanently down" scenarios.
+//   - `delay: ms` — every call delays by ms before delegating. Useful
+//     for slow-disk timing tests.
+//   - `failIfPath: { match: RegExp, error: Error }` — fail only when
+//     the first argument matches `match`. Useful for "this one file
+//     is unreadable" without affecting unrelated I/O.
+//
+// Each fault config can include any subset of these modes. The
+// helper preserves the natural Node error shape (.code, .errno,
+// .syscall) when the caller supplies a config object with a `code`
+// field — the spy synthesizes a NodeError-like object so production
+// `err.code === "ENOSPC"` branches fire.
+//
+// Restore semantics: `restore()` always restores to the real fsp,
+// regardless of which faults fired. Call it from a try/finally so
+// a failing assertion doesn't leak spies into the next test.
+
+const fsModule = require("node:fs");
+const fsp = require("node:fs/promises");
+
+// Methods we support faults on. Add more as tests need them — every
+// store under test today reads/writes via these.
+//
+// We expose the same set against BOTH `node:fs/promises` and the sync
+// `node:fs` namespace. Stores like `admin-jobs-store` use `fs.writeFileSync`
+// + `fs.renameSync` directly; without sync coverage their fault-
+// injection tests would silently pass even with the harness installed.
+const SUPPORTED_METHODS = ["writeFile", "rename", "readFile", "mkdir", "rm"];
+const SUPPORTED_SYNC_METHODS = [
+  "writeFileSync",
+  "renameSync",
+  "readFileSync",
+  "mkdirSync",
+  "rmSync"
+];
+
+function makeError(spec) {
+  if (spec instanceof Error) return spec;
+  const err = new Error(spec.message || `Synthetic ${spec.code || "I/O"} error`);
+  if (spec.code) err.code = spec.code;
+  if (spec.errno !== undefined) err.errno = spec.errno;
+  if (spec.syscall) err.syscall = spec.syscall;
+  if (spec.path) err.path = spec.path;
+  return err;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildAsyncSpyImpl(originalFn, owner, faultConfig) {
+  // Closure-local state so each install gets its own "failOnce" gate.
+  let onceFired = false;
+  return async function spyImpl(...args) {
+    if (typeof faultConfig.delay === "number" && faultConfig.delay > 0) {
+      await sleep(faultConfig.delay);
+    }
+    if (faultConfig.failIfPath) {
+      const target = String(args[0] || "");
+      if (faultConfig.failIfPath.match.test(target)) {
+        throw makeError(faultConfig.failIfPath.error);
+      }
+    }
+    if (faultConfig.failOnce && !onceFired) {
+      onceFired = true;
+      throw makeError(faultConfig.failOnce);
+    }
+    if (faultConfig.failAll) {
+      throw makeError(faultConfig.failAll);
+    }
+    return originalFn.apply(owner, args);
+  };
+}
+
+function buildSyncSpyImpl(originalFn, owner, faultConfig) {
+  // Sync variant — no `delay` support (would block the event loop)
+  // and no async-await. Same failOnce/failAll/failIfPath semantics.
+  let onceFired = false;
+  return function spyImpl(...args) {
+    if (faultConfig.failIfPath) {
+      const target = String(args[0] || "");
+      if (faultConfig.failIfPath.match.test(target)) {
+        throw makeError(faultConfig.failIfPath.error);
+      }
+    }
+    if (faultConfig.failOnce && !onceFired) {
+      onceFired = true;
+      throw makeError(faultConfig.failOnce);
+    }
+    if (faultConfig.failAll) {
+      throw makeError(faultConfig.failAll);
+    }
+    return originalFn.apply(owner, args);
+  };
+}
+
+function installFaultyFs(faults) {
+  const restores = [];
+  // Async fsp methods.
+  for (const method of SUPPORTED_METHODS) {
+    if (!faults[method]) continue;
+    if (typeof fsp[method] !== "function") {
+      throw new Error(`[fs-faulty] node:fs/promises has no method '${method}'`);
+    }
+    const original = fsp[method];
+    const impl = buildAsyncSpyImpl(original, fsp, faults[method]);
+    fsp[method] = impl;
+    restores.push(() => {
+      fsp[method] = original;
+    });
+  }
+  // Sync fs methods.
+  for (const method of SUPPORTED_SYNC_METHODS) {
+    if (!faults[method]) continue;
+    if (typeof fsModule[method] !== "function") {
+      throw new Error(`[fs-faulty] node:fs has no method '${method}'`);
+    }
+    const original = fsModule[method];
+    const impl = buildSyncSpyImpl(original, fsModule, faults[method]);
+    fsModule[method] = impl;
+    restores.push(() => {
+      fsModule[method] = original;
+    });
+  }
+  return {
+    restore() {
+      for (const fn of restores) fn();
+    }
+  };
+}
+
+module.exports = {
+  installFaultyFs,
+  SUPPORTED_METHODS,
+  SUPPORTED_SYNC_METHODS
+};

--- a/tests/stores.fs-fault.test.js
+++ b/tests/stores.fs-fault.test.js
@@ -213,11 +213,20 @@ describe("challenge-results-store: fault-injection", () => {
         fault.restore();
       }
 
-      // Prior state survives.
+      // Prior state survives in memory.
       const inMemory = await store.load();
       expect(inMemory.sessions).toHaveLength(1);
+      // ON-DISK state preserved by the atomic-rename pattern.
       const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
       expect(reloaded.sessions).toHaveLength(1);
+
+      // Recovery: a fresh op after the fault clears succeeds.
+      await store.createSession({
+        challengeId: "c-gamma",
+        profileId: "p-gamma",
+        puzzles: [{ index: 0, word: "GAMMA", guesses: [], solved: false }]
+      });
+      expect((await store.load()).sessions).toHaveLength(2);
     } finally {
       await cleanup(dir);
     }
@@ -312,6 +321,18 @@ describe("webhook-delivery-store: fault-injection", () => {
 
       const inMemory = await store.getSnapshot();
       expect(inMemory.deliveries).toHaveLength(1);
+      // On-disk state preserved.
+      const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
+      expect(reloaded.deliveries).toHaveLength(1);
+
+      // Recovery: a fresh enqueue after the fault clears succeeds.
+      await store.enqueue({
+        subscriptionId: "sub-3",
+        event: "daily.posted",
+        url: "https://example.com/sink",
+        payload: {}
+      });
+      expect((await store.getSnapshot()).deliveries).toHaveLength(2);
     } finally {
       await cleanup(dir);
     }
@@ -348,6 +369,15 @@ describe("push-subscription-store: fault-injection", () => {
 
       const inMemory = await store.getSnapshot();
       expect(inMemory.subscriptions).toHaveLength(1);
+      const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
+      expect(reloaded.subscriptions).toHaveLength(1);
+
+      // Recovery: a fresh upsert after the fault clears succeeds.
+      await store.upsert({
+        endpoint: "https://push.example.com/third",
+        keys: { p256dh: "p".repeat(87), auth: "a".repeat(22) }
+      });
+      expect((await store.getSnapshot()).subscriptions).toHaveLength(2);
     } finally {
       await cleanup(dir);
     }
@@ -474,10 +504,17 @@ describe("classes-store: fault-injection", () => {
         fault.restore();
       }
 
-      // Prior state preserved.
+      // Prior state preserved in memory + on disk.
       const inMemory = await store.getSnapshot();
       expect(inMemory.classes).toHaveLength(1);
       expect(inMemory.classes[0].name).toBe("First");
+      const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
+      expect(reloaded.classes).toHaveLength(1);
+      expect(reloaded.classes[0].name).toBe("First");
+
+      // Recovery: a fresh createClass after the fault clears succeeds.
+      await store.createClass("Second-recovered");
+      expect((await store.getSnapshot()).classes).toHaveLength(2);
     } finally {
       await cleanup(dir);
     }
@@ -527,6 +564,20 @@ describe("leaderboard-store: fault-injection", () => {
       const inMemory = await store.getSnapshot();
       expect(inMemory.profiles).toHaveLength(1);
       expect(inMemory.profiles[0].id).toBe("alpha");
+      const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
+      expect(reloaded.profiles).toHaveLength(1);
+      expect(reloaded.profiles[0].id).toBe("alpha");
+
+      // Recovery: a fresh mutate after the fault clears succeeds.
+      await store.mutate((draft) => {
+        draft.profiles.push({
+          id: "gamma",
+          name: "Gamma",
+          createdAt: "2026-05-11T00:00:00.000Z",
+          updatedAt: "2026-05-11T00:00:00.000Z"
+        });
+      });
+      expect((await store.getSnapshot()).profiles).toHaveLength(2);
     } finally {
       await cleanup(dir);
     }

--- a/tests/stores.fs-fault.test.js
+++ b/tests/stores.fs-fault.test.js
@@ -73,10 +73,14 @@ describe("schedule-store: fault-injection", () => {
         }
       });
       try {
-        // The store throws the underlying error (it doesn't wrap
-        // every writeFile failure into a ScheduleStoreError) — we
-        // assert the original code surfaces so observability stays
-        // intact.
+        // ScheduleStore's `writeJsonAtomic` catches fs-level errors
+        // and rethrows as a `ScheduleStoreError` with code
+        // `STORE_WRITE_FAILED` (preserving the original under
+        // `.cause`). Callers branch on the typed code; the raw
+        // ENOSPC stays available via `.cause.code` if observability
+        // needs it. (Copilot + CodeRabbit caught the prior comment
+        // that incorrectly claimed the underlying error surfaced
+        // directly — PR #135.)
         await expect(
           store.addEntry({ date: "2026-05-09", word: "BETAS", lang: "en" })
         ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });

--- a/tests/stores.fs-fault.test.js
+++ b/tests/stores.fs-fault.test.js
@@ -355,25 +355,19 @@ describe("push-subscription-store: fault-injection", () => {
 });
 
 describe("admin-jobs-store: fault-injection", () => {
-  test("ENOSPC (sync) during enqueue surfaces typed error; finding: in-memory state leaks", async () => {
-    // admin-jobs-store persists via `fs.writeFileSync` (not the async
-    // `fsp.writeFile` other stores use). The harness's sync-method
-    // support covers this — the fault fires on the SYNC writeFileSync
-    // call inside the store's #persist path.
+  test("ENOSPC (sync) during enqueue surfaces typed error; on-disk state preserved", async () => {
+    // admin-jobs-store persists via `fs.writeFileSync` (not the
+    // async `fsp.writeFile` other stores use). The harness's
+    // sync-method support covers this — the fault fires on the
+    // SYNC writeFileSync call inside the store's #persist path.
     //
-    // FINDING discovered by C3 — admin-jobs-store's `#enqueueWrite`
-    // lacks the snapshot-restore wrapper that `classes-store.js` has
-    // (lines 614-641). When `writeJsonAtomicSync` throws, the
-    // already-pushed in-memory job stays in `this.state.jobs` even
-    // though disk wasn't updated. Other stores either:
-    //   - Use a draft + assign-after-persist pattern (leaderboard).
-    //   - Wrap with clone-snapshot try/catch (classes).
+    // Pins the parts of the contract that hold TODAY:
+    //  - rejection surfaces the typed STORE_WRITE_FAILED error
+    //  - on-disk state is preserved (atomic-rename means the .tmp
+    //    write failed and the destination is untouched)
     //
-    // This test asserts the CURRENT behavior (jobs leak to in-memory)
-    // and a follow-up task is filed to apply the classes-store
-    // rollback pattern to admin-jobs-store. Once that lands, this
-    // test's last assertion will need to change from
-    // `toHaveLength(2)` back to `toHaveLength(1)`.
+    // The in-memory rollback assertion lives in the separate
+    // `test.failing` below — see that block for why.
     const { dir, filePath } = tempFilePath("admin-jobs.json");
     try {
       const store = new AdminJobsStore({ filePath, now: frozenNow() });
@@ -394,18 +388,56 @@ describe("admin-jobs-store: fault-injection", () => {
         fault.restore();
       }
 
-      // ON-DISK state preserved (the atomic-rename means the .tmp
-      // write failed, so the destination file still reflects the
-      // prior commit).
       const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
       expect(reloaded.jobs).toHaveLength(1);
       expect(reloaded.jobs[0].request.language).toBe("en");
+    } finally {
+      await cleanup(dir);
+    }
+  });
 
-      // IN-MEMORY state LEAKS — known issue, pending rollback fix.
-      // The 2nd job was already pushed to `this.state.jobs` before
-      // #persist failed; no snapshot-restore wrapper recovers it.
+  // FINDING discovered by C3 — admin-jobs-store's `#enqueueWrite`
+  // lacks the snapshot-restore wrapper that `classes-store.js`
+  // has. When `writeJsonAtomicSync` throws, the already-pushed
+  // in-memory job stays in `this.state.jobs` even though disk
+  // wasn't updated. A follow-up task is filed to apply the
+  // classes-store rollback pattern to admin-jobs-store.
+  //
+  // We use `test.failing` here to TRACK the bug: today this
+  // assertion fails (jobs.length === 2, not 1), which jest
+  // treats as the expected outcome. When the rollback fix lands,
+  // the assertion will pass, jest will fail this test for
+  // "unexpected passing", and CI will surface the test needs to
+  // be promoted to a plain `test()`. That ratchets the bug
+  // closed automatically. Codex caught the prior approach of
+  // asserting `toHaveLength(2)` directly on PR #135 — that would
+  // have masked the fix.
+  test.failing("[pending rollback fix] in-memory state preserved on persist failure", async () => {
+    const { dir, filePath } = tempFilePath("admin-jobs.json");
+    try {
+      const store = new AdminJobsStore({ filePath, now: frozenNow() });
+      await store.load();
+      await store.enqueueProviderImportJob({ provider: "test", language: "en" });
+
+      const fault = installFaultyFs({
+        writeFileSync: {
+          failOnce: { code: "ENOSPC", message: "disk full (synthetic)" }
+        }
+      });
+      try {
+        await expect(
+          store.enqueueProviderImportJob({ provider: "test", language: "es" })
+        ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+      } finally {
+        fault.restore();
+      }
+
+      // EXPECTED post-rollback-fix: in-memory jobs.length === 1.
+      // Today this fails (length === 2 because the push happened
+      // before the throw). `test.failing` makes the failing
+      // assertion the "expected outcome" until the fix lands.
       const inMemory = await store.getSnapshot();
-      expect(inMemory.jobs).toHaveLength(2);
+      expect(inMemory.jobs).toHaveLength(1);
     } finally {
       await cleanup(dir);
     }

--- a/tests/stores.fs-fault.test.js
+++ b/tests/stores.fs-fault.test.js
@@ -1,0 +1,498 @@
+"use strict";
+
+// Fault-injection tests against the persisted-state stores (#129).
+//
+// What this covers per store:
+//   - schedule-store:
+//     * commit-time `writeJsonAtomic` ENOSPC surfaces a typed error;
+//       state is NOT corrupted (next read sees prior state).
+//     * EACCES on initial load surfaces STORE_READ_FAILED (not a
+//       silent corruption).
+//   - challenge-config-store:
+//     * commit-time ENOSPC same contract.
+//   - webhook-store:
+//     * rename-fail mid-commit (simulating a torn atomic rename).
+//
+// Covers the contract documented in `lib/locks.md` and `docs/admin-
+// security-checklist.md` — stores must FAIL CLOSED on I/O errors:
+// throw a typed error, leave on-disk state untouched, leave in-
+// memory state at the prior committed value. No half-writes, no
+// silent corruption.
+//
+// Each scenario installs the harness, runs the store op, asserts
+// both the thrown error code AND a post-fault read showing the
+// store recovered to a consistent state.
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const { ScheduleStore } = require("../lib/schedule-store");
+const { ChallengeConfigStore } = require("../lib/challenge-config-store");
+const { ChallengeResultsStore } = require("../lib/challenge-results-store");
+const { WebhookStore } = require("../lib/webhook-store");
+const { WebhookDeliveryStore } = require("../lib/webhook-delivery-store");
+const { PushSubscriptionStore } = require("../lib/push-subscription-store");
+const { AdminJobsStore } = require("../lib/admin-jobs-store");
+const { ClassesStore } = require("../lib/classes-store");
+const { LeaderboardStore } = require("../lib/leaderboard-store");
+
+const { installFaultyFs } = require("./helpers/fs-faulty");
+
+function tempFilePath(name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-fs-fault-"));
+  return { dir, filePath: path.join(dir, name) };
+}
+
+function frozenNow(iso = "2026-05-11T00:00:00.000Z") {
+  return () => new Date(iso);
+}
+
+async function cleanup(dir) {
+  await fsp.rm(dir, { recursive: true, force: true });
+}
+
+describe("schedule-store: fault-injection", () => {
+  test("ENOSPC during commit surfaces a typed error; prior state preserved", async () => {
+    const { dir, filePath } = tempFilePath("schedule.json");
+    try {
+      const store = new ScheduleStore({ filePath, now: frozenNow() });
+      await store.load();
+      // Successful commit so there's a "prior" state to compare against.
+      await store.addEntry({ date: "2026-05-08", word: "ALPHA", lang: "en" });
+      const beforeFault = await store.getSnapshot();
+      expect(beforeFault.scheduled_words).toHaveLength(1);
+
+      // Install ENOSPC fault on the next writeFile. The store's
+      // writeJsonAtomic helper writes to a `.tmp` path first and then
+      // renames; either failure should surface a typed error.
+      const fault = installFaultyFs({
+        writeFile: {
+          failOnce: { code: "ENOSPC", message: "disk full (synthetic)" }
+        }
+      });
+      try {
+        // The store throws the underlying error (it doesn't wrap
+        // every writeFile failure into a ScheduleStoreError) — we
+        // assert the original code surfaces so observability stays
+        // intact.
+        await expect(
+          store.addEntry({ date: "2026-05-09", word: "BETAS", lang: "en" })
+        ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+      } finally {
+        fault.restore();
+      }
+
+      // After the fault, the store's in-memory state is unchanged
+      // (the prior commit is the most recent). A fresh load from
+      // disk shows only the original row, never the half-applied one.
+      const inMemory = await store.getSnapshot();
+      expect(inMemory.scheduled_words).toHaveLength(1);
+      expect(inMemory.scheduled_words[0].word).toBe("ALPHA");
+
+      const reloadedFromDisk = JSON.parse(await fsp.readFile(filePath, "utf8"));
+      expect(reloadedFromDisk.scheduled_words).toHaveLength(1);
+      expect(reloadedFromDisk.scheduled_words[0].word).toBe("ALPHA");
+
+      // The store is still usable after the fault clears — a fresh
+      // addEntry succeeds and updates both memory and disk.
+      await store.addEntry({ date: "2026-05-10", word: "GAMMA", lang: "en" });
+      const recovered = await store.getSnapshot();
+      expect(recovered.scheduled_words.map((r) => r.word).sort()).toEqual([
+        "ALPHA",
+        "GAMMA"
+      ]);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  test("EACCES on initial load surfaces STORE_READ_FAILED", async () => {
+    const { dir, filePath } = tempFilePath("schedule.json");
+    try {
+      // Pre-seed the file so it exists, then make reads fail.
+      await fsp.writeFile(filePath, JSON.stringify({ version: 1 }), "utf8");
+      const fault = installFaultyFs({
+        readFile: {
+          failOnce: { code: "EACCES", message: "permission denied (synthetic)" }
+        }
+      });
+      try {
+        const store = new ScheduleStore({ filePath, now: frozenNow() });
+        await expect(store.load()).rejects.toMatchObject({
+          code: "STORE_READ_FAILED"
+        });
+      } finally {
+        fault.restore();
+      }
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe("challenge-config-store: fault-injection", () => {
+  test("ENOSPC during commit surfaces a typed error; prior state preserved", async () => {
+    const { dir, filePath } = tempFilePath("challenges.json");
+    try {
+      const store = new ChallengeConfigStore({ filePath, now: frozenNow() });
+      await store.load();
+      const baseInput = {
+        name: "First",
+        lang: "en",
+        puzzleCount: 5,
+        timeBudgetSeconds: 300,
+        maxGuesses: 6,
+        speedBonusFactor: 0.5,
+        perPuzzleScore: 1000,
+        replayPolicy: "best"
+      };
+      await store.create(baseInput);
+      expect((await store.load()).challenges).toHaveLength(1);
+
+      const fault = installFaultyFs({
+        writeFile: {
+          failOnce: { code: "ENOSPC", message: "disk full (synthetic)" }
+        }
+      });
+      try {
+        await expect(
+          store.create({ ...baseInput, name: "Second" })
+        ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+      } finally {
+        fault.restore();
+      }
+
+      // Prior state untouched on disk + in memory.
+      const inMemory = await store.load();
+      expect(inMemory.challenges).toHaveLength(1);
+      expect(inMemory.challenges[0].name).toBe("First");
+
+      const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
+      expect(reloaded.challenges).toHaveLength(1);
+      expect(reloaded.challenges[0].name).toBe("First");
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe("challenge-results-store: fault-injection", () => {
+  test("ENOSPC during createSession surfaces typed error; prior state preserved", async () => {
+    const { dir, filePath } = tempFilePath("challenge-results.json");
+    try {
+      const store = new ChallengeResultsStore({ filePath, now: frozenNow() });
+      await store.load();
+      // Seed one session so there's prior state.
+      await store.createSession({
+        challengeId: "c-alpha",
+        profileId: "p-alpha",
+        puzzles: [{ index: 0, word: "ALPHA", guesses: [], solved: false }]
+      });
+      expect((await store.load()).sessions).toHaveLength(1);
+
+      const fault = installFaultyFs({
+        writeFile: {
+          failOnce: { code: "ENOSPC", message: "disk full (synthetic)" }
+        }
+      });
+      try {
+        await expect(
+          store.createSession({
+            challengeId: "c-beta",
+            profileId: "p-beta",
+            puzzles: [{ index: 0, word: "BETAS", guesses: [], solved: false }]
+          })
+        ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+      } finally {
+        fault.restore();
+      }
+
+      // Prior state survives.
+      const inMemory = await store.load();
+      expect(inMemory.sessions).toHaveLength(1);
+      const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
+      expect(reloaded.sessions).toHaveLength(1);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe("webhook-store: fault-injection", () => {
+  test("rename failure mid-commit surfaces a typed error; prior state preserved", async () => {
+    const { dir, filePath } = tempFilePath("webhooks.json");
+    try {
+      const store = new WebhookStore({ filePath, now: frozenNow() });
+      await store.load();
+      await store.create({
+        url: "https://example.com/first",
+        events: ["daily.posted"],
+        enabled: true
+      });
+      expect((await store.getSnapshot()).subscriptions).toHaveLength(1);
+
+      const fault = installFaultyFs({
+        rename: {
+          failOnce: { code: "ENOSPC", message: "rename failed (synthetic)" }
+        }
+      });
+      try {
+        await expect(
+          store.create({
+            url: "https://example.com/second",
+            events: ["daily.posted"],
+            enabled: true
+          })
+        ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+      } finally {
+        fault.restore();
+      }
+
+      // After a failed atomic-rename, the destination file MUST
+      // still reflect the prior committed state (writeJsonAtomic
+      // writes to .tmp and only renames at the end). No torn write.
+      const snap = await store.getSnapshot();
+      expect(snap.subscriptions).toHaveLength(1);
+      expect(snap.subscriptions[0].url).toBe("https://example.com/first");
+
+      const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
+      expect(reloaded.subscriptions).toHaveLength(1);
+      expect(reloaded.subscriptions[0].url).toBe("https://example.com/first");
+
+      // Recovery: a fresh create works after the fault clears.
+      await store.create({
+        url: "https://example.com/third",
+        events: ["daily.posted"],
+        enabled: true
+      });
+      expect((await store.getSnapshot()).subscriptions).toHaveLength(2);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe("webhook-delivery-store: fault-injection", () => {
+  test("ENOSPC during enqueue surfaces typed error; prior state preserved", async () => {
+    const { dir, filePath } = tempFilePath("webhook-deliveries.json");
+    try {
+      const store = new WebhookDeliveryStore({ filePath, now: frozenNow() });
+      await store.load();
+      await store.enqueue({
+        subscriptionId: "sub-1",
+        event: "daily.posted",
+        url: "https://example.com/sink",
+        payload: { ok: true }
+      });
+      expect((await store.getSnapshot()).deliveries).toHaveLength(1);
+
+      const fault = installFaultyFs({
+        writeFile: {
+          failOnce: { code: "ENOSPC", message: "disk full (synthetic)" }
+        }
+      });
+      try {
+        await expect(
+          store.enqueue({
+            subscriptionId: "sub-2",
+            event: "daily.posted",
+            url: "https://example.com/sink",
+            payload: {}
+          })
+        ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+      } finally {
+        fault.restore();
+      }
+
+      const inMemory = await store.getSnapshot();
+      expect(inMemory.deliveries).toHaveLength(1);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe("push-subscription-store: fault-injection", () => {
+  test("ENOSPC during upsert surfaces typed error; prior state preserved", async () => {
+    const { dir, filePath } = tempFilePath("push-subscriptions.json");
+    try {
+      const store = new PushSubscriptionStore({ filePath, now: frozenNow() });
+      await store.load();
+      await store.upsert({
+        endpoint: "https://push.example.com/first",
+        keys: { p256dh: "p".repeat(87), auth: "a".repeat(22) }
+      });
+      expect((await store.getSnapshot()).subscriptions).toHaveLength(1);
+
+      const fault = installFaultyFs({
+        writeFile: {
+          failOnce: { code: "ENOSPC", message: "disk full (synthetic)" }
+        }
+      });
+      try {
+        await expect(
+          store.upsert({
+            endpoint: "https://push.example.com/second",
+            keys: { p256dh: "p".repeat(87), auth: "a".repeat(22) }
+          })
+        ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+      } finally {
+        fault.restore();
+      }
+
+      const inMemory = await store.getSnapshot();
+      expect(inMemory.subscriptions).toHaveLength(1);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe("admin-jobs-store: fault-injection", () => {
+  test("ENOSPC (sync) during enqueue surfaces typed error; finding: in-memory state leaks", async () => {
+    // admin-jobs-store persists via `fs.writeFileSync` (not the async
+    // `fsp.writeFile` other stores use). The harness's sync-method
+    // support covers this — the fault fires on the SYNC writeFileSync
+    // call inside the store's #persist path.
+    //
+    // FINDING discovered by C3 — admin-jobs-store's `#enqueueWrite`
+    // lacks the snapshot-restore wrapper that `classes-store.js` has
+    // (lines 614-641). When `writeJsonAtomicSync` throws, the
+    // already-pushed in-memory job stays in `this.state.jobs` even
+    // though disk wasn't updated. Other stores either:
+    //   - Use a draft + assign-after-persist pattern (leaderboard).
+    //   - Wrap with clone-snapshot try/catch (classes).
+    //
+    // This test asserts the CURRENT behavior (jobs leak to in-memory)
+    // and a follow-up task is filed to apply the classes-store
+    // rollback pattern to admin-jobs-store. Once that lands, this
+    // test's last assertion will need to change from
+    // `toHaveLength(2)` back to `toHaveLength(1)`.
+    const { dir, filePath } = tempFilePath("admin-jobs.json");
+    try {
+      const store = new AdminJobsStore({ filePath, now: frozenNow() });
+      await store.load();
+      await store.enqueueProviderImportJob({ provider: "test", language: "en" });
+      expect((await store.getSnapshot()).jobs).toHaveLength(1);
+
+      const fault = installFaultyFs({
+        writeFileSync: {
+          failOnce: { code: "ENOSPC", message: "disk full (synthetic)" }
+        }
+      });
+      try {
+        await expect(
+          store.enqueueProviderImportJob({ provider: "test", language: "es" })
+        ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+      } finally {
+        fault.restore();
+      }
+
+      // ON-DISK state preserved (the atomic-rename means the .tmp
+      // write failed, so the destination file still reflects the
+      // prior commit).
+      const reloaded = JSON.parse(await fsp.readFile(filePath, "utf8"));
+      expect(reloaded.jobs).toHaveLength(1);
+      expect(reloaded.jobs[0].request.language).toBe("en");
+
+      // IN-MEMORY state LEAKS — known issue, pending rollback fix.
+      // The 2nd job was already pushed to `this.state.jobs` before
+      // #persist failed; no snapshot-restore wrapper recovers it.
+      const inMemory = await store.getSnapshot();
+      expect(inMemory.jobs).toHaveLength(2);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe("classes-store: fault-injection", () => {
+  test("ENOSPC during createClass surfaces an error; prior state preserved", async () => {
+    const { dir, filePath } = tempFilePath("classes.json");
+    try {
+      const store = new ClassesStore({
+        filePath,
+        now: frozenNow(),
+        logger: { warn: () => {}, error: () => {} }
+      });
+      await store.load();
+      await store.createClass("First");
+      expect((await store.getSnapshot()).classes).toHaveLength(1);
+
+      const fault = installFaultyFs({
+        writeFile: {
+          failOnce: { code: "ENOSPC", message: "disk full (synthetic)" }
+        }
+      });
+      try {
+        // classes-store + leaderboard-store don't wrap fs errors into
+        // STORE_WRITE_FAILED — they let the raw ENOSPC propagate. We
+        // only assert the rejection + state preservation, not a
+        // specific code. This is the actual contract today; if a
+        // future refactor harmonizes error wrapping across stores,
+        // tighten the assertion then.
+        await expect(store.createClass("Second")).rejects.toThrow();
+      } finally {
+        fault.restore();
+      }
+
+      // Prior state preserved.
+      const inMemory = await store.getSnapshot();
+      expect(inMemory.classes).toHaveLength(1);
+      expect(inMemory.classes[0].name).toBe("First");
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe("leaderboard-store: fault-injection", () => {
+  test("ENOSPC during mutate surfaces an error; prior state preserved", async () => {
+    const { dir, filePath } = tempFilePath("leaderboard.json");
+    try {
+      const store = new LeaderboardStore({
+        filePath,
+        now: frozenNow(),
+        logger: { warn: () => {}, error: () => {} }
+      });
+      await store.load();
+      await store.mutate((draft) => {
+        draft.profiles.push({
+          id: "alpha",
+          name: "Alpha",
+          createdAt: "2026-05-11T00:00:00.000Z",
+          updatedAt: "2026-05-11T00:00:00.000Z"
+        });
+      });
+      expect((await store.getSnapshot()).profiles).toHaveLength(1);
+
+      const fault = installFaultyFs({
+        writeFile: {
+          failOnce: { code: "ENOSPC", message: "disk full (synthetic)" }
+        }
+      });
+      try {
+        await expect(
+          store.mutate((draft) => {
+            draft.profiles.push({
+              id: "beta",
+              name: "Beta",
+              createdAt: "2026-05-11T00:00:00.000Z",
+              updatedAt: "2026-05-11T00:00:00.000Z"
+            });
+          })
+        ).rejects.toThrow();
+      } finally {
+        fault.restore();
+      }
+
+      const inMemory = await store.getSnapshot();
+      expect(inMemory.profiles).toHaveLength(1);
+      expect(inMemory.profiles[0].id).toBe("alpha");
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `tests/helpers/fs-faulty.js` — a Jest-spy-based fault-injection harness that intercepts `node:fs/promises` AND sync `node:fs` methods without requiring stores to accept an injectable fs option.

**Supported modes** per method (`writeFile`, `rename`, `readFile`, `mkdir`, `rm` + their `*Sync` counterparts):
- `failOnce` — first call throws; subsequent calls pass through
- `failAll` — every call throws
- `failIfPath` — throw only when the path matches a regex
- `delay` (async only) — inject latency

**Tests:**
- `tests/fs-faulty.test.js` (6 cases) — harness self-tests covering install/restore, failOnce/failAll/failIfPath/delay, multi-method install, real-Error pass-through.
- `tests/stores.fs-fault.test.js` (10 cases across all 9 async stores) — schedule, challenge-config, challenge-results, webhook, webhook-delivery, push-subscription, admin-jobs, classes, leaderboard.

**Per-store contract pinned:**
- Operation rejects with a typed error (`STORE_WRITE_FAILED` in 7 of 9 stores; classes + leaderboard pass the raw fs error through per their current contract).
- On-disk state preserved via the atomic-rename pattern.
- Recovery: a fresh op after the fault clears succeeds.

## Finding surfaced

**admin-jobs-store leaks in-memory state on persist failure.** Its `#enqueueWrite` lacks the snapshot-restore wrapper that `classes-store.js` has (lines 614-641). When `writeJsonAtomicSync` throws, the already-pushed job remains in `this.state.jobs` even though disk wasn't updated. The test asserts the **current** behavior with a TODO comment, and a follow-up task is filed to apply the classes-store rollback pattern to admin-jobs.

This is exactly the class of bug C3 was designed to surface — the harness paid for itself on its first PR.

## C epic ordering

Per the memory order: C1 → C6 → **C3** → C2 → A4/A5 → A/B → C4/C5. C1 and C6 merged; this is C3.

## Test plan
- [x] All 16 new tests pass at default
- [x] Full `npm run check` green: 799 tests, 50 suites (was 783 → +16)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive fault-injection test framework and suite for filesystem operations and persisted-state stores to verify system resilience under error conditions and ensure data integrity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/135)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->