### PR TITLE
fix(reliability): address 9 post-merge reviewer bugs on PRs #153, #154, #156, #157

### DIFF
--- a/lib/backup-store.js
+++ b/lib/backup-store.js
@@ -1177,7 +1177,13 @@ async function cleanupOrphanedRestoreDirs(dataRoot, options = {}) {
     ? Math.max(0, options.ageThresholdMs)
     : DEFAULT_ORPHAN_AGE_THRESHOLD_MS;
   const now = typeof options.now === "function" ? options.now() : Date.now();
-  const orphans = await findOrphanedRestoreDirs(dataRoot);
+  // Allow the caller to pass a pre-computed orphan list so the boot
+  // path doesn't scan twice (Copilot on PR #153 caught the double-
+  // scan). When omitted we still compute internally for the simple
+  // call shape.
+  const orphans = Array.isArray(options.orphans)
+    ? options.orphans
+    : await findOrphanedRestoreDirs(dataRoot);
   const cleaned = [];
   const retained = [];
   const errors = [];

--- a/lib/webhook-service.js
+++ b/lib/webhook-service.js
@@ -64,8 +64,12 @@ function nextBackoffMs(attemptNumber, schedule = DEFAULT_BACKOFF_MS, options = {
   // that want deterministic timing). The `random` injection lets
   // tests assert exact values without freezing Math.random globally.
   if (options.jitter === false) return base;
+  // CR Major on PR #154: clamp to [0, DEFAULT_JITTER_FRACTION] so a
+  // caller can't accidentally exceed the documented 0–25% policy. We
+  // still allow opt-OUT via 0 (deterministic backoff) and opt-DOWN
+  // to any sub-25% value.
   const fraction = Number.isFinite(options.jitterFraction)
-    ? Math.max(0, options.jitterFraction)
+    ? Math.min(DEFAULT_JITTER_FRACTION, Math.max(0, options.jitterFraction))
     : DEFAULT_JITTER_FRACTION;
   if (fraction === 0) return base;
   const random = typeof options.random === "function" ? options.random : Math.random;
@@ -375,8 +379,12 @@ class WebhookService {
       : DEFAULT_GLOBAL_INFLIGHT;
     // B6 / #125: cap deliveries currently in inter-retry backoff sleep.
     // See DEFAULT_MAX_CONCURRENT_RETRIES above for rationale.
+    // CR Major on PR #154: clamp to [1, 256] (the same range the env
+    // wiring in server.js advertises) so a caller can't disable the
+    // safeguard by passing an arbitrarily large value. Non-integer
+    // or non-positive falls back to default.
     this.maxConcurrentRetries = Number.isInteger(options.maxConcurrentRetries) && options.maxConcurrentRetries > 0
-      ? options.maxConcurrentRetries
+      ? Math.min(256, options.maxConcurrentRetries)
       : DEFAULT_MAX_CONCURRENT_RETRIES;
     this.backoffSchedule = Array.isArray(options.backoffSchedule) && options.backoffSchedule.length > 0
       ? options.backoffSchedule
@@ -387,7 +395,7 @@ class WebhookService {
     // deterministic timing, or `random` to inject a deterministic
     // PRNG for exact-value assertions.
     this.jitterFraction = Number.isFinite(options.jitterFraction)
-      ? Math.max(0, options.jitterFraction)
+      ? Math.min(DEFAULT_JITTER_FRACTION, Math.max(0, options.jitterFraction))
       : DEFAULT_JITTER_FRACTION;
     this.random = typeof options.random === "function" ? options.random : null;
     // Pending due timers — tracked so shutdown can clear them.
@@ -631,21 +639,30 @@ class WebhookService {
         });
         return;
       }
-      // B6 / #125: nextBackoffMs() now applies 0..jitterFraction*base
-      // jitter by default. Math.max with `retryAfterMs` honors any
-      // server-supplied Retry-After header that may be larger than the
-      // jittered schedule slot, so a polite upstream's hint still
-      // wins. The DEFAULT_RETRY_AFTER_CAP_MS prevents a hostile or
-      // misconfigured header from pinning us at hours.
-      const backoffMs = Math.min(
-        Math.max(
-          result.retryAfterMs ?? 0,
-          nextBackoffMs(attemptNumber, this.backoffSchedule, {
-            jitterFraction: this.jitterFraction,
-            random: this.random || undefined
-          })
-        ),
+      // B6 / #125: nextBackoffMs() applies 0..jitterFraction*base
+      // jitter by default. We honor a polite upstream's Retry-After
+      // header if it's larger than our schedule's slot — but cap the
+      // header value itself at DEFAULT_RETRY_AFTER_CAP_MS so a hostile
+      // upstream can't strand us for hours.
+      //
+      // Codex P2 on PR #154 caught the previous shape's bug: the cap
+      // was applied to the OUTER Math.max result, so the jittered
+      // schedule value (e.g., 600s + jitter) got clamped back to
+      // exactly 600s. Every long-running retry then synchronized at
+      // the 10-minute slot, defeating the jitter we just added.
+      // Fixed by applying the cap to the Retry-After header alone;
+      // nextBackoffMs's own cap covers the schedule side, and jitter
+      // on the longest schedule slot survives.
+      const cappedRetryAfterMs = Math.min(
+        result.retryAfterMs ?? 0,
         DEFAULT_RETRY_AFTER_CAP_MS
+      );
+      const backoffMs = Math.max(
+        cappedRetryAfterMs,
+        nextBackoffMs(attemptNumber, this.backoffSchedule, {
+          jitterFraction: this.jitterFraction,
+          random: this.random || undefined
+        })
       );
       const nextAt = new Date(this.now().getTime() + backoffMs).toISOString();
       await this.deliveryStore.update(delivery.id, {

--- a/scripts/load-test.js
+++ b/scripts/load-test.js
@@ -183,9 +183,6 @@ const REQUEST_TIMEOUT_MS = 10_000;
 
 function makeRequest(target, options = {}) {
   return new Promise((resolve) => {
-    const url = new URL(target);
-    const lib = url.protocol === "https:" ? https : http;
-    const agent = url.protocol === "https:" ? HTTPS_AGENT : HTTP_AGENT;
     const startedAt = performance.now();
     let settled = false;
     function finalize(result) {
@@ -193,7 +190,29 @@ function makeRequest(target, options = {}) {
       settled = true;
       resolve(result);
     }
-    const req = lib.request(
+    // Copilot on PR #157 caught: the doc comment says "never throws"
+    // but `new URL(target)` and `http(s).request(...)` construction
+    // both throw synchronously on bad input — which would reject the
+    // promise and abort the whole scenario instead of being counted
+    // in `errors`. Catching here keeps the contract.
+    let url;
+    let lib;
+    let agent;
+    try {
+      url = new URL(target);
+      lib = url.protocol === "https:" ? https : http;
+      agent = url.protocol === "https:" ? HTTPS_AGENT : HTTP_AGENT;
+    } catch (err) {
+      finalize({
+        latencyMs: performance.now() - startedAt,
+        status: 0,
+        error: err && err.message ? err.message : String(err)
+      });
+      return;
+    }
+    let req;
+    try {
+      req = lib.request(
       {
         method: options.method || "GET",
         hostname: url.hostname,
@@ -222,6 +241,17 @@ function makeRequest(target, options = {}) {
         });
       }
     );
+    } catch (err) {
+      // http.request can throw synchronously on malformed options
+      // (e.g., invalid header chars). Close the same path as a
+      // network error.
+      finalize({
+        latencyMs: performance.now() - startedAt,
+        status: 0,
+        error: err && err.message ? err.message : String(err)
+      });
+      return;
+    }
     req.on("timeout", () => {
       req.destroy(new Error("request timeout"));
     });
@@ -302,9 +332,13 @@ function buildRequestFactory(scenarioName, args) {
       }
       const playerRead = buildRequestFactory("player-read", args);
       const adminAuth = buildRequestFactory("admin-auth", args);
+      // Copilot on PR #157 caught: `0.91` yields a 10.1:1 ratio.
+      // The exact 10:1 cutoff is 10/11 (~0.9090909). Using the
+      // expression directly so the intent is grep-able.
+      const PLAYER_READ_CUTOFF = 10 / 11;
       return () => {
         const pick = Math.random();
-        if (pick < 0.91) return playerRead();
+        if (pick < PLAYER_READ_CUTOFF) return playerRead();
         return adminAuth();
       };
     }

--- a/server.js
+++ b/server.js
@@ -2233,11 +2233,33 @@ rebuildLanguageRuntimeCatalog();
 // handler's.
 const RESTORE_ORPHAN_CLEANUP_AGE_HOURS = (() => {
   const raw = process.env.RESTORE_ORPHAN_CLEANUP_AGE_HOURS;
-  if (raw === null || raw === undefined || raw === "") return 24;
+  if (raw === null || raw === undefined || raw === "") {
+    // Single source of truth — derive the default from
+    // DEFAULT_ORPHAN_AGE_THRESHOLD_MS in lib/backup-store.js
+    // (Copilot on PR #153 caught the duplicate 24h literal). Lazy-
+    // require here because server.js is still loading when this top-
+    // level const evaluates.
+    const { DEFAULT_ORPHAN_AGE_THRESHOLD_MS } = require("./lib/backup-store.js");
+    return DEFAULT_ORPHAN_AGE_THRESHOLD_MS / 3600000;
+  }
   const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : 24;
+  if (Number.isFinite(n) && n >= 0) return n;
+  const { DEFAULT_ORPHAN_AGE_THRESHOLD_MS } = require("./lib/backup-store.js");
+  return DEFAULT_ORPHAN_AGE_THRESHOLD_MS / 3600000;
 })();
-(async () => {
+
+// Boot-time orphan dir cleanup, awaited from startServer (B5 / #124).
+//
+// CR Major on PR #153 caught the previous fire-and-forget IIFE:
+// running this in the background can race a real in-flight restore
+// (especially with RESTORE_ORPHAN_CLEANUP_AGE_HOURS=0), which would
+// delete the active staging/rollback dirs of a restore that's still
+// going. Moved into the explicit startup sequence so the cleanup
+// completes BEFORE the HTTP listener comes up and BEFORE any
+// inbound traffic can trigger a parallel restore. The age threshold
+// also still protects against the cross-node-shared-mount case
+// where another process might be in the middle of a restore.
+async function runBootOrphanCleanup() {
   try {
     const {
       findOrphanedRestoreDirs,
@@ -2255,8 +2277,13 @@ const RESTORE_ORPHAN_CLEANUP_AGE_HOURS = (() => {
       names: orphans.map((entry) => entry.name),
       summary: list
     });
+    // Reuse the orphan list we just computed — pass it through to
+    // cleanupOrphanedRestoreDirs so it doesn't re-scan the dir
+    // (Copilot on PR #153 caught the double walk + state-skew risk
+    // when the dir listing changed between the two passes).
     const result = await cleanupOrphanedRestoreDirs(dataRoot, {
-      ageThresholdMs: RESTORE_ORPHAN_CLEANUP_AGE_HOURS * 60 * 60 * 1000
+      ageThresholdMs: RESTORE_ORPHAN_CLEANUP_AGE_HOURS * 60 * 60 * 1000,
+      orphans
     });
     if (result.cleaned.length > 0) {
       logger.info("backup-store.orphans.cleaned", {
@@ -2291,7 +2318,7 @@ const RESTORE_ORPHAN_CLEANUP_AGE_HOURS = (() => {
   } catch (err) {
     logger.warn("backup-store.orphan_check_failed", { error: err });
   }
-})();
+}
 
 if (getDefinitionsMode() === "memory") {
   getOrLoadFullDefinitionsMap();
@@ -3778,6 +3805,10 @@ function renderDailyMissing(message) {
 }
 
 async function startServer(listener = app.listen.bind(app)) {
+  // CR Major on PR #153: orphan cleanup awaited HERE — before any
+  // restore route can become reachable — so the cleanup can't race
+  // an in-flight restore.
+  await runBootOrphanCleanup();
   // Await the single boot reconcile BEFORE invoking listener() so the
   // first GET /api/word and /daily can't observe pre-reconcile state.
   // The earlier fire-and-forget form raced app.listen with the still-

--- a/tests/backup-store.cleanup.test.js
+++ b/tests/backup-store.cleanup.test.js
@@ -135,38 +135,40 @@ describe("cleanupOrphanedRestoreDirs (B5 / #124)", () => {
   });
 
   test("partial failure is collected, not thrown", async () => {
+    // CR Minor + Copilot on PR #153 caught that the previous shape
+    // only asserted the response SHAPE on the success path. Now we
+    // deterministically force one dir's rm to throw via jest.spyOn
+    // on the shared fsp module. cleanupOrphanedRestoreDirs's internal
+    // fsp.rm call sees the spy because Node's module cache returns
+    // the same `node:fs/promises` instance to both the lib and the
+    // test.
     const { dir, dataRoot } = await makeTempDataRoot();
+    const goodName = ".restore-staging-good";
+    const badName = ".restore-rollback-bad";
+    const realRm = fsp.rm;
+    const rmSpy = jest.spyOn(fsp, "rm").mockImplementation((target, opts) => {
+      if (typeof target === "string" && target.endsWith(badName)) {
+        const err = new Error("EACCES: permission denied (simulated)");
+        err.code = "EACCES";
+        return Promise.reject(err);
+      }
+      return realRm(target, opts);
+    });
     try {
-      await makeOrphanDir(dataRoot, ".restore-staging-good", {
-        ageMs: 48 * 60 * 60 * 1000
-      });
-      await makeOrphanDir(dataRoot, ".restore-rollback-bad", {
-        ageMs: 48 * 60 * 60 * 1000
-      });
-      // Simulate "bad" being undeletable. The most reliable way to force
-      // a delete failure without root: replace fsp.rm temporarily. We
-      // can't intercept the module-internal binding from outside, so
-      // instead make the dir contain something unrm'able? On Linux a
-      // chmod-000 dir still rm's fine. The cleanest path is to mock
-      // fsp.rm; but to keep this test simple and portable, we just
-      // verify the SHAPE of the response on the success path and trust
-      // the implementation collects errors via the try/catch around
-      // `fsp.rm`. (Exhaustive failure-mode coverage lives in
-      // tests/fs-faulty.test.js which already has an `fsp.rm`-throwing
-      // fixture for the broader stores layer.)
+      await makeOrphanDir(dataRoot, goodName, { ageMs: 48 * 60 * 60 * 1000 });
+      await makeOrphanDir(dataRoot, badName, { ageMs: 48 * 60 * 60 * 1000 });
       const result = await cleanupOrphanedRestoreDirs(dataRoot, { ageThresholdMs: 0 });
-      expect(result.cleaned.length + result.errors.length).toBe(2);
-      expect(result.cleaned.length).toBeGreaterThanOrEqual(1);
-      // ensure both were attempted
-      const attemptedNames = [
-        ...result.cleaned.map((e) => e.name),
-        ...result.errors.map((e) => e.name)
-      ].sort();
-      expect(attemptedNames).toEqual([
-        ".restore-rollback-bad",
-        ".restore-staging-good"
-      ]);
+
+      // Function resolves (does not throw) even when one rm fails.
+      // Good dir lands in `cleaned`; bad dir lands in `errors` with
+      // the simulated message.
+      expect(result.cleaned.map((entry) => entry.name)).toEqual([goodName]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].name).toBe(badName);
+      expect(result.errors[0].message).toMatch(/permission denied/);
+      expect(result.retained).toEqual([]);
     } finally {
+      rmSpy.mockRestore();
       await fsp.rm(dir, { recursive: true, force: true });
     }
   });

--- a/tests/regression/p1-pr98-backup-fixtures.test.js
+++ b/tests/regression/p1-pr98-backup-fixtures.test.js
@@ -32,8 +32,22 @@ const {
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 
+// Track every mkdtemp output across the suite so afterAll can clean
+// them up (Copilot + CR on PR #156 caught the temp-dir leak — every
+// run otherwise left a `wordle-c4-pr98-*` dir in os.tmpdir()).
+const TEMP_PROJECT_ROOTS = [];
+
+afterAll(async () => {
+  await Promise.all(
+    TEMP_PROJECT_ROOTS.map((dir) =>
+      fsp.rm(dir, { recursive: true, force: true }).catch(() => {})
+    )
+  );
+});
+
 async function tempProjectWithSchemas() {
   const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "wordle-c4-pr98-"));
+  TEMP_PROJECT_ROOTS.push(dir);
   await fsp.mkdir(path.join(dir, "data"), { recursive: true });
   const schemaFiles = [
     "data/backup-manifest.schema.json",
@@ -94,8 +108,18 @@ describe("P1 fixture: PR #98 — duplicate archive paths rejected pre-stage", ()
       { name: "manifest.json" }
     );
     archive.append(evilContent, { name: "data/leaderboard.json" });
+    // Wire up reject paths on both the archive (archiver) and the
+    // file-system output stream (Copilot + CR on PR #156 caught the
+    // close-only wait — if either side errors, the test would hang
+    // until Jest's timeout). The race below resolves on the FIRST
+    // close OR error from either source.
+    const archiveDone = new Promise((resolve, reject) => {
+      out.once("close", resolve);
+      out.once("error", reject);
+      archive.once("error", reject);
+    });
     await archive.finalize();
-    await new Promise((resolve) => out.on("close", resolve));
+    await archiveDone;
 
     await expect(validateArchive(archivePath, { projectRoot })).rejects.toMatchObject({
       code: "MANIFEST_DUPLICATE_PATH"

--- a/tests/webhook-service.test.js
+++ b/tests/webhook-service.test.js
@@ -125,6 +125,24 @@ describe("signature + helper functions", () => {
     expect(nextBackoffMs(1, undefined, { jitterFraction: 0 })).toBe(DEFAULT_BACKOFF_MS[0]);
     expect(nextBackoffMs(3, undefined, { jitterFraction: 0 })).toBe(DEFAULT_BACKOFF_MS[2]);
   });
+
+  // CR Major on PR #154
+  test("nextBackoffMs clamps jitterFraction > 0.25 down to the 0–25% policy ceiling", () => {
+    // Without the clamp, jitterFraction=1 would give base..2*base.
+    // With it, the max possible is base + floor(base * 0.25 * 0.999...).
+    const maxJittered = nextBackoffMs(1, undefined, {
+      jitterFraction: 1,
+      random: () => 0.999999
+    });
+    const expectedMax = DEFAULT_BACKOFF_MS[0] + Math.floor(DEFAULT_BACKOFF_MS[0] * 0.25 * 0.999999);
+    expect(maxJittered).toBe(expectedMax);
+    // Floor of the clamped range is just `base` (random=0).
+    const minJittered = nextBackoffMs(1, undefined, {
+      jitterFraction: 1,
+      random: () => 0
+    });
+    expect(minJittered).toBe(DEFAULT_BACKOFF_MS[0]);
+  });
 });
 
 describe("SSRF guard (isPrivateIPv4 / isPrivateIPv6 / assertOutboundUrlAllowed)", () => {
@@ -667,6 +685,21 @@ describe("retry budget cap (B6 / #125)", () => {
     // Now the budget is free again.
     svc.scheduleDelivery("second", 60_000, null, { isRetry: true });
     expect(svc.retryInflightCount).toBe(1);
+    svc.shutdown();
+  });
+
+  // CR Major on PR #154
+  test("constructor clamps maxConcurrentRetries > 256 down to the 256 ceiling", async () => {
+    const { svc } = await buildService({ maxConcurrentRetries: 100_000 });
+    expect(svc.maxConcurrentRetries).toBe(256);
+    svc.shutdown();
+  });
+
+  // CR Major on PR #154: also enforce that the per-service jitterFraction
+  // is clamped (not just the standalone helper).
+  test("constructor clamps jitterFraction > 0.25 down to 0.25", async () => {
+    const { svc } = await buildService({ jitterFraction: 0.9 });
+    expect(svc.jitterFraction).toBe(0.25);
     svc.shutdown();
   });
 


### PR DESCRIPTION
## Summary

Companion to #158 (doc fixes). All behavior changes — no doc-only edits in this PR. Addresses the real-bug findings the bot reviewers posted post-merge on the B5/B6/C4/C5 PRs.

## What this fixes

### PR #153 (B5) — backup/restore disaster recovery

- **CR Major** — Boot orphan cleanup was a fire-and-forget module IIFE. With `RESTORE_ORPHAN_CLEANUP_AGE_HOURS=0` it could race a live restore on a shared `data/` mount and delete its in-flight staging/rollback dirs. Moved into `startServer` and awaited BEFORE the HTTP listener accepts traffic.
- **Copilot** — Eliminated double dir-scan in boot path. `cleanupOrphanedRestoreDirs` now accepts an `options.orphans` pre-computed list.
- **Copilot** — Removed `24` hardcoded default in server.js; derive from `DEFAULT_ORPHAN_AGE_THRESHOLD_MS` export.

### PR #154 (B6) — outbound retry/jitter/budget

- **Codex P2** — At the longest backoff slot (10 min), the outer `Math.min(cap)` clamped jittered values back to exactly 600s, defeating the jitter. Restructured: cap applies to the Retry-After header alone; the schedule's own internal cap covers the schedule side and jitter on the longest slot survives.
- **CR Major** — Clamp `jitterFraction` to `[0, DEFAULT_JITTER_FRACTION]` (0.25) in both standalone helper + per-service field.
- **CR Major** — Clamp `maxConcurrentRetries` to `[1, 256]` (matches the env wiring's advertised range).

### PR #156 (C4) — P1 regression fixtures

- **Copilot + CR** — `mkdtemp` temp dirs cleanup via `afterAll`.
- **Copilot + CR** — Archive write now races `close` vs `error` from both archiver + output stream (was `close`-only — would hang on stream errors).

### PR #157 (C5) — load baseline

- **Copilot** — `makeRequest` wraps `new URL` and `http.request` in try/catch so malformed targets surface as `{ status: 0, error }` per the "never throws" contract.
- **Copilot** — `mixed` ratio: `10 / 11` (exact 10:1) instead of `0.91` (10.1:1).

## Test plan

- [x] +3 new tests (jitterFraction ceiling clamp, maxConcurrentRetries 256 clamp, jitterFraction-on-service clamp).
- [x] Existing `partial failure` test now uses `jest.spyOn(fsp, "rm")` to deterministically exercise the error-collection branch (was previously acknowledged as a no-op).
- [x] `npm run check` — full gate green (1102 tests; was 1099 + 3 new = 1102).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved race condition in restore directory cleanup during server startup
  * Improved webhook retry backoff parameter validation and consistency

* **Improvements**
  * Enhanced restore operation reliability by preventing orphaned directory cleanup conflicts

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->