### PR TITLE
ui: split `.ghost` into semantic button classes (closes #164)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -164,7 +164,7 @@
                 data-i18n-attr="placeholder:play.namePlaceholder"
               />
             </label>
-            <button type="submit" class="ghost" data-i18n="play.useThisName">Use this name</button>
+            <button type="submit" class="btn-primary" data-i18n="play.useThisName">Use this name</button>
           </form>
           <div id="profileStatus" class="message" role="status" aria-live="polite"></div>
           <div id="savedPlayersWrap" class="saved-players hidden">
@@ -267,7 +267,7 @@
           <div class="play-meta-right">
             <strong id="challengeTimer" aria-live="polite">--:--</strong>
             <span id="challengeScoreLine" class="hint"></span>
-            <button type="button" id="challengeQuitBtn" class="ghost" data-i18n="challenge.quit">Quit</button>
+            <button type="button" id="challengeQuitBtn" class="btn-danger" data-i18n="challenge.quit">Quit</button>
           </div>
         </header>
         <div id="challengeBoard" class="board" data-i18n-attr="aria-label:challenge.boardLabel"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -953,7 +953,13 @@ body.high-contrast .key.absent {
     padding: 0.75rem 1.25rem;
   }
 
-  .ghost {
+  .ghost,
+  .btn-primary,
+  .btn-danger {
+    /* Mobile touch-target floor (WCAG 2.5.5 + this app's
+       --touch-target-min). All three semantic button classes share
+       the same mobile padding/min-height so swapping `.ghost` for
+       `.btn-danger` / `.btn-primary` doesn't shrink the hit area. */
     min-height: 44px;
     padding: 0.75rem 1.1rem;
   }
@@ -1253,7 +1259,13 @@ body.high-contrast .key.absent {
     padding: 0.75rem 1.25rem;
   }
 
-  .ghost {
+  .ghost,
+  .btn-primary,
+  .btn-danger {
+    /* Mobile touch-target floor (WCAG 2.5.5 + this app's
+       --touch-target-min). All three semantic button classes share
+       the same mobile padding/min-height so swapping `.ghost` for
+       `.btn-danger` / `.btn-primary` doesn't shrink the hit area. */
     min-height: 44px;
     padding: 0.75rem 1.1rem;
   }

--- a/public/styles.css
+++ b/public/styles.css
@@ -33,7 +33,10 @@
   --modal-border: rgba(148, 163, 184, 0.2);
   --modal-shadow: rgba(2, 6, 23, 0.6);
   --danger: #ef4444;
-  --text-on-danger: #ffffff;
+  /* Dark slate on the red-500 fill so the .btn-danger:hover label
+     hits 5.5:1 contrast (WCAG AA: 4.5:1). White-on-red-500 only
+     lands at ~3.8:1 — caught by CodeRabbit + Codex review on PR #168. */
+  --text-on-danger: #0f172a;
   --focus-outline: var(--accent);
   --touch-target-min: 44.25px;
 
@@ -118,10 +121,19 @@ body.high-contrast {
   --absent: #475569;
   --present: #f97316;
   --correct: #22d3ee;
-  /* High-contrast danger: bright red distinct from --present (orange)
-     and --absent (slate). Keeps AA contrast on the dark hi-contrast bg. */
+  /* High-contrast + dark theme: bright red distinct from --present
+     (orange) and --absent (slate), readable on the dark hi-contrast bg. */
   --danger: #ff5d5d;
   --text-on-danger: #0f172a;
+}
+
+html.theme-light body.high-contrast {
+  /* High-contrast + light theme: the page bg stays light, so the
+     bright red #ff5d5d would only hit ~2.9:1 against white. Re-use the
+     darker red-700 from light theme (.b91c1c on white = 6.4:1).
+     Codex P2 review on PR #168. */
+  --danger: #b91c1c;
+  --text-on-danger: #ffffff;
 }
 
 * {

--- a/public/styles.css
+++ b/public/styles.css
@@ -130,7 +130,7 @@ body.high-contrast {
 html.theme-light body.high-contrast {
   /* High-contrast + light theme: the page bg stays light, so the
      bright red #ff5d5d would only hit ~2.9:1 against white. Re-use the
-     darker red-700 from light theme (.b91c1c on white = 6.4:1).
+     darker red-700 from light theme (#b91c1c on white = 6.4:1).
      Codex P2 review on PR #168. */
   --danger: #b91c1c;
   --text-on-danger: #ffffff;
@@ -363,9 +363,14 @@ p {
    the same visual weight for very different consequence levels.
    Split into three explicit roles below; `.ghost` is kept for true
    secondary actions only. */
+/* `:not(.ghost)` because `.create-form button` (specificity 0,1,1)
+   beats plain `.ghost` (0,1,0) — without the negation, `#randomBtn`
+   (the secondary "Random word" button inside the create form, which
+   carries `class="ghost"`) would render with the primary fill. Codex
+   P2 review on PR #168. */
 .btn-primary,
-.create-form button,
-.admin-form button {
+.create-form button:not(.ghost),
+.admin-form button:not(.ghost) {
   padding: 0.75rem 1rem;
   border: none;
   border-radius: 0.6rem;

--- a/public/styles.css
+++ b/public/styles.css
@@ -32,6 +32,8 @@
   --modal-bg: rgba(15, 23, 42, 0.9);
   --modal-border: rgba(148, 163, 184, 0.2);
   --modal-shadow: rgba(2, 6, 23, 0.6);
+  --danger: #ef4444;
+  --text-on-danger: #ffffff;
   --focus-outline: var(--accent);
   --touch-target-min: 44.25px;
 
@@ -99,6 +101,9 @@ html.theme-light {
   --modal-bg: rgba(255, 255, 255, 0.98);
   --modal-border: rgba(15, 23, 42, 0.16);
   --modal-shadow: rgba(15, 23, 42, 0.18);
+  /* Light theme needs a darker red for AA contrast on a light bg. */
+  --danger: #b91c1c;
+  --text-on-danger: #ffffff;
   --focus-outline: var(--accent);
   color-scheme: light;
 }
@@ -113,6 +118,10 @@ body.high-contrast {
   --absent: #475569;
   --present: #f97316;
   --correct: #22d3ee;
+  /* High-contrast danger: bright red distinct from --present (orange)
+     and --absent (slate). Keeps AA contrast on the dark hi-contrast bg. */
+  --danger: #ff5d5d;
+  --text-on-danger: #0f172a;
 }
 
 * {
@@ -338,6 +347,50 @@ p {
   gap: var(--space-lg);
   align-items: flex-end;
   flex-wrap: wrap;
+}
+
+/* Semantic button classes (issue #164). `.ghost` was previously
+   applied to primary actions (Use this name), destructive actions
+   (Quit), and secondary actions (Copy link, Random word, etc.) —
+   the same visual weight for very different consequence levels.
+   Split into three explicit roles below; `.ghost` is kept for true
+   secondary actions only. */
+.btn-primary {
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 0.6rem;
+  background: var(--accent);
+  color: var(--text-on-accent);
+  font-weight: 700;
+  cursor: pointer;
+  /* Match `.ghost`'s layout primitives so primary and secondary
+     buttons line up cleanly when placed side-by-side in a form-row. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+}
+
+.btn-danger {
+  padding: 0.6rem 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--danger);
+  background: transparent;
+  color: var(--danger);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+}
+
+.btn-danger:hover {
+  /* Outline → filled on hover. Common destructive-action pattern:
+     the visual weight ramps up when the user is about to commit. */
+  background: var(--danger);
+  color: var(--text-on-danger);
 }
 
 .ghost {

--- a/public/styles.css
+++ b/public/styles.css
@@ -332,15 +332,11 @@ p {
   width: 7rem;
 }
 
-.create-form button {
-  padding: 0.75rem 1rem;
-  border: none;
-  border-radius: 0.6rem;
-  background: var(--accent);
-  color: var(--text-on-accent);
-  font-weight: 700;
-  cursor: pointer;
-}
+/* .create-form button + .admin-form button styling now grouped with
+   .btn-primary below — single source of truth for the primary button
+   look. Position kept BEFORE .ghost so #randomBtn (which has both
+   `.create-form > button` matching AND class="ghost") still gets
+   .ghost's overrides via source-order cascade. */
 
 .form-row {
   display: flex;
@@ -355,7 +351,9 @@ p {
    the same visual weight for very different consequence levels.
    Split into three explicit roles below; `.ghost` is kept for true
    secondary actions only. */
-.btn-primary {
+.btn-primary,
+.create-form button,
+.admin-form button {
   padding: 0.75rem 1rem;
   border: none;
   border-radius: 0.6rem;
@@ -887,15 +885,7 @@ body.high-contrast .key.absent {
   font-size: var(--fs-md);
 }
 
-.admin-form button {
-  padding: 0.75rem 1rem;
-  border: none;
-  border-radius: 0.6rem;
-  background: var(--accent);
-  color: var(--text-on-accent);
-  font-weight: 700;
-  cursor: pointer;
-}
+/* .admin-form button styling now grouped with .btn-primary above. */
 
 .admin-current {
   max-width: 28rem;


### PR DESCRIPTION
Closes #164.

## Summary

CSS + HTML — no JS logic touched. Splits the overloaded `.ghost` class into three semantic button classes, each with a distinct visual role.

## Problem

`.ghost` was being applied to **six buttons across three different semantic roles**:

| Button | Where | Real role |
|---|---|---|
| Random word | create form | secondary |
| **Use this name** | profile form submit | **primary** |
| **Quit** | challenge play | **destructive** |
| Copy link | share row | secondary |
| View leaderboard | challenge summary | secondary |
| Close | share modal | secondary |

Same visual weight for the user's primary commit and the destructive abandon-challenge action — no way to tell which is dangerous.

## Fix

Three semantic classes:

- **`.btn-primary`** — accent fill, white text, weight 700. Grouped with the existing `.create-form button` + `.admin-form button` rules (which were near-duplicates) so the primary look has a single source of truth. Applied to `Use this name`.
- **`.btn-danger`** — red outline + red text, fills red on hover. The outline→filled hover is a common destructive-action signal: visual weight ramps up when the user is about to commit a non-reversible action. Applied to `Quit`.
- **`.ghost`** — unchanged. Kept for the four genuine secondary actions.

## Color tokens (theme-scoped, AA-contrast verified)

| Theme | `--danger` | `--text-on-danger` | Pair contrast |
|---|---|---|---|
| Dark (`:root`) | `#ef4444` | `#0f172a` | 5.5:1 ✓ |
| Light (`html.theme-light`) | `#b91c1c` | `#ffffff` | 6.4:1 ✓ |
| Hi-contrast + dark (`body.high-contrast`) | `#ff5d5d` | `#0f172a` | 5.4:1 ✓ |
| Hi-contrast + light (`html.theme-light body.high-contrast`) | `#b91c1c` | `#ffffff` | 6.4:1 ✓ |

The dark-theme `--text-on-danger` was originally `#ffffff` (3.8:1, fails AA) — flagged by CodeRabbit Major + Codex P2 and corrected to `#0f172a`. The hi-contrast + light theme combination was originally not scoped (the bright red `#ff5d5d` landed at 2.9:1 on the light page bg) — flagged by Codex P2 and corrected with an explicit `html.theme-light body.high-contrast` override.

## Mobile touch-target floor

The two existing `@media` blocks that pinned `.ghost { min-height: 44px }` were extended to apply to `.btn-primary, .btn-danger` as well — flagged by Codex P2 when the `.ghost → .btn-danger` reclass on Quit initially dropped the button below the WCAG 2.5.5 floor on narrow viewports. After the fix, `tests/ui/mobile.spec.js`'s touch-target tests pass across iphone-13, pixel-7, max-375, max-360, max-320, landscape.

## HTML changes

```diff
- <button type="submit" class="ghost" data-i18n="play.useThisName">Use this name</button>
+ <button type="submit" class="btn-primary" data-i18n="play.useThisName">Use this name</button>

- <button type="button" id="challengeQuitBtn" class="ghost" data-i18n="challenge.quit">Quit</button>
+ <button type="button" id="challengeQuitBtn" class="btn-danger" data-i18n="challenge.quit">Quit</button>
```

Only two buttons reclassed — the four remaining `.ghost` users (Random word / Copy link / View leaderboard / Close) are genuine secondary actions, which is what `.ghost` was always meant to be.

## Verification

- `npm run schema:check` ✓
- `npm run markdown:check` ✓
- `scripts/i18n-coverage.js` ✓
- `npx playwright test` — full UI suite **78/78** pass, including `tests/ui/mobile.spec.js` touch-target tests across all viewports.

## Known pre-existing CI failure (NOT this PR)

The `test` CI job currently fails on `tests/analytics-endpoint.integration.test.js:93` with `gamesInWindow: 0 vs 2`. The test hardcodes a result date of `2026-05-06` and asserts it falls inside a "7d" rolling window from `Date.now()`. Today is `2026-05-13` — exactly at the boundary, so the assertion now reads 0 instead of 2. **Confirmed pre-existing by `git stash && npx jest tests/analytics-endpoint.integration.test.js` against bare main: same failure.** Filed as #169.

This PR's diff is pure CSS + HTML class swaps and cannot affect the analytics endpoint. Recommend either:
1. Merge anyway (the test failure is documented in #169).
2. Wait until #169 lands a date-pinning fix.

## Doesn't touch

- `public/app.js` — no JS changes.
- Button copy / labels — covered by merged #166.
- Anything outside `public/styles.css` + `public/index.html`.

https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added new danger color tokens and accessible text-on-danger for destructive actions.
  * Introduced primary and danger button styles; updated the player profile "Use this name" and challenge header "Quit" buttons to use them.
  * Clarified ghost as secondary-only; grouped form buttons under primary styling.
  * Improved mobile touch-target sizing for ghost, primary, and danger buttons.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/168)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->