### PR TITLE
feat(security): A3 — throughput budget audit + small-body guard (closes #116)

### DIFF
--- a/docs/admin-security-checklist.md
+++ b/docs/admin-security-checklist.md
@@ -54,5 +54,5 @@ Use this checklist for any release that touches `/api/admin/*`, provider imports
 
 - Leaving `ADMIN_KEY` empty in production and assuming admin endpoints are still protected.
 - Treating encoded share links as secrets (they are convenience encoding only).
-- Raising `JSON_BODY_LIMIT` without reviewing upload limits and rate limits together.
+- Raising `JSON_BODY_LIMIT` without reviewing upload limits and rate limits together. See [`docs/security/throughput-budget.md`](security/throughput-budget.md) for the tabulated body × rate-limit pairs and the small-body pre-check that gates player API paths separately from the global cap.
 - Running behind proxy/VPN without `TRUST_PROXY=true`, causing poor IP attribution for rate limiting.

--- a/docs/security/throughput-budget.md
+++ b/docs/security/throughput-budget.md
@@ -1,0 +1,76 @@
+# Throughput budget audit
+
+Tracking issue: [#116](https://github.com/curdriceaurora/wordle-local/issues/116) (A3 — Body/multipart × rate-limit reconciliation review)
+
+This document tabulates every body-size cap × rate-limit cap pair active on a route and identifies asymmetric pairs where worst-case ingress could exceed the operational budget. **Update this doc whenever you change `JSON_BODY_LIMIT`, `PROVIDER_MANUAL_MAX_FILE_BYTES`, `BACKUP_MAX_BYTES`, or any `RATE_LIMIT_*` env var.**
+
+## Configured limits
+
+### Body-size caps
+
+| Cap | Default | Configurable via | Notes |
+|---|---|---|---|
+| `JSON_BODY_LIMIT` | 12 MiB | env `JSON_BODY_LIMIT` (string, e.g. `"12mb"`) | Applied globally via `app.use(express.json({ limit }))`. Sized for the admin manual-provider-upload path (~11 MiB base64). |
+| `SMALL_BODY_LIMIT_BYTES` | 256 KiB | hardcoded in `server.js` | Pre-check on `/api/stats/*`, `/api/challenges/*`, `/api/push/*`, `/api/notifications/*`. Content-Length over the limit returns 413 before `express.json` parses. |
+| `PROVIDER_MANUAL_MAX_FILE_BYTES` | 8 MiB | env (range 1-32 MiB) | Per-file cap inside `manualFiles[].dataBase64`. Decoded after JSON parsing. |
+| `BACKUP_MAX_BYTES` | 256 MiB | env (range 1 MiB - 4 GiB) | Busboy `fileSize` cap on `POST /api/backups/restore` (multipart, not JSON). |
+
+### Rate limits
+
+| Tier | Default max | Default window | env vars | Mounted on |
+|---|---|---|---|---|
+| Global | 300 | 15 min (= 20 req/min) | `RATE_LIMIT_MAX`, `RATE_LIMIT_WINDOW_MS` | Every request (`app.use(rateLimit(...))`) |
+| Admin | 90 | 15 min (= 6 req/min) | `ADMIN_RATE_LIMIT_MAX`, `ADMIN_RATE_LIMIT_WINDOW_MS` | `/api/admin/*` (any method) |
+| Admin-write | 30 | 15 min (= 2 req/min) | `ADMIN_WRITE_RATE_LIMIT_MAX`, `ADMIN_WRITE_RATE_LIMIT_WINDOW_MS` | `/api/admin/*` (non-GET/HEAD) |
+| Backup | 1 | 30 s (= 2 req/min) | `BACKUP_RATE_LIMIT_MAX`, `BACKUP_RATE_LIMIT_WINDOW_MS` | `/api/backups/*`. Keyed by hashed admin-key (per-operator bucket). |
+
+## Per-route-class throughput
+
+Worst-case ingress per minute (per IP / per admin-key bucket where the limiter is keyed that way).
+
+| Route class | Methods | Body cap effective | Rate × cap | Worst MiB/min |
+|---|---|---|---|---|
+| Public read (`/api/word`, `/api/meta`, `/api/daily`, `/api/auth/*` GET) | GET | n/a | 20/min × 0 | 0 |
+| Player write — stats, challenges, push, notifications | POST/PUT/DELETE | **256 KiB** (small-body pre-check) | 20/min × 256 KiB | **5 MiB/min** |
+| Other public write (anything outside the small-body allowlist) | POST | 12 MiB (`JSON_BODY_LIMIT`) | 20/min × 12 MiB | 240 MiB/min |
+| Admin read | GET | n/a | 6/min × 0 | 0 |
+| Admin write (config, schedule, profiles, etc.) | POST/PUT/DELETE | 12 MiB | 2/min × 12 MiB | 24 MiB/min |
+| Admin provider manual upload | POST `/api/admin/providers/import` | 12 MiB JSON (base64 inside) | 2/min × 12 MiB | 24 MiB/min |
+| Backup restore | POST `/api/backups/restore` | 256 MiB (multipart) | 2/min × 256 MiB | 512 MiB/min, but serialized by `dataMutationLockRef` (one in-flight) |
+| Backup export | GET `/api/backups/export` | n/a (response only) | 2/min × 0 | 0 inbound |
+
+## Asymmetric pairs
+
+### Player write paths (mitigated)
+
+**Was:** A POST to `/api/stats/result` could carry 12 MiB of JSON (200× over the actual payload size), giving 240 MiB/min × parse-cost CPU as a worst-case ingress per IP. The handler discards unknown fields, but the parser still has to materialize and validate the body.
+
+**Mitigation:** Added a small-body pre-check (`SMALL_BODY_PATH_PREFIXES` + `SMALL_BODY_LIMIT_BYTES = 256 KiB`) in `server.js` that runs *before* `express.json`. Player API paths (`stats`, `challenges`, `push`, `notifications`) now reject `Content-Length > 256 KiB` with a 413, dropping the worst case from 240 MiB/min to ~5 MiB/min.
+
+**Audit:** If a future endpoint legitimately needs a larger payload, add its path prefix to the allowlist via a separate exception (or move it out of the `SMALL_BODY_PATH_PREFIXES` covered set). Don't drop the 256 KiB cap for everyone.
+
+### Backup restore (accepted)
+
+**Pattern:** 256 MiB × 2 req/min = 512 MiB/min worst-case ingress. The limit is per-admin-key (hashed) so two operators don't share a bucket.
+
+**Why accepted:** Three concentric gates limit real-world abuse:
+
+1. **Admin key required** — `requireAdmin` middleware runs before backup routes; without the key the request is rejected at 401 before busboy spins up.
+2. **`dataMutationLockRef` is held during apply** — only one restore can be in flight; concurrent restore attempts queue/fail.
+3. **Operational class** — the endpoint is designed for occasional disaster recovery, not steady-state traffic. Operators running concurrent restores under load are misusing the deployment.
+
+If an operator-level abuse becomes a concern, the right knob is `BACKUP_RATE_LIMIT_MAX` (per-admin-key) rather than reducing `BACKUP_MAX_BYTES` (which has a legitimate upper bound for full-archive restores).
+
+### Other public write paths (acceptable)
+
+The "Other public write" row in the throughput table covers any future POST endpoint that isn't in the small-body allowlist. Worst case at default settings: 240 MiB/min × parse-cost. No such endpoint exists today; if one is added, the reviewer should categorize it (small-body or admin) and update both the allowlist and this doc.
+
+## Workflow
+
+When changing any of:
+
+- `JSON_BODY_LIMIT`, `SMALL_BODY_LIMIT_BYTES`, or `SMALL_BODY_PATH_PREFIXES` in `server.js`
+- `RATE_LIMIT_*`, `ADMIN_RATE_LIMIT_*`, `ADMIN_WRITE_RATE_LIMIT_*`, `BACKUP_RATE_LIMIT_*` env vars
+- `BACKUP_MAX_BYTES`, `PROVIDER_MANUAL_MAX_FILE_BYTES`
+
+…re-tabulate the affected row(s) in this doc and confirm the worst-MiB/min column stays consistent with the operational budget. Reviewers should treat ratio changes as security decisions.

--- a/docs/security/throughput-budget.md
+++ b/docs/security/throughput-budget.md
@@ -45,7 +45,12 @@ Worst-case ingress per minute (per IP / per admin-key bucket where the limiter i
 
 **Was:** A POST to `/api/stats/result` could carry 12 MiB of JSON (200× over the actual payload size), giving 240 MiB/min × parse-cost CPU as a worst-case ingress per IP. The handler discards unknown fields, but the parser still has to materialize and validate the body.
 
-**Mitigation:** Added a small-body pre-check (`SMALL_BODY_PATH_PREFIXES` + `SMALL_BODY_LIMIT_BYTES = 256 KiB`) in `server.js` that runs *before* `express.json`. Player API paths (`stats`, `challenges`, `push`, `notifications`) now reject `Content-Length > 256 KiB` with a 413, dropping the worst case from 240 MiB/min to ~5 MiB/min.
+**Mitigation:** Two layers in `server.js`:
+
+1. **Content-Length pre-check** for fast-fail 413 on honest clients that declare an oversized payload. Skips JSON parsing entirely.
+2. **Per-prefix `express.json({ limit: 256 KiB })`** mounted on each prefix BEFORE the global `express.json({ limit: JSON_BODY_LIMIT })`. This is the load-bearing defense — chunked-transfer requests that omit `Content-Length` bypass layer 1, but the per-prefix parser still counts bytes during streaming and throws `entity.too.large` (Codex P2 on PR #146 caught the chunked bypass; the layered approach closes it).
+
+Player API paths now reject oversized payloads with 413 regardless of whether the client uses `Content-Length` or `Transfer-Encoding: chunked`, dropping the worst case from 240 MiB/min to ~5 MiB/min.
 
 **Audit:** If a future endpoint legitimately needs a larger payload, add its path prefix to the allowlist via a separate exception (or move it out of the `SMALL_BODY_PATH_PREFIXES` covered set). Don't drop the 256 KiB cap for everyone.
 

--- a/server.js
+++ b/server.js
@@ -3010,6 +3010,37 @@ app.use(
   })
 );
 app.use(compression());
+// Per-route-class body-size pre-check. The global `express.json({ limit:
+// JSON_BODY_LIMIT })` accepts payloads up to 12 MiB to accommodate the
+// admin manual-provider-upload path (~11 MiB base64). Player API paths
+// (`/api/stats/*`, `/api/challenges/*`, `/api/push/*`) accept tiny
+// payloads (sub-KiB) and should not be a vehicle for 12 MiB ingress
+// abuse — see docs/security/throughput-budget.md for the analysis.
+// Reject early via Content-Length so we don't burn CPU parsing a
+// 12 MiB JSON body just to throw at the route handler.
+const SMALL_BODY_PATH_PREFIXES = Object.freeze([
+  "/api/stats/",
+  "/api/challenges/",
+  "/api/push/",
+  "/api/notifications/"
+]);
+const SMALL_BODY_LIMIT_BYTES = 256 * 1024;
+app.use((req, res, next) => {
+  if (req.method === "GET" || req.method === "HEAD" || req.method === "OPTIONS") {
+    return next();
+  }
+  const path = req.path || "";
+  if (!SMALL_BODY_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+    return next();
+  }
+  const contentLength = req.headers["content-length"];
+  if (contentLength && Number(contentLength) > SMALL_BODY_LIMIT_BYTES) {
+    return res
+      .status(413)
+      .json({ error: "Request payload is too large for this endpoint." });
+  }
+  return next();
+});
 app.use(express.json({ limit: JSON_BODY_LIMIT }));
 app.use((err, req, res, next) => {
   if (!err) {

--- a/server.js
+++ b/server.js
@@ -3010,14 +3010,28 @@ app.use(
   })
 );
 app.use(compression());
-// Per-route-class body-size pre-check. The global `express.json({ limit:
-// JSON_BODY_LIMIT })` accepts payloads up to 12 MiB to accommodate the
-// admin manual-provider-upload path (~11 MiB base64). Player API paths
-// (`/api/stats/*`, `/api/challenges/*`, `/api/push/*`) accept tiny
-// payloads (sub-KiB) and should not be a vehicle for 12 MiB ingress
-// abuse — see docs/security/throughput-budget.md for the analysis.
-// Reject early via Content-Length so we don't burn CPU parsing a
-// 12 MiB JSON body just to throw at the route handler.
+// Per-route-class body-size enforcement. The global
+// `express.json({ limit: JSON_BODY_LIMIT })` accepts payloads up to
+// 12 MiB to accommodate the admin manual-provider-upload path
+// (~11 MiB base64). Player API paths (`/api/stats/*`,
+// `/api/challenges/*`, `/api/push/*`, `/api/notifications/*`) accept
+// tiny payloads (sub-KiB) and should not be a vehicle for 12 MiB
+// ingress abuse — see `docs/security/throughput-budget.md`.
+//
+// Two layers:
+//   1. Optional Content-Length pre-check: fast 413 without invoking
+//      the JSON parser when the client honestly declares a large
+//      body.
+//   2. Per-prefix `express.json({ limit: SMALL_BODY_LIMIT_BYTES })`
+//      mounted BEFORE the global parser. This is the load-bearing
+//      enforcement: chunked-transfer requests that omit
+//      Content-Length still hit this parser first because Express
+//      uses path-based middleware matching, and the parser counts
+//      bytes during streaming. Express's body-parser throws
+//      `PayloadTooLargeError` (entity.too.large) which the existing
+//      error handler converts to 413 (Codex P2 on PR #146 — the
+//      Content-Length-only approach was bypassable via
+//      `Transfer-Encoding: chunked`).
 const SMALL_BODY_PATH_PREFIXES = Object.freeze([
   "/api/stats/",
   "/api/challenges/",
@@ -3041,6 +3055,10 @@ app.use((req, res, next) => {
   }
   return next();
 });
+const smallBodyJsonParser = express.json({ limit: SMALL_BODY_LIMIT_BYTES });
+for (const prefix of SMALL_BODY_PATH_PREFIXES) {
+  app.use(prefix, smallBodyJsonParser);
+}
 app.use(express.json({ limit: JSON_BODY_LIMIT }));
 app.use((err, req, res, next) => {
   if (!err) {

--- a/tests/small-body-guard.test.js
+++ b/tests/small-body-guard.test.js
@@ -111,4 +111,57 @@ describe("small-body Content-Length guard", () => {
       .send(oversizedForSmallGuard);
     expect(res.status).not.toBe(413);
   });
+
+  test(`chunked-transfer bypass: per-prefix express.json rejects oversized chunked body without Content-Length (Codex P2)`, async () => {
+    // The Content-Length pre-check ONLY catches honest clients that
+    // declare an oversized payload. A hostile client can use
+    // `Transfer-Encoding: chunked` and omit Content-Length to skip
+    // the pre-check. The per-prefix `express.json` parser is the
+    // load-bearing defense — it counts bytes during streaming and
+    // throws `entity.too.large` when the limit is exceeded.
+    //
+    // Use raw Node http to issue a chunked request because supertest
+    // automatically sets Content-Length when .send() receives a
+    // string, which short-circuits the pre-check before the chunked
+    // path is exercised.
+    const http = require("node:http");
+    process.env.RATE_LIMIT_MAX = "10000";
+    process.env.RATE_LIMIT_WINDOW_MS = "60000";
+    const app = loadApp();
+    const server = await new Promise((resolve) => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    const port = server.address().port;
+    try {
+      const oversized = JSON.stringify({ junk: "x".repeat(OVERSIZED_BYTES) });
+      const status = await new Promise((resolve, reject) => {
+        const req = http.request(
+          {
+            hostname: "127.0.0.1",
+            port,
+            method: "POST",
+            path: COVERED_PATHS[0],
+            headers: {
+              "Content-Type": "application/json",
+              "Transfer-Encoding": "chunked"
+            }
+          },
+          (res) => {
+            res.resume();
+            res.on("end", () => resolve(res.statusCode));
+          }
+        );
+        req.on("error", reject);
+        // Write in 50 KiB chunks so the limit is exceeded mid-stream.
+        const CHUNK = 50 * 1024;
+        for (let i = 0; i < oversized.length; i += CHUNK) {
+          req.write(oversized.slice(i, i + CHUNK));
+        }
+        req.end();
+      });
+      expect(status).toBe(413);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
 });

--- a/tests/small-body-guard.test.js
+++ b/tests/small-body-guard.test.js
@@ -1,0 +1,114 @@
+"use strict";
+
+// A3 / #116: lock-in for the small-body Content-Length pre-check
+// applied in server.js. The guard runs BEFORE express.json so that
+// payloads way larger than a player API endpoint legitimately needs
+// are rejected with 413 without burning CPU on JSON parsing. Sites
+// the guard covers (`/api/stats/*`, `/api/challenges/*`,
+// `/api/push/*`, `/api/notifications/*`) accept sub-KiB bodies in
+// practice; the cap is 256 KiB so a future modest expansion has
+// headroom before the guard fires.
+
+const request = require("supertest");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_WORD_DATA = fs.readFileSync(
+  path.join(__dirname, "..", "data", "word.json"),
+  "utf8"
+);
+
+function resetEnv() {
+  Object.keys(process.env).forEach((key) => {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  });
+  Object.entries(ORIGINAL_ENV).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+}
+
+function loadApp() {
+  delete require.cache[require.resolve("../server")];
+  return require("../server");
+}
+
+afterEach(() => {
+  // Restore data file (some tests may have touched it) and env.
+  fs.writeFileSync(
+    path.join(__dirname, "..", "data", "word.json"),
+    ORIGINAL_WORD_DATA
+  );
+  resetEnv();
+});
+
+const COVERED_PATHS = [
+  "/api/stats/result",
+  "/api/challenges/something/sessions/x/guess",
+  "/api/push/subscribe",
+  "/api/notifications/broadcast"
+];
+
+const UNCOVERED_PATH = "/api/word"; // admin path (write); should NOT be size-limited by the small-body guard.
+
+const OVERSIZED_BYTES = 300 * 1024; // > SMALL_BODY_LIMIT_BYTES (256 KiB)
+const ALLOWED_BYTES = 100 * 1024; // < SMALL_BODY_LIMIT_BYTES
+
+describe("small-body Content-Length guard", () => {
+  for (const targetPath of COVERED_PATHS) {
+    test(`POST ${targetPath} rejects 300 KiB body with 413`, async () => {
+      process.env.RATE_LIMIT_MAX = "10000";
+      process.env.RATE_LIMIT_WINDOW_MS = "60000";
+      const app = loadApp();
+      const oversized = "x".repeat(OVERSIZED_BYTES);
+      const res = await request(app)
+        .post(targetPath)
+        .set("Content-Type", "application/json")
+        .set("Content-Length", String(oversized.length))
+        .send(oversized);
+      expect(res.status).toBe(413);
+      expect(res.body.error).toMatch(/too large for this endpoint/i);
+    });
+  }
+
+  test(`POST ${COVERED_PATHS[0]} accepts a 100 KiB body (under the limit) and falls through to handler validation`, async () => {
+    process.env.RATE_LIMIT_MAX = "10000";
+    process.env.RATE_LIMIT_WINDOW_MS = "60000";
+    const app = loadApp();
+    // A 100 KiB body should NOT be rejected by the guard. The handler
+    // itself will fail with 400/404 because the JSON shape is wrong,
+    // but specifically NOT 413 (which is what the guard returns).
+    const allowedBody = JSON.stringify({ junk: "x".repeat(ALLOWED_BYTES - 20) });
+    const res = await request(app)
+      .post(COVERED_PATHS[0])
+      .set("Content-Type", "application/json")
+      .send(allowedBody);
+    expect(res.status).not.toBe(413);
+  });
+
+  test(`GET on a covered path is not affected by the guard`, async () => {
+    process.env.RATE_LIMIT_MAX = "10000";
+    process.env.RATE_LIMIT_WINDOW_MS = "60000";
+    const app = loadApp();
+    // GET requests don't carry a body; the guard short-circuits.
+    const res = await request(app).get(COVERED_PATHS[0]);
+    expect(res.status).not.toBe(413);
+  });
+
+  test(`uncovered admin path ${UNCOVERED_PATH} still accepts payloads up to JSON_BODY_LIMIT`, async () => {
+    process.env.RATE_LIMIT_MAX = "10000";
+    process.env.RATE_LIMIT_WINDOW_MS = "60000";
+    process.env.ADMIN_KEY = "secret-test";
+    const app = loadApp();
+    const oversizedForSmallGuard = "x".repeat(OVERSIZED_BYTES);
+    // Posting 300 KiB to /api/word should NOT trip the small-body
+    // guard (it's not in SMALL_BODY_PATH_PREFIXES). It WILL fail with
+    // 400 (bad JSON) or 401 (no admin key) downstream — but not 413.
+    const res = await request(app)
+      .post(UNCOVERED_PATH)
+      .set("Content-Type", "application/json")
+      .set("Content-Length", String(oversizedForSmallGuard.length))
+      .send(oversizedForSmallGuard);
+    expect(res.status).not.toBe(413);
+  });
+});


### PR DESCRIPTION
Tabulated every body × rate-limit pair on the API surface and closed the one genuinely asymmetric gap — player API paths inheriting the 12 MiB global JSON cap despite needing only sub-KiB bodies.

## Summary

- Issue: closes #116
- Scope: A3 — body/multipart × rate-limit reconciliation review
- Epic: A (#111 — Security & Supply Chain Hardening)

## In Scope

- **`docs/security/throughput-budget.md`** — full tabulation of body caps × rate-limit tiers, per-route-class worst-MiB/min, plus per-pair analysis. Includes a workflow rule: any change to `JSON_BODY_LIMIT`, `SMALL_BODY_LIMIT_BYTES`, the small-body path allowlist, or any `RATE_LIMIT_*` / `BACKUP_*` env var requires re-tabulating the affected row.
- **`server.js`** — `SMALL_BODY_PATH_PREFIXES` (frozen array: `/api/stats/`, `/api/challenges/`, `/api/push/`, `/api/notifications/`) + `SMALL_BODY_LIMIT_BYTES = 256 KiB`. Middleware runs BEFORE `express.json` and rejects oversized requests with 413 before the parser materializes the body.
- **`docs/admin-security-checklist.md`** — Common pitfalls section now references `docs/security/throughput-budget.md`.
- **`tests/small-body-guard.test.js`** — 7 tests: 4 covered paths verify 413 on oversized payloads; under-the-limit passes through to the handler; GET unaffected; uncovered admin path still accepts up to `JSON_BODY_LIMIT`.

## Identified asymmetric pairs

| Pair | Before | After |
|---|---|---|
| Player write (stats/challenges/push/notifications) | 12 MiB × 20/min = **240 MiB/min** | 256 KiB × 20/min = **5 MiB/min** |
| Admin write | 12 MiB × 2/min = 24 MiB/min | unchanged (accepted; manual-upload path needs ~11 MiB base64) |
| Backup restore | 256 MiB × 2/min = 512 MiB/min | unchanged (accepted with rationale: admin-key-gated + `dataMutationLockRef`-serialized + disaster-recovery class) |

## Out of Scope

- Multipart streaming limits — different attack class.
- DDoS mitigation — out of scope for a self-hosted family deployment.

## Risk Review

- **Primary risks:**
  - The 256 KiB cap may need to grow if a future player API endpoint needs a larger payload. Adding it to the allowlist is a deliberate review-gated action; the doc workflow forces a re-audit.
  - The pre-check trusts the `Content-Length` header. A malformed client could chunk-encode and bypass; in practice Express decodes chunked transfers before the body is materialized, and the global `express.json({ limit: JSON_BODY_LIMIT })` still caps the post-decode size at 12 MiB. The pre-check is best-effort early rejection, not the only line of defense.
- **Mitigations:**
  - Test coverage confirms 413 on 300 KiB + pass-through on 100 KiB for each covered path.
  - GET requests bypass the guard so prefetch/preview tools don't see surprise rejections.
  - Documented change-management workflow keeps the audit alive across future env-var tweaks.

## Verification checklist

- [x] Tabulation committed at `docs/security/throughput-budget.md`
- [x] Identified asymmetric pair (player POST 240 MiB/min) closed via code change (`SMALL_BODY_LIMIT_BYTES` + path allowlist)
- [x] Accepted pairs (admin write, backup restore) annotated with rationale
- [x] `docs/admin-security-checklist.md` references the new doc
- [x] `npm run check` passes locally (928 Jest tests, all linters, audit gate, proto:check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated admin security checklist with cross-references
  * Added new security documentation on throughput budgets and configuration audits

* **New Features**
  * Smaller request body limits enforced on specific API endpoints
  * Fast-fail validation for oversized requests using Content-Length header

* **Tests**
  * Added comprehensive test suite for request validation across API paths

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/146)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->