### PR TITLE
feat(reliability): B7 — /healthz + /readyz endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,15 @@ services:
     volumes:
       - ./data:/app/data
     restart: unless-stopped
+    # B7 / #126: readiness probe. /readyz returns 200 when the
+    # process is up AND not shutting down AND no restore/backup is
+    # holding the data lock. During graceful shutdown drain (B1) or
+    # while a restore is mid-apply, this returns 503 so the
+    # supervisor stops sending new traffic. For liveness (restart on
+    # genuine hang), use /healthz instead.
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/readyz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s

--- a/docs/admin-platform-architecture-contract.md
+++ b/docs/admin-platform-architecture-contract.md
@@ -99,6 +99,49 @@ Why: this prevents orphaned in-flight jobs after restarts and preserves operator
 - Accepting absolute or traversing relative paths in any persisted artifact path field.
 - Expanding deferred scope (`#9`, `#13`) before demand signals justify complexity.
 
+## Health Endpoints (Locked for B7 / #126)
+
+Two endpoints, mounted at the top of the request pipeline (before
+rate-limit + body parsers so probes never get throttled or blocked
+on parser state):
+
+| Endpoint   | Purpose                                                      | 200 condition                                                                                                       | 503 condition                                                            |
+| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `/healthz` | Liveness probe. Use for "restart on hang".                   | Always (process is up and event loop is responsive).                                                                | n/a — never 503 from this endpoint.                                      |
+| `/readyz`  | Readiness probe. Use for "withhold traffic during shutdown". | `shutdownInFlight=false` AND `restoreInProgressRef.value=false` AND `dataMutationLockRef.value=false`.              | Any of the above is true. Response body lists the active reasons array.  |
+
+The `/readyz` 503 body shape is:
+
+```json
+{
+  "status": "not_ready",
+  "version": "<package version>",
+  "reasons": ["shutting_down", "restore_in_progress", "data_mutation_locked"]
+}
+```
+
+Operator runbook:
+
+- **Docker / docker-compose**: `docker-compose.yml` healthcheck is
+  wired to `/readyz`. During backup phase 3 (the brief swap window)
+  or during a restore, the container will briefly report
+  `unhealthy` — this is intentional. The supervisor should NOT
+  restart on `unhealthy` from `/readyz`; only from `/healthz` failure.
+- **Kubernetes**: map `livenessProbe` to `/healthz`,
+  `readinessProbe` to `/readyz`.
+- **Behind a reverse proxy**: configure the upstream health check to
+  hit `/readyz` so a graceful-shutdown drain (B1 / #120) stops
+  receiving traffic.
+
+What `/readyz` does NOT probe (out of scope per #126):
+
+- Per-store deep health (file readable, schema-valid). A corrupt
+  store on disk will still return 200 from `/readyz` — the bytes
+  aren't probed here.
+- Outbound dependency health (webhook upstreams, web-push gateway).
+
+These are tracked as follow-ups when there's a demand signal.
+
 ## Logging Contract (Locked for B2 / #121)
 
 Production paths (`server.js`, `routes/*.js`, `lib/*.js` excluding test/script files) emit logs through `lib/logger.js`'s structured JSON-line logger, never via bare `console.*`. Each line is `{ ts, level, msg, ...fields }` where:

--- a/routes/health.js
+++ b/routes/health.js
@@ -1,0 +1,80 @@
+"use strict";
+
+// Liveness + readiness endpoints (B7 / #126).
+//
+// /healthz — liveness. Returns 200 as long as the process is up and
+// the event loop is responsive enough to handle the request. Use this
+// from a supervisor (Docker `HEALTHCHECK`, Kubernetes `livenessProbe`,
+// systemd, etc.) to detect genuine hung processes. We deliberately do
+// NOT consult any of the data-mutation refs here: a healthy process
+// during a long restore window is still alive, and restarting it
+// would defeat the very point of the restore exclusion.
+//
+// /readyz — readiness. Returns 200 only when the process is in a
+// state to serve regular traffic — i.e., not shutting down, not in
+// the middle of a backup data-mutation swap, and not restoring.
+// Returns 503 with structured detail otherwise. Use this from a
+// load balancer or reverse proxy to withhold traffic during the
+// drain windows so in-flight requests can complete cleanly.
+//
+// Out of scope (per #126): per-store deep health (would be a
+// follow-up — currently a store with a corrupt file on disk would
+// still return 200 from /readyz because the bytes-on-disk state
+// isn't probed here).
+
+const express = require("express");
+
+function createHealthRouter(deps) {
+  const router = express.Router();
+  const {
+    // Promise barriers — must implement `.value` (boolean) and the
+    // route reads `.value` only. We never call `.waitForRelease()`
+    // from the health route; that would be a self-deadlock if the
+    // probe fires during the held window.
+    restoreInProgressRef,
+    dataMutationLockRef,
+    // Lambda returning the current shutdownInFlight flag from
+    // server.js. Modelled as a function so the route always sees the
+    // CURRENT value (the underlying variable is mutated in-place by
+    // gracefulShutdown rather than via a ref).
+    getShutdownInFlight,
+    // Optional version string the operator can use to confirm which
+    // build is responding. Falls back to "unknown" when not supplied.
+    appVersion = "unknown"
+  } = deps;
+
+  if (!restoreInProgressRef || typeof restoreInProgressRef.value !== "boolean") {
+    throw new TypeError("createHealthRouter: restoreInProgressRef.value (boolean) is required.");
+  }
+  if (!dataMutationLockRef || typeof dataMutationLockRef.value !== "boolean") {
+    throw new TypeError("createHealthRouter: dataMutationLockRef.value (boolean) is required.");
+  }
+  if (typeof getShutdownInFlight !== "function") {
+    throw new TypeError("createHealthRouter: getShutdownInFlight() function is required.");
+  }
+
+  router.get("/healthz", (_req, res) => {
+    res.setHeader("Cache-Control", "no-store");
+    res.status(200).json({ status: "ok", version: appVersion });
+  });
+
+  router.get("/readyz", (_req, res) => {
+    res.setHeader("Cache-Control", "no-store");
+    const reasons = [];
+    if (getShutdownInFlight()) reasons.push("shutting_down");
+    if (restoreInProgressRef.value) reasons.push("restore_in_progress");
+    if (dataMutationLockRef.value) reasons.push("data_mutation_locked");
+    if (reasons.length === 0) {
+      return res.status(200).json({ status: "ready", version: appVersion });
+    }
+    return res.status(503).json({
+      status: "not_ready",
+      version: appVersion,
+      reasons
+    });
+  });
+
+  return router;
+}
+
+module.exports = createHealthRouter;

--- a/server.js
+++ b/server.js
@@ -52,6 +52,7 @@ const {
 } = require("./lib/provider-answer-filter");
 const { logger } = require("./lib/logger");
 const { createRequestIdMiddleware } = require("./lib/request-id-middleware");
+const createHealthRouter = require("./routes/health.js");
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -3040,6 +3041,26 @@ function buildRuntimeConfigResponse() {
   };
 }
 
+// B7 / #126: hoisted so the /healthz + /readyz route can read the
+// current value via a closure when the route is mounted later in this
+// file. gracefulShutdown (defined far below) flips this on entry and
+// back off on completion. The route uses
+// `getShutdownInFlight: () => shutdownInFlight` so it sees the
+// CURRENT value, not the snapshot at mount time.
+let shutdownInFlight = false;
+
+// B7 / #126: surface the running build version via /healthz and
+// /readyz so an operator can confirm which image is responding. Read
+// once at boot from package.json; falls back to "unknown" if the file
+// is unreadable (e.g., a minimal Docker image that strips package.json).
+const APP_VERSION = (() => {
+  try {
+    return require("./package.json").version || "unknown";
+  } catch (_err) {
+    return "unknown";
+  }
+})();
+
 app.disable("x-powered-by");
 if (TRUST_PROXY) {
   app.set("trust proxy", TRUST_PROXY_HOPS);
@@ -3083,6 +3104,20 @@ app.use(helmet({
 // `res.status(429).json({ error: ... })` flows through the decorator.
 // See lib/request-id-middleware.js.
 app.use(createRequestIdMiddleware());
+// B7 / #126: health endpoints mounted BEFORE the rate-limiter so a
+// flood of supervisor probes doesn't trip the global cap and stop
+// the orchestrator from being able to read liveness/readiness. Also
+// before compression + body-parsers — these are GETs with no body
+// and trivial response shapes, no point spending cycles on
+// streaming-compression.
+app.use(
+  createHealthRouter({
+    restoreInProgressRef,
+    dataMutationLockRef,
+    getShutdownInFlight: () => shutdownInFlight,
+    appVersion: APP_VERSION
+  })
+);
 app.use(
   rateLimit({
     windowMs: RATE_LIMIT_WINDOW_MS,
@@ -3861,8 +3896,6 @@ const SHUTDOWN_TOTAL_TIMEOUT_MS =
 const SHUTDOWN_HTTP_DRAIN_TIMEOUT_MS = 10000;
 const SHUTDOWN_WEBHOOK_DRAIN_TIMEOUT_MS = 10000;
 const SHUTDOWN_STORE_FLUSH_TIMEOUT_MS = 10000;
-
-let shutdownInFlight = false;
 
 async function gracefulShutdown(httpServer, signal) {
   // Re-entry guard: a second SIGTERM/SIGINT arriving while a drain

--- a/tests/health-routes.test.js
+++ b/tests/health-routes.test.js
@@ -1,0 +1,174 @@
+"use strict";
+
+const express = require("express");
+const request = require("supertest");
+
+const createHealthRouter = require("../routes/health.js");
+
+// B7 / #126: /healthz (liveness) and /readyz (readiness) probes.
+//
+// Liveness should ALWAYS return 200 as long as the event loop is
+// responsive — no consultation of data-mutation refs. Readiness
+// returns 200 only when none of (restoreInProgressRef,
+// dataMutationLockRef, shutdownInFlight) is held.
+
+function buildApp(refs) {
+  const app = express();
+  app.use(
+    createHealthRouter({
+      restoreInProgressRef: refs.restore,
+      dataMutationLockRef: refs.dataLock,
+      getShutdownInFlight: () => refs.shutdownInFlight,
+      appVersion: refs.version || "test-1.0.0"
+    })
+  );
+  return app;
+}
+
+function makeRefs(initial = {}) {
+  return {
+    restore: { value: initial.restore === true },
+    dataLock: { value: initial.dataLock === true },
+    shutdownInFlight: initial.shutdownInFlight === true,
+    version: initial.version
+  };
+}
+
+describe("createHealthRouter — constructor validation", () => {
+  test("throws when restoreInProgressRef is not a ref shape", () => {
+    expect(() =>
+      createHealthRouter({
+        dataMutationLockRef: { value: false },
+        getShutdownInFlight: () => false
+      })
+    ).toThrow(/restoreInProgressRef/);
+  });
+
+  test("throws when dataMutationLockRef is not a ref shape", () => {
+    expect(() =>
+      createHealthRouter({
+        restoreInProgressRef: { value: false },
+        getShutdownInFlight: () => false
+      })
+    ).toThrow(/dataMutationLockRef/);
+  });
+
+  test("throws when getShutdownInFlight is not a function", () => {
+    expect(() =>
+      createHealthRouter({
+        restoreInProgressRef: { value: false },
+        dataMutationLockRef: { value: false },
+        getShutdownInFlight: false
+      })
+    ).toThrow(/getShutdownInFlight/);
+  });
+});
+
+describe("/healthz", () => {
+  test("returns 200 even during restore", async () => {
+    const refs = makeRefs({ restore: true });
+    const res = await request(buildApp(refs)).get("/healthz");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: "ok", version: "test-1.0.0" });
+  });
+
+  test("returns 200 even during graceful shutdown", async () => {
+    const refs = makeRefs({ shutdownInFlight: true });
+    const res = await request(buildApp(refs)).get("/healthz");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+  });
+
+  test("returns 200 even during data-mutation lock", async () => {
+    const refs = makeRefs({ dataLock: true });
+    const res = await request(buildApp(refs)).get("/healthz");
+    expect(res.status).toBe(200);
+  });
+
+  test("sets Cache-Control: no-store", async () => {
+    const refs = makeRefs();
+    const res = await request(buildApp(refs)).get("/healthz");
+    expect(res.headers["cache-control"]).toBe("no-store");
+  });
+
+  test("falls back to 'unknown' version when not supplied to factory", async () => {
+    // Bypass buildApp's default "test-1.0.0" fallback to exercise the
+    // route-internal default.
+    const app = express();
+    app.use(
+      createHealthRouter({
+        restoreInProgressRef: { value: false },
+        dataMutationLockRef: { value: false },
+        getShutdownInFlight: () => false
+      })
+    );
+    const res = await request(app).get("/healthz");
+    expect(res.body.version).toBe("unknown");
+  });
+});
+
+describe("/readyz", () => {
+  test("returns 200 when no refs are held", async () => {
+    const refs = makeRefs();
+    const res = await request(buildApp(refs)).get("/readyz");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ status: "ready", version: "test-1.0.0" });
+  });
+
+  test("returns 503 with reason `shutting_down` during shutdown", async () => {
+    const refs = makeRefs({ shutdownInFlight: true });
+    const res = await request(buildApp(refs)).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("not_ready");
+    expect(res.body.reasons).toContain("shutting_down");
+  });
+
+  test("returns 503 with reason `restore_in_progress` during restore", async () => {
+    const refs = makeRefs({ restore: true });
+    const res = await request(buildApp(refs)).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.reasons).toContain("restore_in_progress");
+  });
+
+  test("returns 503 with reason `data_mutation_locked` during backup swap", async () => {
+    const refs = makeRefs({ dataLock: true });
+    const res = await request(buildApp(refs)).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.reasons).toContain("data_mutation_locked");
+  });
+
+  test("returns 503 with all reasons when multiple refs held", async () => {
+    const refs = makeRefs({ restore: true, dataLock: true, shutdownInFlight: true });
+    const res = await request(buildApp(refs)).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.reasons.sort()).toEqual([
+      "data_mutation_locked",
+      "restore_in_progress",
+      "shutting_down"
+    ]);
+  });
+
+  test("getShutdownInFlight is consulted ON each request (not snapshotted at mount time)", async () => {
+    let inFlight = false;
+    const app = express();
+    app.use(
+      createHealthRouter({
+        restoreInProgressRef: { value: false },
+        dataMutationLockRef: { value: false },
+        getShutdownInFlight: () => inFlight
+      })
+    );
+    const ready = await request(app).get("/readyz");
+    expect(ready.status).toBe(200);
+    inFlight = true;
+    const notReady = await request(app).get("/readyz");
+    expect(notReady.status).toBe(503);
+    expect(notReady.body.reasons).toEqual(["shutting_down"]);
+  });
+
+  test("sets Cache-Control: no-store", async () => {
+    const refs = makeRefs();
+    const res = await request(buildApp(refs)).get("/readyz");
+    expect(res.headers["cache-control"]).toBe("no-store");
+  });
+});


### PR DESCRIPTION
## Summary

- `GET /healthz` — liveness probe; always 200. For supervisor "restart-on-hang".
- `GET /readyz` — readiness probe; 200 only when not shutting down AND no restore/backup is holding the data lock. For load balancers to withhold traffic during shutdown drain (B1) or restore.
- `docker-compose.yml` healthcheck wired to `/readyz`.
- Closes #126. Part of #112 (Epic B: Operational Resilience).

## What this does

- **`routes/health.js`** — small factory that takes the existing locks/refs as deps and produces an Express router. Throws TypeError at construction if any required dep is missing (matches the routes/admin.js fail-fast policy on the same family of deps).
- **`server.js`** — hoists `let shutdownInFlight = false` and reads `APP_VERSION` from `package.json` (falls back to "unknown" for minimal Docker images). Mounts the health router AFTER `createRequestIdMiddleware` but BEFORE rate-limit / compression / body-parsers / in-flight counter so supervisor probes never get throttled.
- **`docker-compose.yml`** — `healthcheck:` block targeting `/readyz` via `wget --spider`. Alpine BusyBox includes wget so no extra package install.
- **`docs/admin-platform-architecture-contract.md`** — new "Health Endpoints (Locked for B7 / #126)" section with semantics table, response shape, operator runbook (Docker, k8s, reverse proxy), and explicit out-of-scope list.

## Acceptance vs. #126

- [x] Both endpoints exist + tested — 15 tests covering constructor validation, liveness invariance during restore/shutdown/lock, readiness 503 with named reasons for each held ref, multiple-reason aggregation, request-time consultation, Cache-Control no-store, version surfacing.
- [x] docker-compose healthcheck calls `/readyz`.
- [x] Doc updated.

## Test plan

- [x] 15 new tests in `tests/health-routes.test.js`.
- [x] `npm run check` — full gate green (1061 tests; was 1046 + 15 new health = 1061).

## Out of scope (per #126)

- Per-store deep health (file readable, schema-valid).
- Outbound dependency health (webhook upstreams, web-push gateway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoints enabling monitoring of server liveness and readiness states.
  * Configured Docker Compose with automated health checks for container monitoring.

* **Documentation**
  * Added comprehensive deployment documentation for health endpoint integration with container orchestration, Kubernetes, and reverse-proxy configurations.

* **Tests**
  * Added test coverage for health check endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->