### PR TITLE
feat(reliability): C5 — server load test baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,10 @@ PERF_LOGGING=false
 # CHALLENGE_MODE_ENABLED=true
 # CHALLENGE_MAX_TIME_BUDGET_S=1800
 # CHALLENGE_MAX_PUZZLES=20
+
+# Load-test runner (`scripts/load-test.js`, C5/#131). Not a server
+# config — these are CLI-time inputs read by the load test from its
+# own process environment. Listed here so docs:check sees the
+# reference and to give operators a single discoverable place for
+# load-test wiring.
+# BASE_URL=http://localhost:3000

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -41,3 +41,76 @@ Use this checklist before tagging or publishing a release.
    - source provenance requirements (pinned commit + required checksums)
    - fail-closed behavior when provider import artifacts are incomplete
 3. Confirm CI run includes the provider UI regression gate when provider/admin files changed.
+
+## Load baseline (C5 / #131)
+
+`scripts/load-test.js` is a self-contained load runner that drives a
+locally-running server against three scenarios and reports RPS +
+latency percentiles. Use it before each release on a reference
+machine to detect throughput regressions.
+
+### Running
+
+```bash
+# Terminal 1 — start the server with production-ish flags:
+ADMIN_KEY=secret REQUIRE_ADMIN_KEY=true NODE_ENV=production \
+  PORT=3000 node server.js
+
+# Terminal 2 — drive the load:
+BASE_URL=http://localhost:3000 ADMIN_KEY=secret \   <!-- claim:skip -->
+  node scripts/load-test.js --duration=15 --concurrency=8
+
+# Or just one scenario:
+BASE_URL=http://localhost:3000 ADMIN_KEY=secret \   <!-- claim:skip -->
+  node scripts/load-test.js --scenario=player-read --duration=30
+```
+
+Output is JSON to stdout (also writable to `--output=path.json`).
+
+### Scenarios
+
+- **player-read** — random GET across `/api/word?lang=en` and
+  `/api/stats/leaderboard?lang=en&range=7d`. Exercises the common
+  read path through helmet, request-id middleware, rate limiter,
+  in-flight counter, and per-store snapshot read.
+- **admin-write** — random GET across `/api/admin/providers` and
+  `/api/admin/jobs`. Exercises the admin auth gate + admin rate
+  limiter + structured logger. Requires `ADMIN_KEY` env var.
+- **mixed** — 10:1 ratio of player-read to admin-write. Approximates
+  a moderate-traffic deployment with periodic admin checks.
+
+### Interpreting the output
+
+The JSON report has a top-level `scenarios[]` array with one entry
+per scenario. Key fields:
+
+- `requests` — total requests fired during the scenario window
+  (warmup + measured).
+- `sampledRequests` — count of measured requests (post-warmup).
+- `rps` — sampled-requests / measured-window (excludes warmup).
+- `latencyMs.p50`, `.p95`, `.p99` — percentile latencies in ms.
+- `statusCodes` — distribution of HTTP status codes observed.
+- `errorRate` — fraction of requests that failed to receive a
+  response (network errors, timeouts) — NOT 4xx/5xx, which are
+  surfaced in `statusCodes`.
+
+### Recording a baseline
+
+Run the load test on the reference machine for each release and
+paste the report into the release notes (or attach as
+`baseline-<release-tag>.json`). A regression alarm fires when:
+
+- `rps` drops > 20% from the previous baseline.
+- `latencyMs.p95` increases > 50% from the previous baseline.
+- `errorRate` > 0.01 (1%) at the configured concurrency.
+
+Numbers are machine-dependent — comparison is only meaningful
+across runs on the same hardware.
+
+### Out of scope (per #131)
+
+- Distributed load testing (single-machine only).
+- Stress-to-failure (the point is a healthy-state baseline, not a
+  breaking-point).
+- Cross-version comparison harness (operator records baselines per
+  reference machine; comparison is by-hand).

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -51,17 +51,21 @@ machine to detect throughput regressions.
 
 ### Running
 
+`BASE_URL` is the load-runner's target URL — it's NOT a server-side
+env var; the runner reads it from its own process environment. It's
+documented in `.env.example` for discoverability.
+
 ```bash
 # Terminal 1 — start the server with production-ish flags:
 ADMIN_KEY=secret REQUIRE_ADMIN_KEY=true NODE_ENV=production \
   PORT=3000 node server.js
 
 # Terminal 2 — drive the load:
-BASE_URL=http://localhost:3000 ADMIN_KEY=secret \   <!-- claim:skip -->
+BASE_URL=http://localhost:3000 ADMIN_KEY=secret \
   node scripts/load-test.js --duration=15 --concurrency=8
 
 # Or just one scenario:
-BASE_URL=http://localhost:3000 ADMIN_KEY=secret \   <!-- claim:skip -->
+BASE_URL=http://localhost:3000 \
   node scripts/load-test.js --scenario=player-read --duration=30
 ```
 
@@ -69,15 +73,21 @@ Output is JSON to stdout (also writable to `--output=path.json`).
 
 ### Scenarios
 
-- **player-read** — random GET across `/api/word?lang=en` and
-  `/api/stats/leaderboard?lang=en&range=7d`. Exercises the common
-  read path through helmet, request-id middleware, rate limiter,
-  in-flight counter, and per-store snapshot read.
-- **admin-write** — random GET across `/api/admin/providers` and
+- **player-read** — random GET across `/api/meta?lang=en` and
+  `/api/stats/leaderboard?lang=en&range=7d`. Both are PUBLIC routes
+  (no admin auth). Exercises helmet, request-id middleware, rate
+  limiter, in-flight counter, and per-store snapshot read. No
+  `ADMIN_KEY` needed.
+- **admin-auth** — random GET across `/api/admin/providers` and
   `/api/admin/jobs`. Exercises the admin auth gate + admin rate
-  limiter + structured logger. Requires `ADMIN_KEY` env var.
-- **mixed** — 10:1 ratio of player-read to admin-write. Approximates
-  a moderate-traffic deployment with periodic admin checks.
+  limiter + structured logger. Read-only (no writes performed —
+  exercising real writes would need a body crafted per endpoint
+  and would mutate live state). Requires `ADMIN_KEY` env var; fails
+  fast if absent.
+- **mixed** — 10:1 ratio of player-read to admin-auth. Approximates
+  a moderate-traffic deployment with periodic admin checks. Also
+  requires `ADMIN_KEY`; refuses to run without one rather than
+  silently downgrading to player-read.
 
 ### Interpreting the output
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -55,19 +55,33 @@ machine to detect throughput regressions.
 env var; the runner reads it from its own process environment. It's
 documented in `.env.example` for discoverability.
 
+The default global rate limit (`RATE_LIMIT_MAX=300` per 15-min
+window) and admin rate limit (`ADMIN_RATE_LIMIT_MAX=90` per 15-min
+window) will be exceeded by even a short load run — set both to a
+large value when the server is configured for a load test (Codex P1
+on PR #157):
+
 ```bash
-# Terminal 1 — start the server with production-ish flags:
+# Terminal 1 — start the server with production-ish flags, BUT with
+# the per-window rate limits raised so the load test doesn't trip
+# them mid-scenario:
 ADMIN_KEY=secret REQUIRE_ADMIN_KEY=true NODE_ENV=production \
+  RATE_LIMIT_MAX=1000000 ADMIN_RATE_LIMIT_MAX=1000000 \
   PORT=3000 node server.js
 
 # Terminal 2 — drive the load:
 BASE_URL=http://localhost:3000 ADMIN_KEY=secret \
   node scripts/load-test.js --duration=15 --concurrency=8
 
-# Or just one scenario:
+# Or just one scenario (player-read needs no ADMIN_KEY):
 BASE_URL=http://localhost:3000 \
   node scripts/load-test.js --scenario=player-read --duration=30
 ```
+
+The load runner exits non-zero (code 2) if ANY scenario was skipped
+due to missing configuration (e.g., `admin-auth` or `mixed` without
+`ADMIN_KEY`). This stops a release-checklist or CI step from silently
+passing on a partial baseline.
 
 Output is JSON to stdout (also writable to `--output=path.json`).
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -88,7 +88,7 @@ Output is JSON to stdout (also writable to `--output=path.json`).
 ### Scenarios
 
 - **player-read** — random GET across `/api/meta?lang=en` and
-  `/api/stats/leaderboard?lang=en&range=7d`. Both are PUBLIC routes
+  `/api/stats/leaderboard?lang=en&range=weekly`. Both are PUBLIC routes
   (no admin auth). Exercises helmet, request-id middleware, rate
   limiter, in-flight counter, and per-store snapshot read. No
   `ADMIN_KEY` needed.

--- a/scripts/load-test.js
+++ b/scripts/load-test.js
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+"use strict";
+
+// Server load baseline test (C5 / #131).
+//
+// Drives a running wordle-local server against three scenarios —
+// player read, admin write, mixed — and reports RPS + latency
+// percentiles. Self-contained: no autocannon / wrk / k6 dependency.
+// Uses Node's built-in `http(s)` module + the Performance API.
+//
+// Usage
+// -----
+//
+//   # Start the server in one terminal:
+//   ADMIN_KEY=secret REQUIRE_ADMIN_KEY=true PORT=3000 node server.js
+//
+//   # In another terminal:
+//   BASE_URL=http://localhost:3000 ADMIN_KEY=secret \
+//     node scripts/load-test.js
+//
+//   # Or run just one scenario:
+//   BASE_URL=http://localhost:3000 ADMIN_KEY=secret \
+//     node scripts/load-test.js --scenario=player-read --duration=10
+//
+// Args
+// ----
+//
+//   --scenario=<name>      One of: player-read, admin-write, mixed, all
+//                          (default: all)
+//   --duration=<seconds>   How long each scenario runs (default: 15)
+//   --concurrency=<N>      Concurrent in-flight requests per scenario
+//                          (default: 8)
+//   --warmup=<seconds>     Discard latency samples from the first N
+//                          seconds to let JIT settle (default: 2)
+//   --output=<path>        Write the JSON report to a file in addition
+//                          to stdout (default: stdout only)
+//
+// Env
+// ---
+//
+//   BASE_URL         — server URL (default http://localhost:3000)
+//   ADMIN_KEY        — admin key for admin-write + mixed scenarios
+//
+// Output shape
+// ------------
+//
+//   {
+//     "summary": { "totalRequests", "totalDurationMs", "wallStart", "wallEnd" },
+//     "scenarios": [
+//       {
+//         "name": "player-read",
+//         "requests": 1234,
+//         "errors": 0,
+//         "errorRate": 0.0,
+//         "durationMs": 15003,
+//         "rps": 82.3,
+//         "latencyMs": {
+//           "min": 1.2,
+//           "p50": 4.1,
+//           "p95": 12.7,
+//           "p99": 28.4,
+//           "max": 105.2,
+//           "mean": 5.8
+//         },
+//         "statusCodes": { "200": 1230, "503": 4 }
+//       },
+//       ...
+//     ]
+//   }
+//
+// Out of scope (per #131):
+//
+//   - Distributed load (single-machine only).
+//   - Stress-to-failure (this is a baseline, not a breaking-point test).
+//   - Cross-version comparison harness (operator records baselines per
+//     reference machine + records in docs).
+
+const http = require("node:http");
+const https = require("node:https");
+const fs = require("node:fs");
+
+// Use a keep-alive agent so the test measures HANDLER latency in
+// steady state rather than the TCP handshake cost on every request.
+// Real clients (browsers, fetch, axios, curl with -K) reuse
+// connections; the baseline should match. Cap the per-host socket
+// pool at the highest --concurrency we expect; that's 256 (CLI
+// clamp), so size accordingly.
+const HTTP_AGENT = new http.Agent({ keepAlive: true, maxSockets: 256, maxFreeSockets: 64 });
+const HTTPS_AGENT = new https.Agent({ keepAlive: true, maxSockets: 256, maxFreeSockets: 64 });
+
+const DEFAULTS = Object.freeze({
+  baseUrl: "http://localhost:3000",
+  scenario: "all",
+  durationSec: 15,
+  concurrency: 8,
+  warmupSec: 2
+});
+
+function parseArgs(argv) {
+  const args = { ...DEFAULTS, adminKey: process.env.ADMIN_KEY || "", output: null };
+  if (process.env.BASE_URL) args.baseUrl = process.env.BASE_URL;
+  for (const raw of argv.slice(2)) {
+    const m = raw.match(/^--([^=]+)=(.*)$/);
+    if (!m) continue;
+    const [, key, value] = m;
+    switch (key) {
+      case "scenario":
+        args.scenario = String(value);
+        break;
+      case "duration":
+        args.durationSec = Math.max(1, Number(value) | 0);
+        break;
+      case "concurrency":
+        args.concurrency = Math.max(1, Number(value) | 0);
+        break;
+      case "warmup":
+        args.warmupSec = Math.max(0, Number(value) | 0);
+        break;
+      case "output":
+        args.output = String(value);
+        break;
+      default:
+        // Unknown flag; ignore rather than fail so the harness is
+        // forgiving across versions.
+        break;
+    }
+  }
+  return args;
+}
+
+// Percentile from a presorted array of numbers. p in [0, 1].
+// Uses linear interpolation between adjacent ranks (the same method
+// numpy's `interpolation='linear'` uses).
+function percentile(sortedSamples, p) {
+  if (sortedSamples.length === 0) return null;
+  if (sortedSamples.length === 1) return sortedSamples[0];
+  const clamped = Math.max(0, Math.min(1, p));
+  const rank = clamped * (sortedSamples.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sortedSamples[lo];
+  const frac = rank - lo;
+  return sortedSamples[lo] + (sortedSamples[hi] - sortedSamples[lo]) * frac;
+}
+
+function round(value, decimals = 2) {
+  if (value === null || value === undefined) return null;
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function summarize(latencySamples) {
+  if (latencySamples.length === 0) {
+    return { min: null, p50: null, p95: null, p99: null, max: null, mean: null };
+  }
+  const sorted = latencySamples.slice().sort((a, b) => a - b);
+  let sum = 0;
+  for (const v of sorted) sum += v;
+  return {
+    min: round(sorted[0], 3),
+    p50: round(percentile(sorted, 0.5), 3),
+    p95: round(percentile(sorted, 0.95), 3),
+    p99: round(percentile(sorted, 0.99), 3),
+    max: round(sorted[sorted.length - 1], 3),
+    mean: round(sum / sorted.length, 3)
+  };
+}
+
+// Single-shot HTTP request. Returns { latencyMs, status, error }.
+// Designed to never throw — errors are captured in the result.
+function makeRequest(target, options = {}) {
+  return new Promise((resolve) => {
+    const url = new URL(target);
+    const lib = url.protocol === "https:" ? https : http;
+    const agent = url.protocol === "https:" ? HTTPS_AGENT : HTTP_AGENT;
+    const startedAt = performance.now();
+    const req = lib.request(
+      {
+        method: options.method || "GET",
+        hostname: url.hostname,
+        port: url.port || (url.protocol === "https:" ? 443 : 80),
+        path: url.pathname + url.search,
+        headers: options.headers || {},
+        agent
+      },
+      (res) => {
+        // Drain the body so the connection can be reused (keep-alive).
+        res.resume();
+        res.on("end", () => {
+          resolve({
+            latencyMs: performance.now() - startedAt,
+            status: res.statusCode,
+            error: null
+          });
+        });
+        res.on("error", (err) => {
+          resolve({
+            latencyMs: performance.now() - startedAt,
+            status: res.statusCode || 0,
+            error: err.message
+          });
+        });
+      }
+    );
+    req.on("error", (err) => {
+      resolve({
+        latencyMs: performance.now() - startedAt,
+        status: 0,
+        error: err.message
+      });
+    });
+    if (options.body) {
+      req.write(options.body);
+    }
+    req.end();
+  });
+}
+
+// Returns a function that emits the NEXT request to fire for the
+// given scenario. The harness calls it on a tight loop per worker.
+function buildRequestFactory(scenarioName, args) {
+  const { baseUrl, adminKey } = args;
+  const adminHeaders = adminKey ? { "x-admin-key": adminKey } : {};
+  switch (scenarioName) {
+    case "player-read":
+      return () => {
+        // Random pick across two read endpoints.
+        const pick = Math.random();
+        if (pick < 0.5) {
+          return { url: `${baseUrl}/api/word?lang=en`, options: { method: "GET" } };
+        }
+        return {
+          url: `${baseUrl}/api/stats/leaderboard?lang=en&range=7d`,
+          options: { method: "GET" }
+        };
+      };
+    case "admin-write": {
+      if (!adminKey) {
+        throw new Error(
+          "admin-write scenario requires ADMIN_KEY env var; got empty. Set it or run --scenario=player-read."
+        );
+      }
+      // Mix two admin GET endpoints — they go through the admin auth
+      // gate which exercises the most expensive middleware stack
+      // (admin rate-limit + key check + structured logger). Pure
+      // admin-WRITE would require crafting valid POST bodies for
+      // every endpoint, which is brittle and overkill for a baseline.
+      return () => {
+        const pick = Math.random();
+        if (pick < 0.5) {
+          return {
+            url: `${baseUrl}/api/admin/providers`,
+            options: { method: "GET", headers: adminHeaders }
+          };
+        }
+        return {
+          url: `${baseUrl}/api/admin/jobs`,
+          options: { method: "GET", headers: adminHeaders }
+        };
+      };
+    }
+    case "mixed": {
+      const playerRead = buildRequestFactory("player-read", args);
+      const adminWrite = adminKey ? buildRequestFactory("admin-write", args) : null;
+      // 10:1 read-to-admin ratio per #131 spec.
+      return () => {
+        const pick = Math.random();
+        if (pick < 0.91 || !adminWrite) {
+          return playerRead();
+        }
+        return adminWrite();
+      };
+    }
+    default:
+      throw new Error(`Unknown scenario: ${scenarioName}`);
+  }
+}
+
+async function runScenario(scenarioName, args) {
+  const requestFactory = buildRequestFactory(scenarioName, args);
+  const latencies = [];
+  const statusCodes = Object.create(null);
+  let errors = 0;
+  let requests = 0;
+  const warmupDeadline = performance.now() + args.warmupSec * 1000;
+  const endDeadline = performance.now() + (args.warmupSec + args.durationSec) * 1000;
+  const startWall = Date.now();
+  async function worker() {
+    while (performance.now() < endDeadline) {
+      const { url, options } = requestFactory();
+      const result = await makeRequest(url, options);
+      requests += 1;
+      if (result.error || result.status === 0) errors += 1;
+      statusCodes[result.status || "error"] = (statusCodes[result.status || "error"] || 0) + 1;
+      // Discard samples from the warmup window.
+      if (performance.now() >= warmupDeadline) {
+        latencies.push(result.latencyMs);
+      }
+    }
+  }
+  const startedAt = performance.now();
+  const workers = [];
+  for (let i = 0; i < args.concurrency; i += 1) workers.push(worker());
+  await Promise.all(workers);
+  const durationMs = performance.now() - startedAt;
+  const samplesDurationMs = Math.max(0, durationMs - args.warmupSec * 1000);
+  const sampledRequests = latencies.length;
+  return {
+    name: scenarioName,
+    requests,
+    sampledRequests,
+    errors,
+    errorRate: requests === 0 ? 0 : round(errors / requests, 4),
+    durationMs: round(durationMs, 1),
+    samplesDurationMs: round(samplesDurationMs, 1),
+    warmupSec: args.warmupSec,
+    concurrency: args.concurrency,
+    rps: samplesDurationMs > 0 ? round((sampledRequests / samplesDurationMs) * 1000, 1) : null,
+    latencyMs: summarize(latencies),
+    statusCodes,
+    wallStart: new Date(startWall).toISOString(),
+    wallEnd: new Date().toISOString()
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const scenariosToRun =
+    args.scenario === "all" ? ["player-read", "admin-write", "mixed"] : [args.scenario];
+  const wallStart = Date.now();
+  const report = {
+    summary: {
+      baseUrl: args.baseUrl,
+      durationSec: args.durationSec,
+      warmupSec: args.warmupSec,
+      concurrency: args.concurrency,
+      wallStart: new Date(wallStart).toISOString()
+    },
+    scenarios: []
+  };
+  for (const name of scenariosToRun) {
+    try {
+      const result = await runScenario(name, args);
+      report.scenarios.push(result);
+    } catch (err) {
+      report.scenarios.push({
+        name,
+        skipped: true,
+        reason: err && err.message ? err.message : String(err)
+      });
+    }
+  }
+  report.summary.wallEnd = new Date().toISOString();
+  const text = JSON.stringify(report, null, 2);
+  process.stdout.write(text + "\n");
+  if (args.output) {
+    fs.writeFileSync(args.output, text + "\n");
+  }
+}
+
+// Library exports (for tests). When the script is executed directly,
+// the `require.main === module` check fires main(). The exports let
+// tests/scripts.load-test.test.js exercise the pure helpers without
+// spinning up a server.
+module.exports = { parseArgs, percentile, summarize, round };
+
+if (require.main === module) {
+  main().catch((err) => {
+    process.stderr.write(`load-test failed: ${err && err.message ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/load-test.js
+++ b/scripts/load-test.js
@@ -266,7 +266,7 @@ function buildRequestFactory(scenarioName, args) {
           return { url: `${baseUrl}/api/meta?lang=en`, options: { method: "GET" } };
         }
         return {
-          url: `${baseUrl}/api/stats/leaderboard?lang=en&range=7d`,
+          url: `${baseUrl}/api/stats/leaderboard?lang=en&range=weekly`,
           options: { method: "GET" }
         };
       };

--- a/scripts/load-test.js
+++ b/scripts/load-test.js
@@ -111,7 +111,12 @@ function parseArgs(argv) {
         args.durationSec = Math.max(1, Number(value) | 0);
         break;
       case "concurrency":
-        args.concurrency = Math.max(1, Number(value) | 0);
+        // Clamp to [1, 256] (CR Major on PR #157 — unbounded
+        // concurrency would spawn excessive workers and destabilize
+        // baseline runs). 256 matches the HTTP agent's maxSockets
+        // declared above; setting concurrency higher than that has
+        // diminishing returns anyway.
+        args.concurrency = Math.max(1, Math.min(256, Number(value) | 0));
         break;
       case "warmup":
         args.warmupSec = Math.max(0, Number(value) | 0);
@@ -388,6 +393,13 @@ async function main() {
   if (args.output) {
     fs.writeFileSync(args.output, text + "\n");
   }
+  // CR Major on PR #157: destroy the keep-alive agents so their
+  // lingering sockets don't keep the event loop alive after main()
+  // returns. Without this, node exits cleanly anyway (the agents'
+  // socket idle timer eventually fires) but `node ... | head` and
+  // similar invocations would block longer than they should.
+  HTTP_AGENT.destroy();
+  HTTPS_AGENT.destroy();
 }
 
 // Library exports (for tests). When the script is executed directly,

--- a/scripts/load-test.js
+++ b/scripts/load-test.js
@@ -25,7 +25,7 @@
 // Args
 // ----
 //
-//   --scenario=<name>      One of: player-read, admin-write, mixed, all
+//   --scenario=<name>      One of: player-read, admin-auth, mixed, all
 //                          (default: all)
 //   --duration=<seconds>   How long each scenario runs (default: 15)
 //   --concurrency=<N>      Concurrent in-flight requests per scenario
@@ -39,7 +39,7 @@
 // ---
 //
 //   BASE_URL         — server URL (default http://localhost:3000)
-//   ADMIN_KEY        — admin key for admin-write + mixed scenarios
+//   ADMIN_KEY        — admin key for admin-auth + mixed scenarios
 //
 // Output shape
 // ------------
@@ -168,12 +168,26 @@ function summarize(latencySamples) {
 
 // Single-shot HTTP request. Returns { latencyMs, status, error }.
 // Designed to never throw — errors are captured in the result.
+//
+// CR Major on PR #157: a per-request timeout is required so a
+// stalled socket doesn't hang a worker past the scenario deadline.
+// 10s is generous for any of our healthy endpoints; if the server
+// is hanging, errorRate will spike and the operator should
+// investigate rather than have the test compensate.
+const REQUEST_TIMEOUT_MS = 10_000;
+
 function makeRequest(target, options = {}) {
   return new Promise((resolve) => {
     const url = new URL(target);
     const lib = url.protocol === "https:" ? https : http;
     const agent = url.protocol === "https:" ? HTTPS_AGENT : HTTP_AGENT;
     const startedAt = performance.now();
+    let settled = false;
+    function finalize(result) {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    }
     const req = lib.request(
       {
         method: options.method || "GET",
@@ -181,20 +195,21 @@ function makeRequest(target, options = {}) {
         port: url.port || (url.protocol === "https:" ? 443 : 80),
         path: url.pathname + url.search,
         headers: options.headers || {},
-        agent
+        agent,
+        timeout: REQUEST_TIMEOUT_MS
       },
       (res) => {
         // Drain the body so the connection can be reused (keep-alive).
         res.resume();
         res.on("end", () => {
-          resolve({
+          finalize({
             latencyMs: performance.now() - startedAt,
             status: res.statusCode,
             error: null
           });
         });
         res.on("error", (err) => {
-          resolve({
+          finalize({
             latencyMs: performance.now() - startedAt,
             status: res.statusCode || 0,
             error: err.message
@@ -202,8 +217,11 @@ function makeRequest(target, options = {}) {
         });
       }
     );
+    req.on("timeout", () => {
+      req.destroy(new Error("request timeout"));
+    });
     req.on("error", (err) => {
-      resolve({
+      finalize({
         latencyMs: performance.now() - startedAt,
         status: 0,
         error: err.message
@@ -218,33 +236,41 @@ function makeRequest(target, options = {}) {
 
 // Returns a function that emits the NEXT request to fire for the
 // given scenario. The harness calls it on a tight loop per worker.
+//
+// Endpoint choice rationale (Codex P2 + Copilot + CR on PR #157):
+//
+// - player-read hits PUBLIC endpoints only. `/api/word` looked like
+//   the obvious target but is admin-protected (`requireAdminAccess`,
+//   see server.js:3657), so running the recommended
+//   `REQUIRE_ADMIN_KEY=true` config would record 401s instead of
+//   exercising the player path. `/api/meta` and
+//   `/api/stats/leaderboard` are both public.
+//
+// - admin-auth (renamed from admin-write — Copilot caught: we never
+//   POST any writes; we just hit admin-gated GETs to exercise the
+//   admin auth gate + admin rate-limit stack). True admin writes
+//   would need a body crafted for each endpoint; deferred.
 function buildRequestFactory(scenarioName, args) {
   const { baseUrl, adminKey } = args;
   const adminHeaders = adminKey ? { "x-admin-key": adminKey } : {};
   switch (scenarioName) {
     case "player-read":
       return () => {
-        // Random pick across two read endpoints.
         const pick = Math.random();
         if (pick < 0.5) {
-          return { url: `${baseUrl}/api/word?lang=en`, options: { method: "GET" } };
+          return { url: `${baseUrl}/api/meta?lang=en`, options: { method: "GET" } };
         }
         return {
           url: `${baseUrl}/api/stats/leaderboard?lang=en&range=7d`,
           options: { method: "GET" }
         };
       };
-    case "admin-write": {
+    case "admin-auth": {
       if (!adminKey) {
         throw new Error(
-          "admin-write scenario requires ADMIN_KEY env var; got empty. Set it or run --scenario=player-read."
+          "admin-auth scenario requires ADMIN_KEY env var; got empty. Set it or run --scenario=player-read."
         );
       }
-      // Mix two admin GET endpoints — they go through the admin auth
-      // gate which exercises the most expensive middleware stack
-      // (admin rate-limit + key check + structured logger). Pure
-      // admin-WRITE would require crafting valid POST bodies for
-      // every endpoint, which is brittle and overkill for a baseline.
       return () => {
         const pick = Math.random();
         if (pick < 0.5) {
@@ -260,15 +286,21 @@ function buildRequestFactory(scenarioName, args) {
       };
     }
     case "mixed": {
+      // CR Major on PR #157: do not silently downgrade `mixed` to
+      // pure player-read when ADMIN_KEY is missing — that produces a
+      // misleading "mixed" baseline that doesn't reflect the
+      // intended 10:1 read:admin ratio.
+      if (!adminKey) {
+        throw new Error(
+          "mixed scenario requires ADMIN_KEY env var; got empty. Set it or run --scenario=player-read."
+        );
+      }
       const playerRead = buildRequestFactory("player-read", args);
-      const adminWrite = adminKey ? buildRequestFactory("admin-write", args) : null;
-      // 10:1 read-to-admin ratio per #131 spec.
+      const adminAuth = buildRequestFactory("admin-auth", args);
       return () => {
         const pick = Math.random();
-        if (pick < 0.91 || !adminWrite) {
-          return playerRead();
-        }
-        return adminWrite();
+        if (pick < 0.91) return playerRead();
+        return adminAuth();
       };
     }
     default:
@@ -326,7 +358,7 @@ async function runScenario(scenarioName, args) {
 async function main() {
   const args = parseArgs(process.argv);
   const scenariosToRun =
-    args.scenario === "all" ? ["player-read", "admin-write", "mixed"] : [args.scenario];
+    args.scenario === "all" ? ["player-read", "admin-auth", "mixed"] : [args.scenario];
   const wallStart = Date.now();
   const report = {
     summary: {
@@ -360,7 +392,7 @@ async function main() {
 
 // Library exports (for tests). When the script is executed directly,
 // the `require.main === module` check fires main(). The exports let
-// tests/scripts.load-test.test.js exercise the pure helpers without
+// `tests/load-test-utils.test.js` exercise the pure helpers without
 // spinning up a server.
 module.exports = { parseArgs, percentile, summarize, round };
 

--- a/scripts/load-test.js
+++ b/scripts/load-test.js
@@ -388,6 +388,18 @@ async function main() {
     }
   }
   report.summary.wallEnd = new Date().toISOString();
+  // Codex P2 on PR #157: if ANY scenario was skipped due to a
+  // configuration failure (missing ADMIN_KEY for admin-auth/mixed),
+  // exit non-zero so a release-checklist or CI step doesn't silently
+  // pass a partial baseline. The skipped scenario is still recorded
+  // in the report for debugging.
+  const skippedCount = report.scenarios.filter((s) => s.skipped).length;
+  if (skippedCount > 0) {
+    report.summary.skippedCount = skippedCount;
+    process.stderr.write(
+      `load-test: ${skippedCount} scenario(s) skipped — see report.scenarios[].reason. Exiting non-zero.\n`
+    );
+  }
   const text = JSON.stringify(report, null, 2);
   process.stdout.write(text + "\n");
   if (args.output) {
@@ -400,6 +412,9 @@ async function main() {
   // similar invocations would block longer than they should.
   HTTP_AGENT.destroy();
   HTTPS_AGENT.destroy();
+  if (skippedCount > 0) {
+    process.exitCode = 2;
+  }
 }
 
 // Library exports (for tests). When the script is executed directly,

--- a/tests/load-test-utils.test.js
+++ b/tests/load-test-utils.test.js
@@ -1,0 +1,180 @@
+"use strict";
+
+const { parseArgs, percentile, summarize, round } = require("../scripts/load-test.js");
+
+describe("percentile (C5 / #131)", () => {
+  test("returns null for empty array", () => {
+    expect(percentile([], 0.5)).toBeNull();
+  });
+
+  test("returns the single value when array has one element", () => {
+    expect(percentile([42], 0.5)).toBe(42);
+    expect(percentile([42], 0.99)).toBe(42);
+  });
+
+  test("p50 of [1, 2, 3, 4, 5] is 3 (median)", () => {
+    expect(percentile([1, 2, 3, 4, 5], 0.5)).toBe(3);
+  });
+
+  test("p100 returns the max", () => {
+    expect(percentile([10, 20, 30, 40, 50], 1.0)).toBe(50);
+  });
+
+  test("p0 returns the min", () => {
+    expect(percentile([10, 20, 30, 40, 50], 0)).toBe(10);
+  });
+
+  test("interpolates linearly between adjacent ranks", () => {
+    // 4 samples, p25: rank = 0.25 * 3 = 0.75 → between idx 0 and idx 1.
+    // Interpolated: 10 + (20 - 10) * 0.75 = 17.5
+    expect(percentile([10, 20, 30, 40], 0.25)).toBeCloseTo(17.5, 5);
+  });
+
+  test("clamps p > 1 to p = 1", () => {
+    expect(percentile([1, 2, 3], 1.5)).toBe(3);
+  });
+
+  test("clamps p < 0 to p = 0", () => {
+    expect(percentile([1, 2, 3], -0.5)).toBe(1);
+  });
+});
+
+describe("summarize (C5 / #131)", () => {
+  test("returns all-null on empty input", () => {
+    expect(summarize([])).toEqual({
+      min: null,
+      p50: null,
+      p95: null,
+      p99: null,
+      max: null,
+      mean: null
+    });
+  });
+
+  test("computes a sensible shape for a real-looking latency vector", () => {
+    const samples = [];
+    // Build a 1000-sample distribution: 90% fast (2-5ms), 9% warm
+    // (20-30ms), 1% long tail (100-150ms). p95 should land in or
+    // just past the warm cluster, p99 in the long tail.
+    for (let i = 0; i < 900; i += 1) samples.push(2 + Math.random() * 3);
+    for (let i = 0; i < 90; i += 1) samples.push(20 + Math.random() * 10);
+    for (let i = 0; i < 10; i += 1) samples.push(100 + Math.random() * 50);
+    const out = summarize(samples);
+    expect(out.min).toBeGreaterThanOrEqual(2);
+    expect(out.min).toBeLessThan(5);
+    expect(out.p50).toBeGreaterThan(2);
+    expect(out.p50).toBeLessThan(8);
+    expect(out.p95).toBeGreaterThan(15); // 95th percentile lands in the warm cluster
+    expect(out.p99).toBeGreaterThan(20); // 99th in warm or long tail
+    expect(out.max).toBeGreaterThanOrEqual(100);
+    expect(out.mean).toBeGreaterThan(2);
+    expect(out.mean).toBeLessThan(20);
+  });
+
+  test("sorts the input internally; does not mutate the caller's array", () => {
+    const samples = [50, 10, 30, 20, 40];
+    const before = samples.slice();
+    summarize(samples);
+    expect(samples).toEqual(before);
+  });
+
+  test("median of [1, 2, 3, 4] is 2.5 (interpolated)", () => {
+    const out = summarize([1, 2, 3, 4]);
+    expect(out.p50).toBe(2.5);
+    expect(out.min).toBe(1);
+    expect(out.max).toBe(4);
+    expect(out.mean).toBe(2.5);
+  });
+});
+
+describe("round (C5 / #131)", () => {
+  test("returns null for null/undefined input", () => {
+    expect(round(null)).toBeNull();
+    expect(round(undefined)).toBeNull();
+  });
+
+  test("rounds to 2 decimals by default", () => {
+    expect(round(3.14159)).toBe(3.14);
+    expect(round(3.145)).toBeCloseTo(3.15, 5); // banker's-rounding edge tolerated
+  });
+
+  test("respects custom decimal count", () => {
+    expect(round(1.23456789, 4)).toBe(1.2346);
+    expect(round(1.23456789, 0)).toBe(1);
+  });
+});
+
+describe("parseArgs (C5 / #131)", () => {
+  test("defaults when no CLI args + no env", () => {
+    const restoreUrl = process.env.BASE_URL;
+    const restoreKey = process.env.ADMIN_KEY;
+    delete process.env.BASE_URL;
+    delete process.env.ADMIN_KEY;
+    try {
+      const args = parseArgs(["node", "load-test.js"]);
+      expect(args).toMatchObject({
+        baseUrl: "http://localhost:3000",
+        scenario: "all",
+        durationSec: 15,
+        concurrency: 8,
+        warmupSec: 2,
+        adminKey: "",
+        output: null
+      });
+    } finally {
+      if (restoreUrl !== undefined) process.env.BASE_URL = restoreUrl;
+      if (restoreKey !== undefined) process.env.ADMIN_KEY = restoreKey;
+    }
+  });
+
+  test("CLI args override defaults", () => {
+    const args = parseArgs([
+      "node",
+      "load-test.js",
+      "--scenario=player-read",
+      "--duration=30",
+      "--concurrency=64",
+      "--warmup=5",
+      "--output=/tmp/baseline.json"
+    ]);
+    expect(args.scenario).toBe("player-read");
+    expect(args.durationSec).toBe(30);
+    expect(args.concurrency).toBe(64);
+    expect(args.warmupSec).toBe(5);
+    expect(args.output).toBe("/tmp/baseline.json");
+  });
+
+  test("BASE_URL env var is honored", () => {
+    const restore = process.env.BASE_URL;
+    process.env.BASE_URL = "https://example.com";
+    try {
+      const args = parseArgs(["node", "load-test.js"]);
+      expect(args.baseUrl).toBe("https://example.com");
+    } finally {
+      if (restore === undefined) delete process.env.BASE_URL;
+      else process.env.BASE_URL = restore;
+    }
+  });
+
+  test("ADMIN_KEY env var is honored", () => {
+    const restore = process.env.ADMIN_KEY;
+    process.env.ADMIN_KEY = "my-secret";
+    try {
+      const args = parseArgs(["node", "load-test.js"]);
+      expect(args.adminKey).toBe("my-secret");
+    } finally {
+      if (restore === undefined) delete process.env.ADMIN_KEY;
+      else process.env.ADMIN_KEY = restore;
+    }
+  });
+
+  test("negative duration clamps to 1 second floor (never zero)", () => {
+    const args = parseArgs(["node", "load-test.js", "--duration=-5"]);
+    expect(args.durationSec).toBe(1);
+  });
+
+  test("zero concurrency clamps to 1 (never zero)", () => {
+    const args = parseArgs(["node", "load-test.js", "--concurrency=0"]);
+    expect(args.concurrency).toBe(1);
+  });
+});

--- a/tests/load-test-utils.test.js
+++ b/tests/load-test-utils.test.js
@@ -52,23 +52,25 @@ describe("summarize (C5 / #131)", () => {
   });
 
   test("computes a sensible shape for a real-looking latency vector", () => {
+    // Deterministic distribution (Copilot on PR #157 caught — random
+    // samples make rare-tail flakes hard to reproduce). 100 samples:
+    // 90% fast (3ms), 10% warm (25ms). Linear-interpolation
+    // percentiles land cleanly on the cluster values; no
+    // interpolation-edge surprises.
     const samples = [];
-    // Build a 1000-sample distribution: 90% fast (2-5ms), 9% warm
-    // (20-30ms), 1% long tail (100-150ms). p95 should land in or
-    // just past the warm cluster, p99 in the long tail.
-    for (let i = 0; i < 900; i += 1) samples.push(2 + Math.random() * 3);
-    for (let i = 0; i < 90; i += 1) samples.push(20 + Math.random() * 10);
-    for (let i = 0; i < 10; i += 1) samples.push(100 + Math.random() * 50);
+    for (let i = 0; i < 90; i += 1) samples.push(3);
+    for (let i = 0; i < 10; i += 1) samples.push(25);
     const out = summarize(samples);
-    expect(out.min).toBeGreaterThanOrEqual(2);
-    expect(out.min).toBeLessThan(5);
-    expect(out.p50).toBeGreaterThan(2);
-    expect(out.p50).toBeLessThan(8);
-    expect(out.p95).toBeGreaterThan(15); // 95th percentile lands in the warm cluster
-    expect(out.p99).toBeGreaterThan(20); // 99th in warm or long tail
-    expect(out.max).toBeGreaterThanOrEqual(100);
-    expect(out.mean).toBeGreaterThan(2);
-    expect(out.mean).toBeLessThan(20);
+    expect(out.min).toBe(3);
+    // p50: rank = 0.5 * 99 = 49.5; idx 49 and 50 both = 3 → 3
+    expect(out.p50).toBe(3);
+    // p95: rank = 0.95 * 99 = 94.05; idx 94 and 95 both = 25 → 25
+    expect(out.p95).toBe(25);
+    // p99: rank = 0.99 * 99 = 98.01; idx 98 and 99 both = 25 → 25
+    expect(out.p99).toBe(25);
+    expect(out.max).toBe(25);
+    // mean = (90*3 + 10*25) / 100 = (270 + 250) / 100 = 5.2
+    expect(out.mean).toBeCloseTo(5.2, 3);
   });
 
   test("sorts the input internally; does not mutate the caller's array", () => {

--- a/tests/load-test-utils.test.js
+++ b/tests/load-test-utils.test.js
@@ -179,4 +179,10 @@ describe("parseArgs (C5 / #131)", () => {
     const args = parseArgs(["node", "load-test.js", "--concurrency=0"]);
     expect(args.concurrency).toBe(1);
   });
+
+  // CR Major on PR #157
+  test("concurrency clamps to 256 ceiling (unbounded values would destabilize)", () => {
+    const args = parseArgs(["node", "load-test.js", "--concurrency=1024"]);
+    expect(args.concurrency).toBe(256);
+  });
 });


### PR DESCRIPTION
## Summary

- `scripts/load-test.js` — self-contained load runner that drives a running wordle-local server against three scenarios (player-read, admin-write, mixed) and emits a JSON RPS+latency report.
- `docs/release-checklist.md` — new "Load baseline (C5 / #131)" section covering how to run, interpret, and call regressions.
- Closes #131. Part of #113 (Epic C: Test Coverage & Fault Injection).

## What this does

- **`scripts/load-test.js`** — pure Node, no autocannon/wrk/k6 dependency. Uses built-in `node:http(s)` + `node:perf_hooks`. CLI flags for duration, concurrency, warmup, output path, scenario picker. Three scenarios per #131 spec:
  - `player-read` — random GET across `/api/word?lang=en` and `/api/stats/leaderboard?lang=en&range=7d`.
  - `admin-write` — random GET across `/api/admin/providers` and `/api/admin/jobs` (exercises the admin auth gate + admin rate limiter + structured logger). Requires `ADMIN_KEY`.
  - `mixed` — 10:1 read:write ratio.

- **`tests/load-test-utils.test.js`** — 21 unit tests covering `percentile`, `summarize`, `round`, `parseArgs`. The networked run is NOT in the jest suite (requires a real running server + produces machine-dependent numbers); the test pins the math so a future refactor catches here.

- **`docs/release-checklist.md`** — new section with running instructions, scenario descriptions, output-shape interpretation, baseline-recording recipe, and regression alarms (rps drop >20%, p95 increase >50%, errorRate >1%).

## Acceptance vs. #131

- [x] Load script runs + produces report.
- [x] Baseline recorded in `docs/` — interpretation guide + alarm thresholds shipped; actual numbers recorded by the operator on the reference machine per release (the script supports `--output=path.json`).
- [x] Release checklist references it.

## Test plan

- [x] `tests/load-test-utils.test.js` — 21 tests.
- [x] `npm run check` — full gate green (1098 tests; was 1077 + 21 = 1098).

## Out of scope (per #131)

- Distributed load testing.
- Stress-to-failure.
- Cross-version comparison harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI load-testing tool to run configurable baseline scenarios (player-read, admin-auth, mixed), control duration/concurrency/warmup, and emit structured JSON reports.

* **Documentation**
  * Added a load-testing guide covering usage, interpreting metrics (RPS, latency percentiles, status/error rates), recording baselines, regression thresholds, and limitations.

* **Tests**
  * Added unit tests for argument parsing, percentile/summary calculations, and rounding behavior.

* **Chores**
  * Added BASE_URL entry to .env.example.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/157)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->