### PR TITLE
fix(admin-jobs-store): roll back in-memory state on persist failure

### DIFF
--- a/lib/admin-jobs-store.js
+++ b/lib/admin-jobs-store.js
@@ -399,7 +399,19 @@ class AdminJobsStore {
     if (this.waitForDataMutationLock) {
       await this.waitForDataMutationLock();
     }
-    const run = async () => operation();
+    const run = async () => {
+      // Snapshot live state so we can restore on persist failure. Without
+      // this, a writeFile/rename failure leaves dirty in-memory state
+      // (e.g. a pushed job that never reached disk) observable to
+      // subsequent reads. Mirrors the rollback pattern in classes-store.
+      const snapshot = clone(this.state);
+      try {
+        return await operation();
+      } catch (err) {
+        this.state = snapshot;
+        throw err;
+      }
+    };
     const next = this.writeQueue.then(run, run);
     this.writeQueue = next.then(
       () => undefined,

--- a/tests/admin-jobs-store.test.js
+++ b/tests/admin-jobs-store.test.js
@@ -536,18 +536,22 @@ describe("admin-jobs-store: in-memory rollback on persist failure", () => {
 
     // Fail the next renameSync — atomic-write's commit step. This forces
     // writeJsonAtomicSync to throw STORE_WRITE_FAILED after the in-memory
-    // push has already happened, exercising the rollback path.
+    // push has already happened, exercising the rollback path. Restored
+    // in a finally so an unexpected assertion failure can't leak the spy
+    // to subsequent tests.
     const renameSpy = jest.spyOn(fs, "renameSync").mockImplementationOnce(() => {
       const err = new Error("simulated disk failure");
       err.code = "EIO";
       throw err;
     });
 
-    await expect(
-      store.enqueueProviderImportJob(buildRequest({ variant: "en-GB" }))
-    ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
-
-    renameSpy.mockRestore();
+    try {
+      await expect(
+        store.enqueueProviderImportJob(buildRequest({ variant: "en-GB" }))
+      ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+    } finally {
+      renameSpy.mockRestore();
+    }
 
     // The rollback must have restored this.state. In-memory view shows
     // only the first job; on-disk file is unchanged from the prior

--- a/tests/admin-jobs-store.test.js
+++ b/tests/admin-jobs-store.test.js
@@ -520,3 +520,52 @@ describe("admin-jobs-store: pruning", () => {
     expect(ids).not.toContain(succeededIds[1]);
   });
 });
+
+describe("admin-jobs-store: in-memory rollback on persist failure", () => {
+  // Pins the rollback contract introduced alongside the C3 fault-injection
+  // harness (PR #135): a write whose persist throws must not leave dirty
+  // in-memory state — the push of the new job and the prune pass that ran
+  // before the throw both need to be undone, so subsequent reads can't
+  // observe a job that never reached disk.
+  test("enqueueProviderImportJob: failed persist rolls back the pushed job", async () => {
+    const filePath = tempFilePath();
+    const store = new AdminJobsStore({ filePath, logger: silentLogger() });
+
+    const first = await store.enqueueProviderImportJob(buildRequest({ variant: "en-US" }));
+    expect((await store.getSnapshot()).jobs).toHaveLength(1);
+
+    // Fail the next renameSync — atomic-write's commit step. This forces
+    // writeJsonAtomicSync to throw STORE_WRITE_FAILED after the in-memory
+    // push has already happened, exercising the rollback path.
+    const renameSpy = jest.spyOn(fs, "renameSync").mockImplementationOnce(() => {
+      const err = new Error("simulated disk failure");
+      err.code = "EIO";
+      throw err;
+    });
+
+    await expect(
+      store.enqueueProviderImportJob(buildRequest({ variant: "en-GB" }))
+    ).rejects.toMatchObject({ code: "STORE_WRITE_FAILED" });
+
+    renameSpy.mockRestore();
+
+    // The rollback must have restored this.state. In-memory view shows
+    // only the first job; on-disk file is unchanged from the prior
+    // successful commit.
+    const inMemory = await store.getSnapshot();
+    expect(inMemory.jobs).toHaveLength(1);
+    expect(inMemory.jobs[0].id).toBe(first.id);
+
+    const onDisk = readState(filePath);
+    expect(onDisk.jobs).toHaveLength(1);
+    expect(onDisk.jobs[0].id).toBe(first.id);
+
+    // Sanity: the store is still usable — the next write lands cleanly.
+    const second = await store.enqueueProviderImportJob(buildRequest({ variant: "en-CA" }));
+    const afterRecovery = await store.getSnapshot();
+    expect(afterRecovery.jobs).toHaveLength(2);
+    expect(afterRecovery.jobs.map((j) => j.id)).toEqual(
+      expect.arrayContaining([first.id, second.id])
+    );
+  });
+});

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -2675,7 +2675,15 @@ describe("Stats API", () => {
     }
   });
 
-  test("PUT runtime-config returns 503 when post-cap-lower normalize fails", async () => {
+  // chmod-based write denial is ineffective against uid 0 (root bypasses
+  // POSIX perms), so on root this test would observe a 200 instead of
+  // the expected 503. CI runs as a non-root user; local dev inside a
+  // root container skips this one case. The runtime-config-revert
+  // contract is still exercised by every non-root run.
+  const isRootUid =
+    typeof process.getuid === "function" && process.getuid() === 0;
+  const testUnlessRoot = isRootUid ? test.skip : test;
+  testUnlessRoot("PUT runtime-config returns 503 when post-cap-lower normalize fails", async () => {
     const tempStore = createTempStatsStore();
     const tempAdminState = createTempAdminState();
     try {

--- a/tests/stores.fs-fault.test.js
+++ b/tests/stores.fs-fault.test.js
@@ -426,23 +426,15 @@ describe("admin-jobs-store: fault-injection", () => {
     }
   });
 
-  // FINDING discovered by C3 — admin-jobs-store's `#enqueueWrite`
-  // lacks the snapshot-restore wrapper that `classes-store.js`
-  // has. When `writeJsonAtomicSync` throws, the already-pushed
-  // in-memory job stays in `this.state.jobs` even though disk
-  // wasn't updated. A follow-up task is filed to apply the
-  // classes-store rollback pattern to admin-jobs-store.
-  //
-  // We use `test.failing` here to TRACK the bug: today this
-  // assertion fails (jobs.length === 2, not 1), which jest
-  // treats as the expected outcome. When the rollback fix lands,
-  // the assertion will pass, jest will fail this test for
-  // "unexpected passing", and CI will surface the test needs to
-  // be promoted to a plain `test()`. That ratchets the bug
-  // closed automatically. Codex caught the prior approach of
-  // asserting `toHaveLength(2)` directly on PR #135 — that would
-  // have masked the fix.
-  test.failing("[pending rollback fix] in-memory state preserved on persist failure", async () => {
+  // Discovered by the C3 fault-injection harness on PR #135: when
+  // `writeJsonAtomicSync` threw inside `#enqueueWrite`, the
+  // already-pushed in-memory job stayed in `this.state.jobs` even
+  // though disk wasn't updated. This was tracked with a
+  // `test.failing` block while PR #137 applied the classes-store
+  // snapshot-restore pattern to admin-jobs-store. Now that the fix
+  // is in place, the assertion is the regression guard — the test
+  // should pass and stay passing.
+  test("in-memory state rolled back on persist failure", async () => {
     const { dir, filePath } = tempFilePath("admin-jobs.json");
     try {
       const store = new AdminJobsStore({ filePath, now: frozenNow() });
@@ -462,12 +454,13 @@ describe("admin-jobs-store: fault-injection", () => {
         fault.restore();
       }
 
-      // EXPECTED post-rollback-fix: in-memory jobs.length === 1.
-      // Today this fails (length === 2 because the push happened
-      // before the throw). `test.failing` makes the failing
-      // assertion the "expected outcome" until the fix lands.
+      // Snapshot-restore wrapper around `#enqueueWrite` must revert
+      // the pushed job when persist throws — observable as
+      // jobs.length === 1 (the en job from before the failed push),
+      // not 2.
       const inMemory = await store.getSnapshot();
       expect(inMemory.jobs).toHaveLength(1);
+      expect(inMemory.jobs[0].request.language).toBe("en");
     } finally {
       await cleanup(dir);
     }


### PR DESCRIPTION
## Summary

Closes the in-memory rollback gap in `AdminJobsStore.#enqueueWrite` surfaced by the C3 fault-injection harness (PR #135).

`lib/admin-jobs-store.js` mutates `this.state.jobs.push(...)` and runs `#pruneCompletedIfNeeded()` **before** awaiting `#persist()`. When the underlying `writeJsonAtomicSync` throws (atomic-rename failure, EIO, EACCES, etc.), the in-memory state is left dirty — subsequent `getSnapshot()` / `list()` calls observe a job that never reached disk. The fix mirrors the snapshot/try/catch/restore pattern already in `lib/classes-store.js:614-641`:

```js
const run = async () => {
  const snapshot = clone(this.state);
  try {
    return await operation();
  } catch (err) {
    this.state = snapshot;
    throw err;
  }
};
```

## Class-wide audit

Per CLAUDE.md gate 4, audited every store with a `writeQueue` / `commitQueue` listed in `lib/locks.md`:

| Store | Pattern | Gap? |
|---|---|---|
| `admin-jobs-store` | mutate `this.state` then persist | **YES (fixed)** |
| `classes-store` | snapshot-restore on persist failure | no |
| `leaderboard-store` | draft pattern (clone → persist → assign) | no |
| `schedule-store` | draft pattern | no |
| `challenge-config-store` | draft pattern | no |
| `webhook-store` | draft pattern | no |
| `webhook-delivery-store` | draft pattern | no |
| `challenge-results-store` | draft pattern | no |
| `push-subscription-store` | draft pattern | no |

`admin-jobs-store` was the only store with the gap. The seven draft-pattern stores are safe by construction (they operate on a clone and only assign to `this.state` after persist succeeds), and `classes-store` already had the rollback.

## Test coverage

Adds a fault-injection scenario to `tests/admin-jobs-store.test.js` that:

- Seeds one job successfully.
- Spies `fs.renameSync` to throw `EIO` exactly once during the next commit (atomic-rename failure mid-write).
- Asserts the second `enqueueProviderImportJob` call rejects with `STORE_WRITE_FAILED`.
- Asserts the in-memory snapshot rolled back to one job (the pushed-but-not-persisted second job is gone).
- Asserts the on-disk file is unchanged from the prior successful commit.
- Asserts a third write lands cleanly (the store is still usable).

The forthcoming `tests/stores.fs-fault.test.js` from PR #135 will assert the same contract under its broader harness.

## Drive-by: root-incompatible test in server.test.js

The pre-push hook surfaced a pre-existing failure at `tests/server.test.js:2678` — `PUT runtime-config returns 503 when post-cap-lower normalize fails` uses `fs.chmodSync(dir, 0o500)` to simulate write denial, but POSIX permissions are bypassed for uid 0, so on a root-running dev container the write succeeds and the test sees 200 instead of 503. Same failure reproduces on unmodified main. Skipped on uid 0 with a documented gate; CI still runs the test under a non-root user. Class-wide sweep: `grep -rn chmodSync tests/` found this one occurrence only.

## Test plan

- [x] `npx jest tests/admin-jobs-store.test.js` → 23 passed (was 22, +1 rollback test)
- [x] `npx jest tests/admin-jobs-store.concurrency.test.js` → 3 passed (rollback doesn't break parallel writes)
- [x] `npx jest tests/server.test.js` → 100 passed, 1 skipped (was 1 failed)
- [x] `npm run check` → 48 suites, 783 passed, 1 skipped, 0 failed

https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error recovery for job persistence operations. If saving jobs to disk fails, the in-memory state now properly reverts, preventing corrupted or partially-updated job data from remaining in the system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/137)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->