### PR TITLE
test(fuzz): C2 — admin route input fuzz harness (closes #128)

### DIFF
--- a/tests/admin-routes.fuzz.test.js
+++ b/tests/admin-routes.fuzz.test.js
@@ -2,33 +2,49 @@
 
 // Admin route input fuzz harness — Epic C #128.
 //
-// Feeds malformed payloads to every admin write route and asserts
-// the production contract:
+// Feeds malformed payloads to every admin write route under test and
+// asserts the production contract:
 //
-//   - Status code is 4xx (typically 400/401/403) — never 5xx unless
-//     the malformed input genuinely triggers a server bug we want to
-//     surface.
-//   - Response body shape is the sanitized-error envelope. No
-//     filesystem paths, no stack traces, no env var values.
-//   - The server survives — a follow-up GET on the same endpoint
-//     succeeds (no process-level corruption from the malformed body).
-//   - Prototype-pollution keys (__proto__, constructor, prototype)
-//     are rejected; Object.prototype is unchanged.
+//   - Server doesn't crash (status < 500). A 2xx response is fine
+//     if the route legitimately accepts the sanitized input —
+//     Express's body parser strips `__proto__` keys before the
+//     handler sees them, accepts BOM prefixes, etc. The contract
+//     is "no crash, no leak, no proto-pollution" — NOT "every
+//     malformed input must 4xx".
+//   - Neither `response.body` NOR `response.text` leaks
+//     filesystem paths, the ADMIN_KEY value, or V8 stack frames.
+//     We check both because body-parser errors typically yield a
+//     plain-text response with body === {} (Copilot caught this
+//     on PR #136).
+//   - Object.prototype is unchanged AFTER the full fuzz matrix
+//     (asserted via a sentinel set BEFORE the matrix runs +
+//     checked AFTER, NOT between tests — the afterEach hook
+//     deliberately leaves prototype mutations intact across the
+//     matrix so the sentinel runs against a worst-case state).
+//   - A follow-up GET on a known-safe admin route still works.
 //
 // What we fuzz (each route gets cross-matrix coverage):
-//   1. Empty body / null body
-//   2. Oversized body (just past JSON_BODY_LIMIT)
-//   3. Depth-bombed JSON (deeply-nested objects/arrays)
-//   4. Prototype-pollution keys at top level
-//   5. Prototype-pollution keys nested
-//   6. Non-UTF-8 bytes / BOM prefix
-//   7. JSON-with-comments (invalid per JSON.parse)
-//   8. Embedded NUL characters
+//   - empty / null body
+//   - depth-bombed JSON (object + array, 500 levels each)
+//   - `__proto__` injection (top + nested) — injected via
+//     JSON.parse so the literal key actually traverses the wire
+//     (in a JS object literal, `{ __proto__: X }` SETS the
+//     prototype to X rather than setting a property named
+//     `__proto__`; Codex caught this on PR #136).
+//   - `constructor.prototype` injection
+//   - JSON-with-comments (invalid per JSON.parse)
+//   - BOM-prefixed JSON (constructed via String.fromCharCode so
+//     the source stays pure-ASCII)
+//   - trailing-comma JSON (invalid)
+//   - embedded NUL in a string field
+//   - non-UTF-8 raw byte stream (Buffer sent verbatim via the
+//     supertest `.write()` path so Node doesn't transparently
+//     re-encode it as UTF-8)
 //
-// We DON'T cover every admin route exhaustively in this PR — the
-// harness pattern is the deliverable. A representative cross-section
-// (schedule, webhook, challenge config) is exercised. Adding routes
-// is a one-line append to ROUTES_TO_FUZZ; nothing else changes.
+// We DON'T cover every admin route exhaustively — the harness
+// pattern is the deliverable. A representative cross-section is
+// exercised. Adding routes is a one-line append to
+// ROUTES_TO_FUZZ; nothing else changes.
 
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
@@ -63,21 +79,47 @@ function loadApp(adminKey) {
     delete process.env.ADMIN_KEY;
   }
   process.env.NODE_ENV = "test";
-  // Point every store at a per-test tempdir so concurrent fuzz tests
-  // don't trip over each other on disk.
+  // Point every store at a per-test tempdir. CRITICAL: the env var
+  // NAMES must match what `server.js` reads — Copilot caught on
+  // PR #136 that several names were wrong (e.g. WEBHOOK_STORE_PATH
+  // vs the actual WEBHOOKS_STORE_PATH), which silently let the
+  // fuzz run against the REAL repo data/ directory. Names below
+  // come from grepping `server.js` for `process.env.*PATH`.
   const schedule = tempPath("schedule.json");
   const stats = tempPath("leaderboard.json");
   const webhooks = tempPath("webhooks.json");
   const deliveries = tempPath("webhook-deliveries.json");
   const challenges = tempPath("challenges.json");
   const results = tempPath("challenge-results.json");
-  tempDirs.push(schedule.dir, stats.dir, webhooks.dir, deliveries.dir, challenges.dir, results.dir);
+  const classes = tempPath("classes.json");
+  const adminJobs = tempPath("admin-jobs.json");
+  const pushSubs = tempPath("push-subscriptions.json");
+  const vapid = tempPath("vapid.json");
+  const appConfig = tempPath("app-config.json");
+  tempDirs.push(
+    schedule.dir,
+    stats.dir,
+    webhooks.dir,
+    deliveries.dir,
+    challenges.dir,
+    results.dir,
+    classes.dir,
+    adminJobs.dir,
+    pushSubs.dir,
+    vapid.dir,
+    appConfig.dir
+  );
   process.env.SCHEDULE_STORE_PATH = schedule.filePath;
   process.env.STATS_STORE_PATH = stats.filePath;
-  process.env.WEBHOOK_STORE_PATH = webhooks.filePath;
-  process.env.WEBHOOK_DELIVERY_STORE_PATH = deliveries.filePath;
-  process.env.CHALLENGE_CONFIG_STORE_PATH = challenges.filePath;
+  process.env.WEBHOOKS_STORE_PATH = webhooks.filePath;
+  process.env.WEBHOOK_DELIVERIES_STORE_PATH = deliveries.filePath;
+  process.env.CHALLENGE_STORE_PATH = challenges.filePath;
   process.env.CHALLENGE_RESULTS_STORE_PATH = results.filePath;
+  process.env.CLASSES_STORE_PATH = classes.filePath;
+  process.env.ADMIN_JOBS_STORE_PATH = adminJobs.filePath;
+  process.env.PUSH_SUBSCRIPTIONS_STORE_PATH = pushSubs.filePath;
+  process.env.VAPID_KEYS_STORE_PATH = vapid.filePath;
+  process.env.APP_CONFIG_PATH = appConfig.filePath;
   process.env.SCHEDULER_CHECK_INTERVAL_MS = String(60 * 60 * 1000);
   return require("../server");
 }
@@ -92,8 +134,6 @@ afterAll(async () => {
 
 // ---------- Payload generators ----------
 
-// Build a deeply-nested object N levels deep — depth-bomb that a
-// naive normalizer might stack-overflow on.
 function depthBombObject(depth) {
   let inner = { leaf: 1 };
   for (let i = 0; i < depth; i += 1) {
@@ -102,7 +142,6 @@ function depthBombObject(depth) {
   return inner;
 }
 
-// Build a deeply-nested array.
 function depthBombArray(depth) {
   let inner = [];
   for (let i = 0; i < depth; i += 1) {
@@ -111,38 +150,36 @@ function depthBombArray(depth) {
   return inner;
 }
 
-// Payloads we send. Each is { name, body, contentType?, raw? }:
-//   - name: human label for failure messages
-//   - body: object passed via supertest .send(body), OR a string
-//     for raw text bodies via .set("Content-Type") + .send(string)
-//   - raw: if true, body is sent as raw text (not auto-stringified)
+// `__proto__` in a JS object literal is special — it SETS the
+// prototype rather than creating a property named `__proto__`. To
+// actually send the key over the wire, parse from a JSON string
+// (where __proto__ IS a regular property name).
+const PROTO_INJECT_TOP = JSON.parse(
+  '{"__proto__":{"polluted":"yes"},"date":"2026-05-08","word":"ALPHA","lang":"en"}'
+);
+const PROTO_INJECT_NESTED = JSON.parse(
+  '{"date":"2026-05-08","word":"ALPHA","lang":"en","meta":{"__proto__":{"polluted":"yes"}}}'
+);
+
+// Payloads. Each entry:
+//   - name: human label
+//   - body: object (auto-JSON-serialized) OR raw string (`raw: true`)
+//   - raw: if true, body is sent verbatim
+//   - rawBytes: optional Buffer for non-UTF-8 cases — sent via
+//     supertest's write/end path so Node doesn't re-encode it
 const PAYLOADS = [
   { name: "empty body", body: {} },
   { name: "null body", body: null },
   { name: "depth-bomb (object, 500 levels)", body: depthBombObject(500) },
   { name: "depth-bomb (array, 500 levels)", body: depthBombArray(500) },
-  {
-    name: "__proto__ injection at top",
-    body: { __proto__: { polluted: "yes" }, date: "2026-05-08", word: "ALPHA", lang: "en" }
-  },
+  { name: "__proto__ injection at top", body: PROTO_INJECT_TOP },
   {
     name: "constructor.prototype injection",
-    body: {
-      constructor: { prototype: { polluted: "yes" } },
-      date: "2026-05-08",
-      word: "ALPHA",
-      lang: "en"
-    }
+    body: JSON.parse(
+      '{"constructor":{"prototype":{"polluted":"yes"}},"date":"2026-05-08","word":"ALPHA","lang":"en"}'
+    )
   },
-  {
-    name: "nested __proto__ injection",
-    body: {
-      date: "2026-05-08",
-      word: "ALPHA",
-      lang: "en",
-      meta: { __proto__: { polluted: "yes" } }
-    }
-  },
+  { name: "nested __proto__ injection", body: PROTO_INJECT_NESTED },
   {
     name: "JSON-with-comments (invalid)",
     raw: true,
@@ -151,9 +188,6 @@ const PAYLOADS = [
   {
     name: "BOM-prefixed JSON",
     raw: true,
-    // U+FEFF prefix constructed via String.fromCharCode so the
-    // source file stays pure-ASCII (a literal BOM in source trips
-    // ESLint's no-irregular-whitespace).
     body: String.fromCharCode(0xfeff) + `{"date":"2026-05-08","word":"ALPHA","lang":"en"}`
   },
   {
@@ -170,18 +204,16 @@ const PAYLOADS = [
     body: `{"date":"2026-05-08",}`
   },
   {
-    name: "non-UTF-8 bytes",
-    raw: true,
-    body: Buffer.from([0xff, 0xfe, 0x00, 0x01]).toString("binary")
+    // Raw non-UTF-8 byte stream — sent as a Buffer via Node's
+    // request stream so the bytes survive verbatim (toString("binary")
+    // would have been re-encoded by supertest's body serializer).
+    name: "non-UTF-8 bytes (raw Buffer)",
+    rawBytes: Buffer.from([0xff, 0xfe, 0x00, 0x01, 0x80, 0x90])
   }
 ];
 
 // ---------- Routes under fuzz ----------
-//
-// Each entry: { method, path, requiresAdmin } — we cycle every
-// payload through every entry. `requiresAdmin: true` means the
-// fuzz uses an x-admin-key header (otherwise the request 401s
-// before the body parser even gets to the malformed payload).
+
 const ROUTES_TO_FUZZ = [
   {
     method: "post",
@@ -209,69 +241,78 @@ const ROUTES_TO_FUZZ = [
   }
 ];
 
-// ---------- Sentinel: confirm Object.prototype isn't polluted ----------
+// ---------- Prototype-pollution sentinel ----------
+//
+// We do NOT clean Object.prototype between fuzz cases. A polluting
+// payload that lands during one case would otherwise be wiped by
+// afterEach before the assertion below could observe it. Cleanup
+// happens ONLY at suite end (afterAll). The sentinel assertions run
+// inside the matrix loop AND after the loop completes so any
+// pollution is caught regardless of which payload introduced it.
+// Codex P2 + Copilot caught the prior afterEach-then-assert ordering
+// on PR #136.
 
-const PROTO_SENTINEL_KEY = "__c2_fuzz_pollution_sentinel__";
-function isPrototypePolluted() {
-  return (
-    Object.prototype.hasOwnProperty.call({}, PROTO_SENTINEL_KEY)
-    || ({})[PROTO_SENTINEL_KEY] !== undefined
-  );
-}
-
-afterEach(() => {
-  // Defensive cleanup — if a fuzz somehow DID land a __proto__
-  // mutation on Object.prototype, clear it so the next test starts
-  // clean. The assertion in the prototype-pollution sentinel
-  // describe block will have already failed; we just don't want
-  // cross-test contamination.
-  delete Object.prototype[PROTO_SENTINEL_KEY];
+afterAll(() => {
+  // One-time cleanup so a polluted Object.prototype doesn't leak
+  // into later suites that share this process.
   delete Object.prototype.polluted;
 });
+
+function objectPrototypeIsClean() {
+  return (
+    Object.prototype.polluted === undefined
+    && Object.getPrototypeOf({}).polluted === undefined
+    && ({}).polluted === undefined
+  );
+}
 
 // ---------- The matrix ----------
 
 describe("admin route input fuzz: every route × every payload survives malformed input", () => {
-  for (const route of ROUTES_TO_FUZZ) {
+  for (const route of ROUTES_TO_FUZZE_NAME_GUARD(ROUTES_TO_FUZZ)) {
     describe(`${route.method.toUpperCase()} ${route.path} (${route.label})`, () => {
       for (const payload of PAYLOADS) {
         test(`payload: ${payload.name}`, async () => {
           const app = loadApp("test-key");
           const req = supertest(app)[route.method](route.path);
-          req.set("x-admin-key", "test-key");
+          if (route.requiresAdmin) {
+            req.set("x-admin-key", "test-key");
+          }
+
           let response;
-          if (payload.raw) {
+          if (payload.rawBytes) {
+            // Raw bytes — set the type and send the Buffer verbatim.
+            req.set("Content-Type", "application/octet-stream");
+            response = await req.send(payload.rawBytes);
+          } else if (payload.raw) {
             req.set("Content-Type", "application/json");
             response = await req.send(payload.body);
           } else {
             response = await req.send(payload.body);
           }
-          // CONTRACT (1): the server doesn't crash. Status MAY be:
-          //   - 2xx (route accepted after stripping/sanitizing the
-          //     bad parts — e.g., express.json() drops `__proto__`
-          //     keys before they reach the handler)
-          //   - 4xx (route rejected the malformed input outright)
-          // What's NEVER OK is 5xx, which would mean the server
-          // crashed reading the body or the handler threw an
-          // unexpected error.
+
+          // Contract (1): no crash.
           expect(response.status).toBeLessThan(500);
 
-          // CONTRACT (2): if a body is returned, it must not leak
-          // sensitive substrings. We check for absolute paths,
-          // process secrets, and the canonical Node stack-trace
-          // prefix.
-          const bodyText = typeof response.body === "string"
-            ? response.body
-            : JSON.stringify(response.body || {});
-          expect(bodyText).not.toMatch(/\/Users\/|\/home\/|\/private\/|node_modules/);
-          expect(bodyText).not.toMatch(/test-key/); // ADMIN_KEY value
-          expect(bodyText).not.toMatch(/at\s+[A-Za-z]+\s+\(.*:\d+:\d+\)/); // V8 stack frame
+          // Contract (2): no info leak — check BOTH response.body
+          // (JSON shape) and response.text (raw, used by body-parser
+          // error responses).
+          const haystack = [
+            typeof response.body === "string" ? response.body : JSON.stringify(response.body || {}),
+            response.text || ""
+          ].join("\n");
+          expect(haystack).not.toMatch(/\/Users\/|\/home\/|\/private\/|node_modules/);
+          expect(haystack).not.toMatch(/test-key/);
+          expect(haystack).not.toMatch(/at\s+[A-Za-z]+\s+\(.*:\d+:\d+\)/);
+
+          // Contract (3): no pollution from THIS payload.
+          // Asserted here (in the loop) AND once at the very end
+          // so a payload-specific pollution gets attributed to
+          // its payload.
+          expect(objectPrototypeIsClean()).toBe(true);
         });
       }
       test("server survives the matrix: subsequent GET still works", async () => {
-        // After the malformed-input matrix above, a follow-up GET
-        // should still succeed. Run a GET on a safe admin route to
-        // confirm process-level survival.
         const app = loadApp("test-key");
         const res = await supertest(app)
           .get("/api/admin/schedule")
@@ -282,13 +323,23 @@ describe("admin route input fuzz: every route × every payload survives malforme
   }
 });
 
-describe("admin route input fuzz: prototype-pollution sentinel", () => {
-  test("after the full fuzz matrix, Object.prototype is unchanged", () => {
-    // If any of the __proto__ / constructor.prototype payloads
-    // succeeded in mutating Object.prototype, this would fail.
-    // Catches the worst-case proto-pollution outcome.
-    expect(isPrototypePolluted()).toBe(false);
-    expect(Object.prototype.hasOwnProperty.call({}, "polluted")).toBe(false);
-    expect(({}).polluted).toBeUndefined();
+// Tiny guard that surfaces an obvious error if someone removes
+// ROUTES_TO_FUZZ entries without re-checking the matrix iteration.
+function ROUTES_TO_FUZZE_NAME_GUARD(routes) {
+  if (!Array.isArray(routes) || routes.length === 0) {
+    throw new Error("ROUTES_TO_FUZZ must be a non-empty array");
+  }
+  return routes;
+}
+
+// ---------- Belt-and-suspenders: post-matrix sentinel ----------
+
+describe("admin route input fuzz: prototype-pollution sentinel (post-matrix)", () => {
+  test("after every fuzz test ran, Object.prototype remains clean", () => {
+    // The matrix loop above asserts per-payload. This sentinel
+    // catches the case where a pollution lands but somehow isn't
+    // observable by the per-test check (e.g., gets cleared before
+    // the inline assert). Belt-and-suspenders.
+    expect(objectPrototypeIsClean()).toBe(true);
   });
 });

--- a/tests/admin-routes.fuzz.test.js
+++ b/tests/admin-routes.fuzz.test.js
@@ -26,9 +26,14 @@
 //     observes the worst-case state. Cleanup is suite-end only.
 //   - A baseline GET on a fresh server instance still returns 200
 //     (post-matrix sanity check that the test infrastructure
-//     itself is healthy — NOT a process-level survival assertion;
-//     every fuzz test re-requires server.js via loadApp(), so
-//     each one runs against a fresh process anyway).
+//     itself is healthy — NOT a process-level survival assertion).
+//     `loadApp()` calls `jest.resetModules()` + re-requires
+//     server.js, which gives a fresh MODULE GRAPH in the same
+//     Jest worker process; it does NOT spawn a new OS process.
+//     Genuine process-wide side effects (e.g., a hypothetical
+//     fuzz that polluted Object.prototype) would persist across
+//     loadApp boundaries — that's why the post-matrix
+//     prototype-pollution sentinel still earns its keep.
 //
 // What we fuzz (each route gets cross-matrix coverage):
 //   - empty / null body
@@ -327,7 +332,16 @@ describe("admin route input fuzz: every route × every payload survives malforme
             /\/Users\/|\/home\/|\/private\/|\/tmp\/|node_modules/
           );
           expect(haystack).not.toMatch(/test-key/);
-          expect(haystack).not.toMatch(/at\s+[A-Za-z]+\s+\(.*:\d+:\d+\)/);
+          // V8 stack-frame patterns:
+          //   - `at funcName (path:line:col)`            — basic
+          //   - `at Layer.handle [as handle_request] (path:line:col)` — Express
+          //   - `at node:internal/process/...:line:col`  — Node internals
+          //   - `at async funcName (path:line:col)`       — async frames
+          // Match any line starting with `at ` followed by anything,
+          // ending in `:digits:digits)?`. Copilot caught the prior
+          // narrow regex missing `Layer.handle [as ...]` and
+          // `node:internal/...` on PR #136 round 5.
+          expect(haystack).not.toMatch(/\bat\s+\S+.*:\d+:\d+\)?/);
 
           // Contract (3): no pollution. We only assert at suite-end
           // (post-matrix sentinel below) rather than per-payload —

--- a/tests/admin-routes.fuzz.test.js
+++ b/tests/admin-routes.fuzz.test.js
@@ -19,11 +19,16 @@
 //     plain-text response with body === {} (Copilot caught this
 //     on PR #136).
 //   - Object.prototype is unchanged AFTER the full fuzz matrix
-//     (asserted via a sentinel set BEFORE the matrix runs +
-//     checked AFTER, NOT between tests — the afterEach hook
-//     deliberately leaves prototype mutations intact across the
-//     matrix so the sentinel runs against a worst-case state).
-//   - A follow-up GET on a known-safe admin route still works.
+//     (a single post-matrix sentinel test reads Object.prototype
+//     and asserts no `polluted` key landed). NO per-test cleanup
+//     runs between fuzz cases — a polluting payload's effect is
+//     deliberately preserved across the matrix so the sentinel
+//     observes the worst-case state. Cleanup is suite-end only.
+//   - A baseline GET on a fresh server instance still returns 200
+//     (post-matrix sanity check that the test infrastructure
+//     itself is healthy — NOT a process-level survival assertion;
+//     every fuzz test re-requires server.js via loadApp(), so
+//     each one runs against a fresh process anyway).
 //
 // What we fuzz (each route gets cross-matrix coverage):
 //   - empty / null body

--- a/tests/admin-routes.fuzz.test.js
+++ b/tests/admin-routes.fuzz.test.js
@@ -169,7 +169,11 @@ const PROTO_INJECT_NESTED = JSON.parse(
 //     supertest's write/end path so Node doesn't re-encode it
 const PAYLOADS = [
   { name: "empty body", body: {} },
-  { name: "null body", body: null },
+  // superagent.send(null) actually sends NO body (it early-returns
+  // before serialization), so the prior `body: null` was a duplicate
+  // of "empty body". To exercise the literal JSON `null` path, send
+  // the string "null" as raw JSON. CodeRabbit caught this on PR #136.
+  { name: "literal JSON null", raw: true, body: "null" },
   { name: "depth-bomb (object, 500 levels)", body: depthBombObject(500) },
   { name: "depth-bomb (array, 500 levels)", body: depthBombArray(500) },
   { name: "__proto__ injection at top", body: PROTO_INJECT_TOP },
@@ -269,7 +273,7 @@ function objectPrototypeIsClean() {
 // ---------- The matrix ----------
 
 describe("admin route input fuzz: every route × every payload survives malformed input", () => {
-  for (const route of ROUTES_TO_FUZZE_NAME_GUARD(ROUTES_TO_FUZZ)) {
+  for (const route of requireRoutes(ROUTES_TO_FUZZ)) {
     describe(`${route.method.toUpperCase()} ${route.path} (${route.label})`, () => {
       for (const payload of PAYLOADS) {
         test(`payload: ${payload.name}`, async () => {
@@ -301,18 +305,37 @@ describe("admin route input fuzz: every route × every payload survives malforme
             typeof response.body === "string" ? response.body : JSON.stringify(response.body || {}),
             response.text || ""
           ].join("\n");
-          expect(haystack).not.toMatch(/\/Users\/|\/home\/|\/private\/|node_modules/);
+          // Include `/tmp/` (the Linux/CI tempdir) — CodeRabbit
+          // caught the prior pattern only covering macOS-style
+          // `/private/var/folders` + repo-style `/Users` and
+          // `/home` paths. On the GitHub Actions Linux runner,
+          // `os.tmpdir()` resolves to `/tmp`, so a path-style leak
+          // through there would have been missed.
+          expect(haystack).not.toMatch(
+            /\/Users\/|\/home\/|\/private\/|\/tmp\/|node_modules/
+          );
           expect(haystack).not.toMatch(/test-key/);
           expect(haystack).not.toMatch(/at\s+[A-Za-z]+\s+\(.*:\d+:\d+\)/);
 
-          // Contract (3): no pollution from THIS payload.
-          // Asserted here (in the loop) AND once at the very end
-          // so a payload-specific pollution gets attributed to
-          // its payload.
-          expect(objectPrototypeIsClean()).toBe(true);
+          // Contract (3): no pollution. We only assert at suite-end
+          // (post-matrix sentinel below) rather than per-payload —
+          // CodeRabbit caught that the per-payload check would
+          // cascade failures across every subsequent test once any
+          // single payload pollutes, making the polluter harder to
+          // identify in the test output. The single end-of-suite
+          // check still catches the worst-case outcome with cleaner
+          // diagnostics.
         });
       }
-      test("server survives the matrix: subsequent GET still works", async () => {
+      // The per-payload tests above each call loadApp() which
+      // jest.resetModules() + re-requires server.js, so each fuzz
+      // already exercises a fresh process-level server. The
+      // survival test ALSO uses a fresh app — which means it's
+      // really "fresh app handles a sane GET", not "the process
+      // survived the malformed inputs above" (CodeRabbit caught
+      // the doc-vs-test mismatch on PR #136). Renamed to reflect
+      // what it actually verifies: a clean post-fuzz baseline.
+      test("baseline GET on a fresh app returns 200 (post-matrix sanity)", async () => {
         const app = loadApp("test-key");
         const res = await supertest(app)
           .get("/api/admin/schedule")
@@ -325,7 +348,9 @@ describe("admin route input fuzz: every route × every payload survives malforme
 
 // Tiny guard that surfaces an obvious error if someone removes
 // ROUTES_TO_FUZZ entries without re-checking the matrix iteration.
-function ROUTES_TO_FUZZE_NAME_GUARD(routes) {
+// (Originally named ROUTES_TO_FUZZE_NAME_GUARD with a typo +
+// SCREAMING_SNAKE_CASE; CodeRabbit caught both on PR #136.)
+function requireRoutes(routes) {
   if (!Array.isArray(routes) || routes.length === 0) {
     throw new Error("ROUTES_TO_FUZZ must be a non-empty array");
   }

--- a/tests/admin-routes.fuzz.test.js
+++ b/tests/admin-routes.fuzz.test.js
@@ -6,11 +6,13 @@
 // asserts the production contract:
 //
 //   - Server doesn't crash (status < 500). A 2xx response is fine
-//     if the route legitimately accepts the sanitized input —
-//     Express's body parser strips `__proto__` keys before the
-//     handler sees them, accepts BOM prefixes, etc. The contract
-//     is "no crash, no leak, no proto-pollution" — NOT "every
-//     malformed input must 4xx".
+//     when the route legitimately accepts the input — `express.json()`
+//     with default options PARSES the JSON but does not strip
+//     `__proto__` keys; whether pollution lands depends on what the
+//     handler does with the parsed object. The contract this harness
+//     asserts is "no crash, no leak, no proto-pollution observed via
+//     the post-matrix sentinel" — NOT "every malformed input must
+//     4xx" and NOT "the parser sanitizes the body".
 //   - Neither `response.body` NOR `response.text` leaks
 //     filesystem paths, the ADMIN_KEY value, or V8 stack frames.
 //     We check both because body-parser errors typically yield a
@@ -63,12 +65,17 @@ function resetEnv() {
   });
 }
 
-function tempPath(name) {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-fuzz-"));
-  return { dir, filePath: path.join(dir, name) };
-}
-
+// One tempdir per loadApp call (not per-store). Hosts all 11 store
+// files side-by-side. The prior implementation called mkdtempSync
+// once per store; multiplied by 48+ fuzz cases that's ~528 mkdtemp
+// calls and ~528 rmdir calls per run — observable filesystem
+// overhead. CodeRabbit caught this on PR #136 round 2.
 const tempDirs = [];
+function mkAppTempdir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-fuzz-"));
+  tempDirs.push(dir);
+  return dir;
+}
 
 function loadApp(adminKey) {
   jest.resetModules();
@@ -85,41 +92,18 @@ function loadApp(adminKey) {
   // vs the actual WEBHOOKS_STORE_PATH), which silently let the
   // fuzz run against the REAL repo data/ directory. Names below
   // come from grepping `server.js` for `process.env.*PATH`.
-  const schedule = tempPath("schedule.json");
-  const stats = tempPath("leaderboard.json");
-  const webhooks = tempPath("webhooks.json");
-  const deliveries = tempPath("webhook-deliveries.json");
-  const challenges = tempPath("challenges.json");
-  const results = tempPath("challenge-results.json");
-  const classes = tempPath("classes.json");
-  const adminJobs = tempPath("admin-jobs.json");
-  const pushSubs = tempPath("push-subscriptions.json");
-  const vapid = tempPath("vapid.json");
-  const appConfig = tempPath("app-config.json");
-  tempDirs.push(
-    schedule.dir,
-    stats.dir,
-    webhooks.dir,
-    deliveries.dir,
-    challenges.dir,
-    results.dir,
-    classes.dir,
-    adminJobs.dir,
-    pushSubs.dir,
-    vapid.dir,
-    appConfig.dir
-  );
-  process.env.SCHEDULE_STORE_PATH = schedule.filePath;
-  process.env.STATS_STORE_PATH = stats.filePath;
-  process.env.WEBHOOKS_STORE_PATH = webhooks.filePath;
-  process.env.WEBHOOK_DELIVERIES_STORE_PATH = deliveries.filePath;
-  process.env.CHALLENGE_STORE_PATH = challenges.filePath;
-  process.env.CHALLENGE_RESULTS_STORE_PATH = results.filePath;
-  process.env.CLASSES_STORE_PATH = classes.filePath;
-  process.env.ADMIN_JOBS_STORE_PATH = adminJobs.filePath;
-  process.env.PUSH_SUBSCRIPTIONS_STORE_PATH = pushSubs.filePath;
-  process.env.VAPID_KEYS_STORE_PATH = vapid.filePath;
-  process.env.APP_CONFIG_PATH = appConfig.filePath;
+  const root = mkAppTempdir();
+  process.env.SCHEDULE_STORE_PATH = path.join(root, "schedule.json");
+  process.env.STATS_STORE_PATH = path.join(root, "leaderboard.json");
+  process.env.WEBHOOKS_STORE_PATH = path.join(root, "webhooks.json");
+  process.env.WEBHOOK_DELIVERIES_STORE_PATH = path.join(root, "webhook-deliveries.json");
+  process.env.CHALLENGE_STORE_PATH = path.join(root, "challenges.json");
+  process.env.CHALLENGE_RESULTS_STORE_PATH = path.join(root, "challenge-results.json");
+  process.env.CLASSES_STORE_PATH = path.join(root, "classes.json");
+  process.env.ADMIN_JOBS_STORE_PATH = path.join(root, "admin-jobs.json");
+  process.env.PUSH_SUBSCRIPTIONS_STORE_PATH = path.join(root, "push-subscriptions.json");
+  process.env.VAPID_KEYS_STORE_PATH = path.join(root, "vapid.json");
+  process.env.APP_CONFIG_PATH = path.join(root, "app-config.json");
   process.env.SCHEDULER_CHECK_INTERVAL_MS = String(60 * 60 * 1000);
   return require("../server");
 }
@@ -169,11 +153,14 @@ const PROTO_INJECT_NESTED = JSON.parse(
 //     supertest's write/end path so Node doesn't re-encode it
 const PAYLOADS = [
   { name: "empty body", body: {} },
-  // superagent.send(null) actually sends NO body (it early-returns
-  // before serialization), so the prior `body: null` was a duplicate
-  // of "empty body". To exercise the literal JSON `null` path, send
-  // the string "null" as raw JSON. CodeRabbit caught this on PR #136.
-  { name: "literal JSON null", raw: true, body: "null" },
+  // Top-level JSON `null` against `express.json()` default options:
+  // strict mode (which is the default) rejects this with
+  // `entity.parse.failed`. The case exercises that strict-parser
+  // error path — handler is never reached. NOT a "happy null body"
+  // case (CodeRabbit caught the prior naming on PR #136; Copilot
+  // refined the rationale on round 2 — the test still earns its
+  // keep by covering the parser-strict-reject branch).
+  { name: "top-level JSON null (strict-parser reject)", raw: true, body: "null" },
   { name: "depth-bomb (object, 500 levels)", body: depthBombObject(500) },
   { name: "depth-bomb (array, 500 levels)", body: depthBombArray(500) },
   { name: "__proto__ injection at top", body: PROTO_INJECT_TOP },
@@ -249,12 +236,16 @@ const ROUTES_TO_FUZZ = [
 //
 // We do NOT clean Object.prototype between fuzz cases. A polluting
 // payload that lands during one case would otherwise be wiped by
-// afterEach before the assertion below could observe it. Cleanup
-// happens ONLY at suite end (afterAll). The sentinel assertions run
-// inside the matrix loop AND after the loop completes so any
-// pollution is caught regardless of which payload introduced it.
-// Codex P2 + Copilot caught the prior afterEach-then-assert ordering
-// on PR #136.
+// afterEach before the post-matrix sentinel could observe it.
+// Cleanup happens ONLY at suite end (afterAll). The single
+// sentinel test below runs AFTER every matrix test and asserts the
+// worst-case state. We deliberately moved AWAY from a per-payload
+// check on round 2 — the cascade pattern (one polluter → all
+// subsequent payload tests fail) drowned the polluter's identity
+// in the test output; one end-of-suite check gives cleaner
+// diagnostics. The downside is the sentinel doesn't pinpoint
+// which payload polluted; if that becomes relevant in practice,
+// adding a tightly-scoped per-payload assert is straightforward.
 
 afterAll(() => {
   // One-time cleanup so a polluted Object.prototype doesn't leak
@@ -361,10 +352,10 @@ function requireRoutes(routes) {
 
 describe("admin route input fuzz: prototype-pollution sentinel (post-matrix)", () => {
   test("after every fuzz test ran, Object.prototype remains clean", () => {
-    // The matrix loop above asserts per-payload. This sentinel
-    // catches the case where a pollution lands but somehow isn't
-    // observable by the per-test check (e.g., gets cleared before
-    // the inline assert). Belt-and-suspenders.
+    // This is the ONLY pollution assertion in the file. We moved
+    // away from a per-payload check on round 2 (it cascaded once
+    // any payload polluted, making the polluter hard to identify
+    // — CodeRabbit caught the noise on PR #136).
     expect(objectPrototypeIsClean()).toBe(true);
   });
 });

--- a/tests/admin-routes.fuzz.test.js
+++ b/tests/admin-routes.fuzz.test.js
@@ -1,0 +1,294 @@
+"use strict";
+
+// Admin route input fuzz harness — Epic C #128.
+//
+// Feeds malformed payloads to every admin write route and asserts
+// the production contract:
+//
+//   - Status code is 4xx (typically 400/401/403) — never 5xx unless
+//     the malformed input genuinely triggers a server bug we want to
+//     surface.
+//   - Response body shape is the sanitized-error envelope. No
+//     filesystem paths, no stack traces, no env var values.
+//   - The server survives — a follow-up GET on the same endpoint
+//     succeeds (no process-level corruption from the malformed body).
+//   - Prototype-pollution keys (__proto__, constructor, prototype)
+//     are rejected; Object.prototype is unchanged.
+//
+// What we fuzz (each route gets cross-matrix coverage):
+//   1. Empty body / null body
+//   2. Oversized body (just past JSON_BODY_LIMIT)
+//   3. Depth-bombed JSON (deeply-nested objects/arrays)
+//   4. Prototype-pollution keys at top level
+//   5. Prototype-pollution keys nested
+//   6. Non-UTF-8 bytes / BOM prefix
+//   7. JSON-with-comments (invalid per JSON.parse)
+//   8. Embedded NUL characters
+//
+// We DON'T cover every admin route exhaustively in this PR — the
+// harness pattern is the deliverable. A representative cross-section
+// (schedule, webhook, challenge config) is exercised. Adding routes
+// is a one-line append to ROUTES_TO_FUZZ; nothing else changes.
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const supertest = require("supertest");
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv() {
+  Object.keys(process.env).forEach((key) => {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  });
+  Object.entries(ORIGINAL_ENV).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+}
+
+function tempPath(name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-fuzz-"));
+  return { dir, filePath: path.join(dir, name) };
+}
+
+const tempDirs = [];
+
+function loadApp(adminKey) {
+  jest.resetModules();
+  resetEnv();
+  if (adminKey) {
+    process.env.ADMIN_KEY = adminKey;
+  } else {
+    delete process.env.ADMIN_KEY;
+  }
+  process.env.NODE_ENV = "test";
+  // Point every store at a per-test tempdir so concurrent fuzz tests
+  // don't trip over each other on disk.
+  const schedule = tempPath("schedule.json");
+  const stats = tempPath("leaderboard.json");
+  const webhooks = tempPath("webhooks.json");
+  const deliveries = tempPath("webhook-deliveries.json");
+  const challenges = tempPath("challenges.json");
+  const results = tempPath("challenge-results.json");
+  tempDirs.push(schedule.dir, stats.dir, webhooks.dir, deliveries.dir, challenges.dir, results.dir);
+  process.env.SCHEDULE_STORE_PATH = schedule.filePath;
+  process.env.STATS_STORE_PATH = stats.filePath;
+  process.env.WEBHOOK_STORE_PATH = webhooks.filePath;
+  process.env.WEBHOOK_DELIVERY_STORE_PATH = deliveries.filePath;
+  process.env.CHALLENGE_CONFIG_STORE_PATH = challenges.filePath;
+  process.env.CHALLENGE_RESULTS_STORE_PATH = results.filePath;
+  process.env.SCHEDULER_CHECK_INTERVAL_MS = String(60 * 60 * 1000);
+  return require("../server");
+}
+
+afterAll(async () => {
+  resetEnv();
+  for (const dir of tempDirs) {
+    await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+  tempDirs.length = 0;
+});
+
+// ---------- Payload generators ----------
+
+// Build a deeply-nested object N levels deep — depth-bomb that a
+// naive normalizer might stack-overflow on.
+function depthBombObject(depth) {
+  let inner = { leaf: 1 };
+  for (let i = 0; i < depth; i += 1) {
+    inner = { nested: inner };
+  }
+  return inner;
+}
+
+// Build a deeply-nested array.
+function depthBombArray(depth) {
+  let inner = [];
+  for (let i = 0; i < depth; i += 1) {
+    inner = [inner];
+  }
+  return inner;
+}
+
+// Payloads we send. Each is { name, body, contentType?, raw? }:
+//   - name: human label for failure messages
+//   - body: object passed via supertest .send(body), OR a string
+//     for raw text bodies via .set("Content-Type") + .send(string)
+//   - raw: if true, body is sent as raw text (not auto-stringified)
+const PAYLOADS = [
+  { name: "empty body", body: {} },
+  { name: "null body", body: null },
+  { name: "depth-bomb (object, 500 levels)", body: depthBombObject(500) },
+  { name: "depth-bomb (array, 500 levels)", body: depthBombArray(500) },
+  {
+    name: "__proto__ injection at top",
+    body: { __proto__: { polluted: "yes" }, date: "2026-05-08", word: "ALPHA", lang: "en" }
+  },
+  {
+    name: "constructor.prototype injection",
+    body: {
+      constructor: { prototype: { polluted: "yes" } },
+      date: "2026-05-08",
+      word: "ALPHA",
+      lang: "en"
+    }
+  },
+  {
+    name: "nested __proto__ injection",
+    body: {
+      date: "2026-05-08",
+      word: "ALPHA",
+      lang: "en",
+      meta: { __proto__: { polluted: "yes" } }
+    }
+  },
+  {
+    name: "JSON-with-comments (invalid)",
+    raw: true,
+    body: `{ /* comment */ "date": "2026-05-08" }`
+  },
+  {
+    name: "BOM-prefixed JSON",
+    raw: true,
+    // U+FEFF prefix constructed via String.fromCharCode so the
+    // source file stays pure-ASCII (a literal BOM in source trips
+    // ESLint's no-irregular-whitespace).
+    body: String.fromCharCode(0xfeff) + `{"date":"2026-05-08","word":"ALPHA","lang":"en"}`
+  },
+  {
+    name: "embedded NUL in string field",
+    body: {
+      date: "2026-05-08",
+      word: `AL${String.fromCharCode(0)}PHA`,
+      lang: "en"
+    }
+  },
+  {
+    name: "trailing comma (invalid JSON)",
+    raw: true,
+    body: `{"date":"2026-05-08",}`
+  },
+  {
+    name: "non-UTF-8 bytes",
+    raw: true,
+    body: Buffer.from([0xff, 0xfe, 0x00, 0x01]).toString("binary")
+  }
+];
+
+// ---------- Routes under fuzz ----------
+//
+// Each entry: { method, path, requiresAdmin } — we cycle every
+// payload through every entry. `requiresAdmin: true` means the
+// fuzz uses an x-admin-key header (otherwise the request 401s
+// before the body parser even gets to the malformed payload).
+const ROUTES_TO_FUZZ = [
+  {
+    method: "post",
+    path: "/api/admin/schedule/entries",
+    requiresAdmin: true,
+    label: "schedule entry create"
+  },
+  {
+    method: "put",
+    path: "/api/admin/schedule/config",
+    requiresAdmin: true,
+    label: "schedule config update"
+  },
+  {
+    method: "post",
+    path: "/api/admin/webhooks",
+    requiresAdmin: true,
+    label: "webhook create"
+  },
+  {
+    method: "post",
+    path: "/api/admin/challenges",
+    requiresAdmin: true,
+    label: "challenge create"
+  }
+];
+
+// ---------- Sentinel: confirm Object.prototype isn't polluted ----------
+
+const PROTO_SENTINEL_KEY = "__c2_fuzz_pollution_sentinel__";
+function isPrototypePolluted() {
+  return (
+    Object.prototype.hasOwnProperty.call({}, PROTO_SENTINEL_KEY)
+    || ({})[PROTO_SENTINEL_KEY] !== undefined
+  );
+}
+
+afterEach(() => {
+  // Defensive cleanup — if a fuzz somehow DID land a __proto__
+  // mutation on Object.prototype, clear it so the next test starts
+  // clean. The assertion in the prototype-pollution sentinel
+  // describe block will have already failed; we just don't want
+  // cross-test contamination.
+  delete Object.prototype[PROTO_SENTINEL_KEY];
+  delete Object.prototype.polluted;
+});
+
+// ---------- The matrix ----------
+
+describe("admin route input fuzz: every route × every payload survives malformed input", () => {
+  for (const route of ROUTES_TO_FUZZ) {
+    describe(`${route.method.toUpperCase()} ${route.path} (${route.label})`, () => {
+      for (const payload of PAYLOADS) {
+        test(`payload: ${payload.name}`, async () => {
+          const app = loadApp("test-key");
+          const req = supertest(app)[route.method](route.path);
+          req.set("x-admin-key", "test-key");
+          let response;
+          if (payload.raw) {
+            req.set("Content-Type", "application/json");
+            response = await req.send(payload.body);
+          } else {
+            response = await req.send(payload.body);
+          }
+          // CONTRACT (1): the server doesn't crash. Status MAY be:
+          //   - 2xx (route accepted after stripping/sanitizing the
+          //     bad parts — e.g., express.json() drops `__proto__`
+          //     keys before they reach the handler)
+          //   - 4xx (route rejected the malformed input outright)
+          // What's NEVER OK is 5xx, which would mean the server
+          // crashed reading the body or the handler threw an
+          // unexpected error.
+          expect(response.status).toBeLessThan(500);
+
+          // CONTRACT (2): if a body is returned, it must not leak
+          // sensitive substrings. We check for absolute paths,
+          // process secrets, and the canonical Node stack-trace
+          // prefix.
+          const bodyText = typeof response.body === "string"
+            ? response.body
+            : JSON.stringify(response.body || {});
+          expect(bodyText).not.toMatch(/\/Users\/|\/home\/|\/private\/|node_modules/);
+          expect(bodyText).not.toMatch(/test-key/); // ADMIN_KEY value
+          expect(bodyText).not.toMatch(/at\s+[A-Za-z]+\s+\(.*:\d+:\d+\)/); // V8 stack frame
+        });
+      }
+      test("server survives the matrix: subsequent GET still works", async () => {
+        // After the malformed-input matrix above, a follow-up GET
+        // should still succeed. Run a GET on a safe admin route to
+        // confirm process-level survival.
+        const app = loadApp("test-key");
+        const res = await supertest(app)
+          .get("/api/admin/schedule")
+          .set("x-admin-key", "test-key");
+        expect(res.status).toBe(200);
+      });
+    });
+  }
+});
+
+describe("admin route input fuzz: prototype-pollution sentinel", () => {
+  test("after the full fuzz matrix, Object.prototype is unchanged", () => {
+    // If any of the __proto__ / constructor.prototype payloads
+    // succeeded in mutating Object.prototype, this would fail.
+    // Catches the worst-case proto-pollution outcome.
+    expect(isPrototypePolluted()).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call({}, "polluted")).toBe(false);
+    expect(({}).polluted).toBeUndefined();
+  });
+});

--- a/tests/admin-routes.fuzz.test.js
+++ b/tests/admin-routes.fuzz.test.js
@@ -276,8 +276,13 @@ describe("admin route input fuzz: every route × every payload survives malforme
 
           let response;
           if (payload.rawBytes) {
-            // Raw bytes — set the type and send the Buffer verbatim.
-            req.set("Content-Type", "application/octet-stream");
+            // Raw bytes — set Content-Type to application/json so
+            // express.json() actually attempts to parse them
+            // (Codex P2 caught on PR #136 round 3: an
+            // octet-stream Content-Type made the middleware skip
+            // parsing entirely, so the bytes never traversed the
+            // JSON-decode path we wanted to fuzz).
+            req.set("Content-Type", "application/json");
             response = await req.send(payload.rawBytes);
           } else if (payload.raw) {
             req.set("Content-Type", "application/json");

--- a/tests/admin-routes.fuzz.test.js
+++ b/tests/admin-routes.fuzz.test.js
@@ -281,13 +281,24 @@ describe("admin route input fuzz: every route × every payload survives malforme
 
           let response;
           if (payload.rawBytes) {
-            // Raw bytes — set Content-Type to application/json so
-            // express.json() actually attempts to parse them
-            // (Codex P2 caught on PR #136 round 3: an
-            // octet-stream Content-Type made the middleware skip
-            // parsing entirely, so the bytes never traversed the
-            // JSON-decode path we wanted to fuzz).
+            // Raw bytes through the JSON parser. Two non-obvious
+            // mechanics here, both caught by Codex on PR #136:
+            //
+            //   1. `Content-Type: application/json` is required so
+            //      `express.json()` actually attempts to parse the
+            //      body (with `application/octet-stream` the
+            //      middleware skips entirely → handler sees no body
+            //      → indistinguishable from the empty-body case).
+            //   2. `.send(Buffer)` with a JSON Content-Type makes
+            //      superagent JSON-serialize the Buffer into
+            //      `{"type":"Buffer","data":[...]}`, so the server
+            //      receives valid UTF-8 JSON, not the malformed
+            //      bytes. `.serialize((d) => d)` overrides that
+            //      serializer to return the Buffer verbatim — the
+            //      malformed bytes survive the supertest layer
+            //      and reach the JSON parser.
             req.set("Content-Type", "application/json");
+            req.serialize((d) => d);
             response = await req.send(payload.rawBytes);
           } else if (payload.raw) {
             req.set("Content-Type", "application/json");


### PR DESCRIPTION
## Summary

Adds `tests/admin-routes.fuzz.test.js` — a cross-matrix fuzz that feeds 12 malformed payloads to 4 representative admin write routes and asserts the production contract:

- **Server doesn't crash** (status < 500). A 2xx response is fine if the route legitimately accepts the input — `express.json()` parses but does NOT strip `__proto__`; the contract is "no crash, no leak, no pollution observed via the post-matrix sentinel" — NOT "every malformed input must 4xx" and NOT "the parser sanitizes the body".
- **Response body never leaks** filesystem paths (including `/tmp/` on Linux CI), the `ADMIN_KEY` value, or V8 stack frames (regex covers standard `at fn (path:n:m)`, Express `Layer.handle [as ...]`, and `node:internal` frames).
- **`Object.prototype` is unchanged** across the full matrix — verified by a single end-of-suite sentinel test (deliberate; per-payload cleanup was tried in round 1 and removed because it wiped pollution before observation, and per-payload assertion cascades drown the polluter in noise).
- **Baseline GET on a fresh app** returns 200 — sanity check that the test infrastructure is healthy after the matrix. NOT a process-level survival assertion (every fuzz test re-requires `server.js` via `loadApp()` which calls `jest.resetModules()` — same Jest worker process, fresh module graph).

## Payloads (12)

empty body · top-level JSON null (strict-parser reject) · depth-bomb object (500 levels) · depth-bomb array (500 levels) · `__proto__` injection at top (via `JSON.parse` so the literal key actually traverses the wire) · `constructor.prototype` injection · nested `__proto__` injection · JSON-with-comments · BOM-prefixed JSON · trailing-comma JSON · embedded NUL in string field · non-UTF-8 raw Buffer (delivered through `req.serialize((d) => d)` to bypass superagent's body serializer)

## Routes covered (4 representative)

- `POST /api/admin/schedule/entries`
- `PUT  /api/admin/schedule/config`
- `POST /api/admin/webhooks`
- `POST /api/admin/challenges`

12 × 4 = **48 fuzz tests** + 4 baseline-GET tests + 1 prototype-pollution sentinel = **53 test cases total**.

## C epic ordering

Per the saved order: C1 → C6 → C3 → **C2** → A4/A5 → A/B → C4/C5. C1, C6, and C3 merged; this is C2.

## Test plan
- [x] 53/53 fuzz tests pass
- [x] Full `npm run check` green: 856 tests, 51 suites
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)