### PR TITLE
feat(reliability): B6 — outbound retry/timeout audit + jitter + aggregate retry budget

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -78,6 +78,23 @@ def verify(raw_body: bytes, header: str, secret: str) -> bool:
     return hmac.compare_digest(header, expected)
 ```
 
+## Outbound-call retry/timeout audit
+
+Three outbound-call paths in this codebase. Snapshot of each as of
+B6 / #125:
+
+| Path | File:lines | HTTP client | Timeout | Retry | Intervals | Jitter | Concurrency cap |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **Webhook delivery** | `lib/webhook-service.js` | Node `fetch` (optional undici) | `WEBHOOK_REQUEST_TIMEOUT_MS` (default 10s) | Per-sub `maxAttempts` (default 5) | `[1s, 5s, 30s, 2m, 10m]` | 0–25% additive (B6) | `WEBHOOK_GLOBAL_INFLIGHT_LIMIT=4` for in-flight; `WEBHOOK_MAX_CONCURRENT_RETRIES=16` for retry budget (B6) |
+| **Provider artifact fetch** | `lib/provider-fetch.js:97-171` | Node `fetch` | `DEFAULT_FETCH_TIMEOUT_MS=15s` | Single-shot (admin can re-upload) | n/a | n/a | None (single per-import event) |
+| **Web-push send** | `lib/notification-service.js:110-141` | `web-push` npm | Delegated to library | Fire-and-forget; next daily fire re-tries | n/a | n/a | `maxConcurrent` worker pool (default 8) |
+
+Web-push deliberately does NOT retry within a single fire — failure
+modes are tracked via `failureStreak` and the next daily fire re-
+attempts. See `docs/notifications.md` for the failure-mode table.
+Provider fetch is admin-initiated and re-invokable; adding retry
+there would mask transient errors operators need to see.
+
 ## Retries and backoff
 
 Failed deliveries are retried with exponential backoff. The default
@@ -89,6 +106,44 @@ failed delivery from the Webhooks tab.
 A `Retry-After` header on the response (numeric seconds OR HTTP-date) is
 honored, but capped at 10 minutes so a misbehaving recipient cannot
 strand a delivery forever.
+
+### Jitter (B6 / #125)
+
+The retry schedule above is the BASE; every retry interval has 0–25%
+additive random jitter applied on top. So an attempt-3 retry whose
+base slot is 30s lands somewhere in `[30s, 37.5s]`. A fleet of
+deliveries all failing at the same moment (e.g., the upstream
+endpoint returned 503 for everyone) therefore smears the next attempt
+across a 7.5-second window rather than synchronously hammering the
+upstream as it tries to recover.
+
+Jitter is `Math.floor(base * 0.25 * Math.random())` — pure additive,
+never below the base. The thundering-herd argument is one-sided:
+jittering above the base is always safe; jittering below would let a
+delivery retry sooner than the operator configured, which we treat
+as a contract violation.
+
+### Aggregate retry-budget cap (B6 / #125)
+
+In addition to the per-subscription `maxAttempts` cap, the dispatcher
+enforces a **system-wide cap on concurrent retrying deliveries**.
+Each delivery sitting in its inter-retry backoff sleep counts against
+`WEBHOOK_MAX_CONCURRENT_RETRIES` (default 16). When a new attempt
+fails and would enter retry state but the budget is full, the
+delivery is marked `failed` with `lastError: "retry budget exhausted
+(>=N retries inflight)"` and an operator-visible `[webhook] retry
+budget exhausted` warn-log fires.
+
+This caps memory and timer usage during a system-wide upstream
+outage — without it, every failing delivery would queue an
+indefinitely-extending retry timer, blowing the timer table and
+delaying graceful shutdown. The default (16 = 4x `globalInflight=4`)
+gives ample headroom for normal transient errors while still capping
+a runaway.
+
+If you observe `retry budget exhausted` logs and no upstream outage,
+either raise the env var or investigate why so many deliveries are
+piling up at once.
 
 ### HTTP status classification
 
@@ -142,6 +197,7 @@ backup also restores webhook subscriptions and recent deliveries.
 | `WEBHOOK_DELIVERY_HISTORY_MAX`     | `200`   | 10–10000         | Retention cap for `data/webhook-deliveries.json`.                    |
 | `WEBHOOK_MAX_ATTEMPTS_DEFAULT`     | `5`     | 1–20             | Default `maxAttempts` for new subscriptions.                         |
 | `WEBHOOK_GLOBAL_INFLIGHT_LIMIT`    | `4`     | 1–64             | Concurrent in-flight delivery cap across all subscriptions.          |
+| `WEBHOOK_MAX_CONCURRENT_RETRIES`   | `16`    | 1–256            | Aggregate retry-budget cap (B6 / #125). See *Aggregate retry-budget cap* above. |
 | `WEBHOOK_ALLOW_PRIVATE_NETWORKS`   | `false` | bool             | Bypass SSRF guard. Local dev only — never enable in production.      |
 | `WEBHOOKS_STORE_PATH`              | `data/webhooks.json` | path | Override the subscription store location (e.g. for tests). |
 | `WEBHOOK_DELIVERIES_STORE_PATH`    | `data/webhook-deliveries.json` | path | Override the delivery store location.            |

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -87,11 +87,11 @@ B6 / #125:
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | **Webhook delivery** | `lib/webhook-service.js` | Node `fetch` (optional undici) | `WEBHOOK_REQUEST_TIMEOUT_MS` (default 10s) | Per-sub `maxAttempts` (default 5) | `[1s, 5s, 30s, 2m, 10m]` | 0–25% additive (B6) | `WEBHOOK_GLOBAL_INFLIGHT_LIMIT=4` for in-flight; `WEBHOOK_MAX_CONCURRENT_RETRIES=16` for retry budget (B6) |
 | **Provider artifact fetch** | `lib/provider-fetch.js:97-171` | Node `fetch` | `DEFAULT_FETCH_TIMEOUT_MS=15s` | Single-shot (admin can re-upload) | n/a | n/a | None (single per-import event) |
-| **Web-push send** | `lib/notification-service.js:110-141` | `web-push` npm | Delegated to library | Fire-and-forget; next daily fire re-tries | n/a | n/a | `maxConcurrent` worker pool (default 8) |
+| **Web-push send** | `lib/notification-service.js:110-141` | `web-push` npm | Delegated to library | Fire-and-forget; next daily fire retries | n/a | n/a | `maxConcurrent` worker pool (default 8) |
 
 Web-push deliberately does NOT retry within a single fire — failure
-modes are tracked via `failureStreak` and the next daily fire re-
-attempts. See `docs/notifications.md` for the failure-mode table.
+modes are tracked via `failureStreak` and the next daily fire
+retries. See `docs/notifications.md` for the failure-mode table.
 Provider fetch is admin-initiated and re-invokable; adding retry
 there would mask transient errors operators need to see.
 

--- a/lib/webhook-service.js
+++ b/lib/webhook-service.js
@@ -23,6 +23,20 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_MAX_BODY_BYTES = 64 * 1024;
 const DEFAULT_GLOBAL_INFLIGHT = 4;
 const DEFAULT_RETRY_AFTER_CAP_MS = 600_000; // never wait more than the longest backoff slot
+// B6 / #125: cap the number of deliveries simultaneously sitting in
+// their inter-retry backoff sleep. Once we have this many waiting,
+// new deliveries that would enter retry state are marked failed with
+// `retry budget exhausted` instead of being queued indefinitely.
+// 16 = 4x the default globalInflight, giving headroom for normal
+// transient-upstream-error patterns while still capping a system-wide
+// runaway.
+const DEFAULT_MAX_CONCURRENT_RETRIES = 16;
+// B6 / #125: deterministic backoff schedules synchronously hit the
+// upstream during recovery, producing a thundering herd. Adding
+// 0-25% additive random jitter spreads each retry across a 25%
+// window so a fleet of failing deliveries smear their retries rather
+// than stacking them on the same second.
+const DEFAULT_JITTER_FRACTION = 0.25;
 
 class WebhookSendError extends Error {
   constructor(code, message, options = {}) {
@@ -37,14 +51,28 @@ class WebhookSendError extends Error {
   }
 }
 
-function nextBackoffMs(attemptNumber, schedule = DEFAULT_BACKOFF_MS) {
+function nextBackoffMs(attemptNumber, schedule = DEFAULT_BACKOFF_MS, options = {}) {
   // attemptNumber is 1-indexed (the attempt that just failed). The backoff
   // for the NEXT attempt is schedule[attemptNumber-1] when retrying for
   // the second time, etc. If we've used the whole schedule, we cap at
   // the last slot (so a 6th attempt — if maxAttempts allowed it — still
   // gets the 10-minute slot).
   const idx = Math.max(0, Math.min(attemptNumber - 1, schedule.length - 1));
-  return schedule[idx];
+  const base = schedule[idx];
+  // B6 / #125: 0..jitterFraction*base additive jitter (default 25%).
+  // Default-on; opt out via options.jitter === false (used by tests
+  // that want deterministic timing). The `random` injection lets
+  // tests assert exact values without freezing Math.random globally.
+  if (options.jitter === false) return base;
+  const fraction = Number.isFinite(options.jitterFraction)
+    ? Math.max(0, options.jitterFraction)
+    : DEFAULT_JITTER_FRACTION;
+  if (fraction === 0) return base;
+  const random = typeof options.random === "function" ? options.random : Math.random;
+  // Math.floor is intentional: produces a uniform integer in
+  // [0, base*fraction]; never overshoots base*(1+fraction).
+  const jitter = Math.floor(base * fraction * random());
+  return base + jitter;
 }
 
 function isPrivateIPv4(ip) {
@@ -345,13 +373,29 @@ class WebhookService {
     this.globalInflight = Number.isInteger(options.globalInflight) && options.globalInflight > 0
       ? options.globalInflight
       : DEFAULT_GLOBAL_INFLIGHT;
+    // B6 / #125: cap deliveries currently in inter-retry backoff sleep.
+    // See DEFAULT_MAX_CONCURRENT_RETRIES above for rationale.
+    this.maxConcurrentRetries = Number.isInteger(options.maxConcurrentRetries) && options.maxConcurrentRetries > 0
+      ? options.maxConcurrentRetries
+      : DEFAULT_MAX_CONCURRENT_RETRIES;
     this.backoffSchedule = Array.isArray(options.backoffSchedule) && options.backoffSchedule.length > 0
       ? options.backoffSchedule
       : DEFAULT_BACKOFF_MS;
     this.fetchImpl = options.fetchImpl || globalThis.fetch;
     this.enabled = options.enabled !== false;
+    // B6 / #125: jitter knob, default-on. Tests pass jitter:false for
+    // deterministic timing, or `random` to inject a deterministic
+    // PRNG for exact-value assertions.
+    this.jitterFraction = Number.isFinite(options.jitterFraction)
+      ? Math.max(0, options.jitterFraction)
+      : DEFAULT_JITTER_FRACTION;
+    this.random = typeof options.random === "function" ? options.random : null;
     // Pending due timers — tracked so shutdown can clear them.
     this.scheduledTimers = new Set();
+    // B6 / #125: counter of deliveries currently waiting in their
+    // inter-retry backoff sleep (i.e., scheduled with isRetry=true).
+    // Used by scheduleDelivery to enforce maxConcurrentRetries.
+    this.retryInflightCount = 0;
     // Concurrency semaphore — counts in-flight executeOnce() calls.
     this.activeCount = 0;
     // Queue of delivery IDs ready to run when a slot frees up.
@@ -387,11 +431,36 @@ class WebhookService {
   // shutdown can clear pending work cleanly. Gated on `enabled` so admin
   // routes (and recoverOnBoot) can call this directly without bypassing
   // the WEBHOOKS_ENABLED contract.
-  scheduleDelivery(deliveryId, delayMs = 0, runtimeContext = null) {
+  //
+  // B6 / #125: when `options.isRetry === true` the call counts toward
+  // `maxConcurrentRetries`. If the budget is already exhausted, the
+  // delivery is marked failed with `retry budget exhausted` instead of
+  // being scheduled, preventing a system-wide retry pile-up from
+  // exhausting timers / memory while an upstream is down.
+  scheduleDelivery(deliveryId, delayMs = 0, runtimeContext = null, options = {}) {
     if (this.shutdownRequested) return;
     if (!this.enabled) return;
+    const isRetry = options.isRetry === true;
+    if (isRetry && this.retryInflightCount >= this.maxConcurrentRetries) {
+      // Retry budget exhausted. Mark the delivery as failed and log
+      // a warning so the operator can see that the system is under
+      // retry pressure (versus a single delivery failing on its own
+      // merits). The deliveryStore update is fire-and-forget here so
+      // a failing store doesn't crash the caller's flow.
+      const reason = `retry budget exhausted (>=${this.maxConcurrentRetries} retries inflight)`;
+      this.deliveryStore.update(deliveryId, {
+        status: "failed",
+        lastError: reason
+      }).catch((err) => {
+        this.logger.error?.(`[webhook] retry-budget-exhaust update failed for ${deliveryId}:`, err);
+      });
+      this.logger.warn?.(`[webhook] retry budget exhausted; dropping delivery ${deliveryId} (${reason})`);
+      return;
+    }
+    if (isRetry) this.retryInflightCount += 1;
     const timer = setTimeout(() => {
       this.scheduledTimers.delete(timer);
+      if (isRetry) this.retryInflightCount = Math.max(0, this.retryInflightCount - 1);
       this.enqueueReady(deliveryId, runtimeContext);
     }, Math.max(0, delayMs));
     if (typeof timer.unref === "function") timer.unref();
@@ -554,8 +623,20 @@ class WebhookService {
         });
         return;
       }
+      // B6 / #125: nextBackoffMs() now applies 0..jitterFraction*base
+      // jitter by default. Math.max with `retryAfterMs` honors any
+      // server-supplied Retry-After header that may be larger than the
+      // jittered schedule slot, so a polite upstream's hint still
+      // wins. The DEFAULT_RETRY_AFTER_CAP_MS prevents a hostile or
+      // misconfigured header from pinning us at hours.
       const backoffMs = Math.min(
-        Math.max(result.retryAfterMs ?? 0, nextBackoffMs(attemptNumber, this.backoffSchedule)),
+        Math.max(
+          result.retryAfterMs ?? 0,
+          nextBackoffMs(attemptNumber, this.backoffSchedule, {
+            jitterFraction: this.jitterFraction,
+            random: this.random || undefined
+          })
+        ),
         DEFAULT_RETRY_AFTER_CAP_MS
       );
       const nextAt = new Date(this.now().getTime() + backoffMs).toISOString();
@@ -566,7 +647,9 @@ class WebhookService {
         lastError: `HTTP ${result.responseStatus}; retrying`,
         nextAttemptAt: nextAt
       });
-      this.scheduleDelivery(delivery.id, backoffMs, runtimeContext);
+      // B6 / #125: mark as retry so scheduleDelivery counts toward
+      // the retry budget.
+      this.scheduleDelivery(delivery.id, backoffMs, runtimeContext, { isRetry: true });
       return;
     }
     // Reached here: result has an errorMessage (network/timeout) — treat as retriable.
@@ -577,14 +660,17 @@ class WebhookService {
       });
       return;
     }
-    const backoffMs = nextBackoffMs(attemptNumber, this.backoffSchedule);
+    const backoffMs = nextBackoffMs(attemptNumber, this.backoffSchedule, {
+      jitterFraction: this.jitterFraction,
+      random: this.random || undefined
+    });
     const nextAt = new Date(this.now().getTime() + backoffMs).toISOString();
     await this.deliveryStore.update(delivery.id, {
       status: "queued",
       lastError: result?.errorMessage || "Unknown error",
       nextAttemptAt: nextAt
     });
-    this.scheduleDelivery(delivery.id, backoffMs, runtimeContext);
+    this.scheduleDelivery(delivery.id, backoffMs, runtimeContext, { isRetry: true });
   }
 
   async retryDelivery(deliveryId) {

--- a/lib/webhook-service.js
+++ b/lib/webhook-service.js
@@ -447,10 +447,18 @@ class WebhookService {
       // retry pressure (versus a single delivery failing on its own
       // merits). The deliveryStore update is fire-and-forget here so
       // a failing store doesn't crash the caller's flow.
+      //
+      // Copilot on PR #154 caught: the prior `queued` update set
+      // `nextAttemptAt`. When we transition straight to `failed`
+      // without rescheduling, that field must be cleared — otherwise
+      // the row looks like "failed but rescheduled" to operators and
+      // the admin UI's retry-attempt-time column shows a phantom
+      // future timestamp on a permanently-failed row.
       const reason = `retry budget exhausted (>=${this.maxConcurrentRetries} retries inflight)`;
       this.deliveryStore.update(deliveryId, {
         status: "failed",
-        lastError: reason
+        lastError: reason,
+        nextAttemptAt: null
       }).catch((err) => {
         this.logger.error?.(`[webhook] retry-budget-exhaust update failed for ${deliveryId}:`, err);
       });
@@ -695,6 +703,15 @@ class WebhookService {
     if (candidates.length === 0) return 0;
     let recovered = 0;
     for (const d of candidates) {
+      // B6 / #125 (Codex P2 + Copilot on PR #154): a recovered
+      // delivery with attempts > 0 is by definition a retry — it
+      // counts against `maxConcurrentRetries`. Without this flag, a
+      // process restart in the middle of a system-wide upstream
+      // outage would re-schedule every persisted-queued retry past
+      // the budget cap and the runaway resumes. attempts === 0 means
+      // the row was enqueued but never sent; treat that as a
+      // first-attempt schedule (no budget consumption).
+      const isRetry = (d.attempts || 0) > 0;
       if (d.status === "running") {
         // The previous process died mid-flight; requeue with a small
         // backoff so a tight crash loop doesn't hammer the recipient.
@@ -703,7 +720,7 @@ class WebhookService {
           lastError: "Recovered after restart",
           nextAttemptAt: new Date(this.now().getTime() + 1000).toISOString()
         });
-        this.scheduleDelivery(d.id, 1000);
+        this.scheduleDelivery(d.id, 1000, null, { isRetry });
         recovered += 1;
       } else if (d.status === "queued") {
         // Honor the persisted nextAttemptAt if any; otherwise schedule
@@ -712,7 +729,7 @@ class WebhookService {
         if (d.nextAttemptAt) {
           delay = Math.max(0, new Date(d.nextAttemptAt).getTime() - this.now().getTime());
         }
-        this.scheduleDelivery(d.id, delay);
+        this.scheduleDelivery(d.id, delay, null, { isRetry });
         recovered += 1;
       }
     }

--- a/server.js
+++ b/server.js
@@ -326,6 +326,17 @@ const ENV_WEBHOOK_GLOBAL_INFLIGHT_LIMIT = clampEnvBounded(
   64,
   "WEBHOOK_GLOBAL_INFLIGHT_LIMIT"
 );
+// B6 / #125: cap concurrent deliveries sitting in inter-retry backoff
+// sleep so a system-wide upstream failure doesn't pile up unbounded
+// retries. New deliveries that hit this cap are marked failed with
+// `retry budget exhausted` rather than being scheduled.
+const ENV_WEBHOOK_MAX_CONCURRENT_RETRIES = clampEnvBounded(
+  process.env.WEBHOOK_MAX_CONCURRENT_RETRIES,
+  16,
+  1,
+  256,
+  "WEBHOOK_MAX_CONCURRENT_RETRIES"
+);
 
 // Web Push notifications. Disabled at the runtime level via the
 // notifications.enabled config flag, set through `PUT
@@ -1413,6 +1424,9 @@ const webhookService = new WebhookService({
   timeoutMs: ENV_WEBHOOK_REQUEST_TIMEOUT_MS,
   maxBodyBytes: ENV_WEBHOOK_MAX_BODY_BYTES,
   globalInflight: ENV_WEBHOOK_GLOBAL_INFLIGHT_LIMIT,
+  // B6 / #125: aggregate retry-budget cap. Default 16 = 4x
+  // globalInflight, configurable via WEBHOOK_MAX_CONCURRENT_RETRIES.
+  maxConcurrentRetries: ENV_WEBHOOK_MAX_CONCURRENT_RETRIES,
   logger: console
 });
 const pushSubscriptionStore = new PushSubscriptionStore({

--- a/tests/webhook-service.test.js
+++ b/tests/webhook-service.test.js
@@ -682,6 +682,91 @@ describe("retry budget cap (B6 / #125)", () => {
     expect(svcStr.maxConcurrentRetries).toBe(16);
     svcStr.shutdown();
   });
+
+  // Helper: seed a delivery in the persisted store with arbitrary
+  // attempts/status to simulate a crash-recovered row. enqueue() always
+  // creates with status=queued/attempts=0; update() advances state.
+  async function seedDelivery(deliveries, sub, { attempts, nextAttemptAt, status } = {}) {
+    const created = await deliveries.enqueue({
+      subscriptionId: sub.id,
+      event: "e",
+      url: sub.url,
+      nextAttemptAt: nextAttemptAt || undefined,
+      payload: {}
+    });
+    if (attempts !== undefined || status) {
+      await deliveries.update(created.id, {
+        ...(attempts !== undefined ? { attempts } : {}),
+        ...(status ? { status } : {})
+      });
+    }
+    return created;
+  }
+
+  // Codex P2 + Copilot on PR #154
+  test("recoverOnBoot counts persisted-retry deliveries against the budget", async () => {
+    const { svc, subs, deliveries } = await buildService({
+      maxConcurrentRetries: 2,
+      // Far-future nextAttemptAt so the schedule doesn't fire and
+      // unwind the budget before we observe.
+      backoffSchedule: [60_000]
+    });
+    const sub = await subs.create({
+      url: "https://a.example/",
+      events: ["e"],
+      maxAttempts: 5
+    });
+    const nowFar = new Date(Date.now() + 60_000).toISOString();
+    await seedDelivery(deliveries, sub, { attempts: 2, nextAttemptAt: nowFar });
+    await seedDelivery(deliveries, sub, { attempts: 2, nextAttemptAt: nowFar });
+    await seedDelivery(deliveries, sub, { attempts: 2, nextAttemptAt: nowFar });
+    expect(svc.retryInflightCount).toBe(0);
+    await svc.recoverOnBoot();
+    // Two get scheduled (budget=2); the third hits the budget cap
+    // and is marked failed instead of scheduled.
+    expect(svc.retryInflightCount).toBe(2);
+    await waitForCondition(async () => {
+      const all = (await deliveries.load()).deliveries;
+      return all.some((d) => /retry budget exhausted/.test(d.lastError || "") && d.status === "failed");
+    });
+    const all = (await deliveries.load()).deliveries;
+    const exhausted = all.find((d) => /retry budget exhausted/.test(d.lastError || ""));
+    expect(exhausted).toBeTruthy();
+    expect(exhausted.status).toBe("failed");
+    // Copilot on PR #154: nextAttemptAt must be cleared when the
+    // budget-exhaust path marks the row failed, not left as a
+    // phantom future timestamp.
+    expect(exhausted.nextAttemptAt === null || exhausted.nextAttemptAt === undefined || exhausted.nextAttemptAt === "").toBe(true);
+    svc.shutdown();
+  });
+
+  test("recoverOnBoot treats first-attempt persisted deliveries (attempts=0) as NOT retries", async () => {
+    const { svc, subs, deliveries } = await buildService({
+      maxConcurrentRetries: 1,
+      backoffSchedule: [60_000]
+    });
+    const sub = await subs.create({
+      url: "https://a.example/",
+      events: ["e"],
+      maxAttempts: 5
+    });
+    // Fill the retry budget with a real retry (attempts=2).
+    await seedDelivery(deliveries, sub, {
+      attempts: 2,
+      nextAttemptAt: new Date(Date.now() + 60_000).toISOString()
+    });
+    // And a first-attempt-scheduled row (attempts=0 — default from enqueue).
+    await seedDelivery(deliveries, sub, {});
+    await svc.recoverOnBoot();
+    expect(svc.retryInflightCount).toBe(1); // only the attempts=2 row counted
+    // The attempts=0 row should NOT have been marked failed —
+    // first-attempt schedules bypass the retry budget entirely.
+    const all = (await deliveries.load()).deliveries;
+    const firstAttempt = all.find((d) => (d.attempts || 0) === 0);
+    expect(firstAttempt).toBeTruthy();
+    expect(firstAttempt.status).not.toBe("failed");
+    svc.shutdown();
+  });
 });
 
 // B6 / #125: jitter is on by default. Inject a deterministic random

--- a/tests/webhook-service.test.js
+++ b/tests/webhook-service.test.js
@@ -93,10 +93,37 @@ describe("signature + helper functions", () => {
     expect(classifyHttpStatus(502)).toEqual({ ok: false, retriable: true });
   });
 
-  test("nextBackoffMs uses schedule index and caps at last slot", () => {
-    expect(nextBackoffMs(1)).toBe(DEFAULT_BACKOFF_MS[0]);
-    expect(nextBackoffMs(5)).toBe(DEFAULT_BACKOFF_MS[4]);
-    expect(nextBackoffMs(99)).toBe(DEFAULT_BACKOFF_MS[4]);
+  test("nextBackoffMs uses schedule index and caps at last slot (jitter off for determinism)", () => {
+    expect(nextBackoffMs(1, undefined, { jitter: false })).toBe(DEFAULT_BACKOFF_MS[0]);
+    expect(nextBackoffMs(5, undefined, { jitter: false })).toBe(DEFAULT_BACKOFF_MS[4]);
+    expect(nextBackoffMs(99, undefined, { jitter: false })).toBe(DEFAULT_BACKOFF_MS[4]);
+  });
+
+  // B6 / #125
+  test("nextBackoffMs default applies 0-25% additive jitter", () => {
+    const trials = 200;
+    const observed = new Set();
+    for (let i = 0; i < trials; i += 1) {
+      const value = nextBackoffMs(1);
+      expect(value).toBeGreaterThanOrEqual(DEFAULT_BACKOFF_MS[0]);
+      expect(value).toBeLessThanOrEqual(Math.floor(DEFAULT_BACKOFF_MS[0] * 1.25));
+      observed.add(value);
+    }
+    // Spread check: jitter should produce more than a single value
+    // across 200 trials with 250 possible integer outcomes.
+    expect(observed.size).toBeGreaterThan(20);
+  });
+
+  test("nextBackoffMs respects injected random()", () => {
+    expect(nextBackoffMs(1, undefined, { random: () => 0 })).toBe(DEFAULT_BACKOFF_MS[0]);
+    expect(nextBackoffMs(1, undefined, { random: () => 0.999999 })).toBe(
+      DEFAULT_BACKOFF_MS[0] + Math.floor(DEFAULT_BACKOFF_MS[0] * 0.25 * 0.999999)
+    );
+  });
+
+  test("nextBackoffMs jitterFraction=0 disables jitter even without jitter:false flag", () => {
+    expect(nextBackoffMs(1, undefined, { jitterFraction: 0 })).toBe(DEFAULT_BACKOFF_MS[0]);
+    expect(nextBackoffMs(3, undefined, { jitterFraction: 0 })).toBe(DEFAULT_BACKOFF_MS[2]);
   });
 });
 
@@ -566,5 +593,165 @@ describe("WebhookService.shutdown", () => {
     svc.shutdown();
     expect(svc.scheduledTimers.size).toBe(0);
     expect(svc.shutdownRequested).toBe(true);
+  });
+});
+
+// B6 / #125: aggregate retry-budget cap. The default is 16 concurrent
+// retries in flight, configurable via WEBHOOK_MAX_CONCURRENT_RETRIES.
+// When the cap is hit, scheduleDelivery({ isRetry: true }) marks the
+// delivery as failed rather than queueing it.
+describe("retry budget cap (B6 / #125)", () => {
+  test("scheduleDelivery with isRetry=true counts against the cap", async () => {
+    const { svc } = await buildService({ maxConcurrentRetries: 3 });
+    expect(svc.retryInflightCount).toBe(0);
+    // Long delay so the timers don't fire before we observe state.
+    svc.scheduleDelivery("delivery-a", 60_000, null, { isRetry: true });
+    svc.scheduleDelivery("delivery-b", 60_000, null, { isRetry: true });
+    svc.scheduleDelivery("delivery-c", 60_000, null, { isRetry: true });
+    expect(svc.retryInflightCount).toBe(3);
+    svc.shutdown();
+  });
+
+  test("first-attempt schedules (isRetry omitted) do NOT count against the retry cap", async () => {
+    const { svc } = await buildService({ maxConcurrentRetries: 2 });
+    svc.scheduleDelivery("delivery-a", 60_000, null); // no isRetry → first-attempt
+    svc.scheduleDelivery("delivery-b", 60_000, null);
+    svc.scheduleDelivery("delivery-c", 60_000, null);
+    expect(svc.retryInflightCount).toBe(0);
+    svc.shutdown();
+  });
+
+  test("exceeding the budget marks the delivery as failed instead of scheduling", async () => {
+    const fetchImpl = async () => ({
+      status: 500,
+      headers: { get: () => null },
+      body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+    });
+    const { svc, subs, deliveries } = await buildService({
+      fetchImpl,
+      maxConcurrentRetries: 1,
+      // 60s backoff so the first delivery stays in the retry budget
+      // while we issue the second one.
+      backoffSchedule: [60_000]
+    });
+    const sub = await subs.create({
+      url: "https://a.example/webhook",
+      events: ["e"],
+      maxAttempts: 3
+    });
+    await svc.emit("e", {});
+    // Wait for first delivery to fail-and-schedule-retry.
+    await waitForCondition(() => svc.retryInflightCount >= 1);
+    expect(svc.retryInflightCount).toBe(1);
+    // Issue a second emit; its first attempt also fails, would schedule
+    // a retry — but the retry budget (=1) is already exhausted.
+    await svc.emit("e", {});
+    await waitForCondition(async () => {
+      const recent = await deliveries.findRecent({ subscriptionId: sub.id, limit: 5 });
+      return recent.some((d) => d.status === "failed" && /retry budget exhausted/.test(d.lastError || ""));
+    });
+    const recent = await deliveries.findRecent({ subscriptionId: sub.id, limit: 5 });
+    const exhausted = recent.find((d) => /retry budget exhausted/.test(d.lastError || ""));
+    expect(exhausted).toBeTruthy();
+    expect(exhausted.status).toBe("failed");
+    svc.shutdown();
+  });
+
+  test("a completing retry frees budget for the next one", async () => {
+    const { svc } = await buildService({ maxConcurrentRetries: 1 });
+    // Fast timer — let it fire so the counter decrements.
+    svc.scheduleDelivery("first", 10, null, { isRetry: true });
+    expect(svc.retryInflightCount).toBe(1);
+    await waitForCondition(() => svc.retryInflightCount === 0, { timeoutMs: 1000 });
+    expect(svc.retryInflightCount).toBe(0);
+    // Now the budget is free again.
+    svc.scheduleDelivery("second", 60_000, null, { isRetry: true });
+    expect(svc.retryInflightCount).toBe(1);
+    svc.shutdown();
+  });
+
+  test("constructor clamps non-positive / non-integer maxConcurrentRetries to default", async () => {
+    const { svc: svcNeg } = await buildService({ maxConcurrentRetries: -5 });
+    expect(svcNeg.maxConcurrentRetries).toBe(16);
+    svcNeg.shutdown();
+    const { svc: svcNaN } = await buildService({ maxConcurrentRetries: NaN });
+    expect(svcNaN.maxConcurrentRetries).toBe(16);
+    svcNaN.shutdown();
+    const { svc: svcStr } = await buildService({ maxConcurrentRetries: "8" });
+    // Non-integer (string) falls back to default — caller must pass int.
+    expect(svcStr.maxConcurrentRetries).toBe(16);
+    svcStr.shutdown();
+  });
+});
+
+// B6 / #125: jitter is on by default. Inject a deterministic random
+// to exercise an exact backoff value; verify that the next-attempt
+// timestamp written by executeOnce reflects the jittered delay.
+describe("jitter applied to retry backoff (B6 / #125)", () => {
+  test("retry backoff uses the WebhookService's injected random()", async () => {
+    let attempts = 0;
+    const fetchImpl = async () => {
+      attempts += 1;
+      return {
+        status: 500,
+        headers: { get: () => null },
+        body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+      };
+    };
+    const { svc, subs, deliveries } = await buildService({
+      fetchImpl,
+      backoffSchedule: [1000],
+      random: () => 0.5  // halfway through the jitter window
+    });
+    const sub = await subs.create({
+      url: "https://example.com/",
+      events: ["e"],
+      maxAttempts: 5
+    });
+    const before = Date.now();
+    await svc.emit("e", {});
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && typeof d.nextAttemptAt === "string" && d.nextAttemptAt.length > 0;
+    });
+    const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+    const nextMs = new Date(d.nextAttemptAt).getTime();
+    // random=0.5, jitterFraction=0.25, base=1000 → jitter = floor(1000 * 0.25 * 0.5) = 125.
+    // nextAttemptAt should land ~before + 1125ms (give 1500ms slack
+    // for I/O + timer scheduling).
+    expect(nextMs - before).toBeGreaterThanOrEqual(1100);
+    expect(nextMs - before).toBeLessThan(2600);
+    expect(attempts).toBeGreaterThanOrEqual(1);
+    svc.shutdown();
+  });
+
+  test("WebhookService respects jitterFraction=0 (deterministic backoff)", async () => {
+    const fetchImpl = async () => ({
+      status: 500,
+      headers: { get: () => null },
+      body: { getReader: () => ({ read: async () => ({ done: true }) }) }
+    });
+    const { svc, subs, deliveries } = await buildService({
+      fetchImpl,
+      backoffSchedule: [777],
+      jitterFraction: 0
+    });
+    const sub = await subs.create({
+      url: "https://example.com/",
+      events: ["e"],
+      maxAttempts: 5
+    });
+    const before = Date.now();
+    await svc.emit("e", {});
+    await waitForCondition(async () => {
+      const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+      return d && typeof d.nextAttemptAt === "string" && d.nextAttemptAt.length > 0;
+    });
+    const d = (await deliveries.findRecent({ subscriptionId: sub.id, limit: 1 }))[0];
+    const delay = new Date(d.nextAttemptAt).getTime() - before;
+    // With jitterFraction=0, backoff is exactly 777ms (plus I/O slack).
+    expect(delay).toBeGreaterThanOrEqual(700);
+    expect(delay).toBeLessThan(2500);
+    svc.shutdown();
   });
 });


### PR DESCRIPTION
## Summary

- 0–25% additive jitter on every webhook retry interval (default-on).
- Aggregate retry-budget cap (`WEBHOOK_MAX_CONCURRENT_RETRIES`, default 16): exceeding it marks the delivery `failed` rather than queueing indefinitely.
- Audit table for all three outbound-call paths (webhook, provider fetch, web-push) in `docs/webhooks.md`.
- Closes #125. Part of #112 (Epic B: Operational Resilience).

## What this does

### Jitter
`nextBackoffMs(attemptNumber, schedule, { jitterFraction, random })` now applies `Math.floor(base * 0.25 * random())` additive jitter by default. Tests pass `{ jitter: false }` or `{ jitterFraction: 0 }` for determinism, or `{ random: () => 0.5 }` for exact-value assertions. Pure additive — never below the base; jittering above is always safe.

### Aggregate retry-budget cap
New `maxConcurrentRetries` field on `WebhookService` (default 16, env `WEBHOOK_MAX_CONCURRENT_RETRIES`, range 1–256). `scheduleDelivery(..., { isRetry: true })` counts against this budget. Exhaustion → delivery marked `failed` with `lastError: "retry budget exhausted (>=N retries inflight)"` + `[webhook] retry budget exhausted` warn-log.

### Audit
`docs/webhooks.md` gains an "Outbound-call retry/timeout audit" table covering webhook delivery, provider artifact fetch (single-shot by design), and web-push send (fire-and-forget by design).

## Acceptance vs. #125

- [x] Tabulation committed (`docs/webhooks.md` "Outbound-call retry/timeout audit").
- [x] Every retry interval has jitter applied (default-on).
- [x] Aggregate retry-budget cap exists + tested.
- [x] Docs updated (`docs/webhooks.md`).

## Test plan

- [x] +10 new tests in `tests/webhook-service.test.js`:
  - 5 in `retry budget cap (B6 / #125)`: counter increments/decrements, exhaust marks failed, completing retry frees budget, constructor clamps invalid values.
  - 2 in `jitter applied to retry backoff (B6 / #125)`: injected `random()` deterministic backoff; `jitterFraction=0` disable.
  - 3 jitter shape tests in the helper-functions block: spread check across 200 trials, exact value with `random:()=>0.999999`, `jitterFraction:0` disable.
- [x] Existing `nextBackoffMs uses schedule index` updated to pass `{ jitter: false }` (jitter is now default-on).
- [x] `npm run check` — full gate green (1056 tests; was 1046 before B6).

## Out of scope

- Circuit breakers (issue explicitly out-of-scopes — "probably overkill at our scale").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry backoff now uses additive jitter (0–25%) to reduce synchronized retry storms.
  * Global retry-concurrency cap added to limit concurrent retrying deliveries; excess retries are marked failed. Default cap exposed via WEBHOOK_MAX_CONCURRENT_RETRIES (configurable).

* **Documentation**
  * Webhook docs expanded with retry/timeout audit, jitter behavior, and retry-budget configuration details.

* **Tests**
  * Added tests covering jitter behavior, retry-budget enforcement, and recovered-retry handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/154)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->