### PR TITLE
ui: unify play + challenge keyboard render (partial #163)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -787,9 +787,51 @@ function buildBoard() {
   }
 }
 
-function buildKeyboard() {
-  keyboardEl.innerHTML = "";
-  keyboardKeyEls = new Map();
+// Shared keyboard build helpers (issue #163, partial). Both the
+// play (#keyboard) and the challenge (#challengeKeyboard) on-screen
+// keyboards used to have parallel build code with copy-pasted
+// BACK/ENTER accessibility logic and a duplicate row-iteration loop.
+// `makeKeyButton` + `renderKeyboardInto` are the single source of
+// truth so future a11y/layout fixes only need to be applied once.
+function makeKeyButton(key, opts = {}) {
+  const { onClick } = opts;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "key";
+  button.dataset.key = key;
+  if (key === "ENTER" || key === "BACK") {
+    button.classList.add("wide");
+  }
+  if (key === "BACK") {
+    // Wrap the ⌫ glyph in aria-hidden so the only accessible name is
+    // the explicit aria-label. Some auditors flag a button whose
+    // visible text is purely an unnamed Unicode glyph even when
+    // aria-label is set (Chrome's Lighthouse button-name has been
+    // strict about this in the past).
+    const glyph = document.createElement("span");
+    glyph.setAttribute("aria-hidden", "true");
+    glyph.textContent = "⌫";
+    button.appendChild(glyph);
+    button.setAttribute("aria-label", "Backspace");
+  } else if (key === "ENTER") {
+    button.textContent = "ENTER";
+    // "Submit guess" is more meaningful to assistive tech than the
+    // raw "ENTER" label.
+    button.setAttribute("aria-label", "Submit guess");
+  } else {
+    button.textContent = key;
+    button.setAttribute("aria-label", key);
+  }
+  if (onClick) {
+    button.addEventListener("click", () => onClick(key));
+  }
+  return button;
+}
+
+function renderKeyboardInto(rootEl, opts = {}) {
+  const { onKey, captureRefMap } = opts;
+  rootEl.innerHTML = "";
+  if (captureRefMap) captureRefMap.clear();
   KEYBOARD_LAYOUT.forEach((rowKeys, rowIndex) => {
     const rowEl = document.createElement("div");
     rowEl.className = "key-row";
@@ -797,40 +839,20 @@ function buildKeyboard() {
       rowEl.classList.add("offset");
     }
     rowKeys.forEach((key) => {
-      const button = document.createElement("button");
-      button.type = "button";
-      button.className = "key";
-      button.dataset.key = key;
-      if (key === "ENTER" || key === "BACK") {
-        button.classList.add("wide");
-      }
-      if (key === "BACK") {
-        // Wrap the ⌫ glyph in aria-hidden so the only accessible name
-        // is the explicit aria-label. Some auditors flag a button whose
-        // visible text is purely an unnamed Unicode glyph even when
-        // aria-label is set (Chrome's Lighthouse button-name has been
-        // strict about this in the past).
-        const glyph = document.createElement("span");
-        glyph.setAttribute("aria-hidden", "true");
-        glyph.textContent = "⌫";
-        button.appendChild(glyph);
-        button.setAttribute("aria-label", "Backspace");
-      } else if (key === "ENTER") {
-        button.textContent = key;
-        // "Submit guess" is more meaningful to assistive tech than the
-        // raw key name; matches what the challenge keyboard uses.
-        button.setAttribute("aria-label", "Submit guess");
-      } else {
-        button.textContent = key;
-        button.setAttribute("aria-label", key);
-      }
-      button.addEventListener("click", () => handleKey(key));
+      const button = makeKeyButton(key, { onClick: onKey });
       rowEl.appendChild(button);
-      if (key.length === 1) {
-        keyboardKeyEls.set(key, button);
+      if (captureRefMap && key.length === 1) {
+        captureRefMap.set(key, button);
       }
     });
-    keyboardEl.appendChild(rowEl);
+    rootEl.appendChild(rowEl);
+  });
+}
+
+function buildKeyboard() {
+  renderKeyboardInto(keyboardEl, {
+    onKey: handleKey,
+    captureRefMap: keyboardKeyEls
   });
 }
 
@@ -2377,52 +2399,7 @@ function renderChallengeBoard() {
 
 function renderChallengeKeyboard() {
   if (!challengeKeyboardEl) return;
-  challengeKeyboardEl.innerHTML = '';
-  const rows = ['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM'];
-  for (let r = 0; r < rows.length; r++) {
-    const rowEl = document.createElement('div');
-    // Match the daily/created keyboard's class names (.key-row / .key /
-    // .key.wide). The earlier kb-row/kb-key naming had no styles in
-    // public/styles.css, so the challenge keyboard rendered as
-    // unstyled buttons stacked vertically.
-    rowEl.className = 'key-row';
-    if (r === rows.length - 1) {
-      rowEl.appendChild(makeKbKey('Enter', 'Enter', 'wide'));
-    }
-    for (const ch of rows[r]) rowEl.appendChild(makeKbKey(ch, ch));
-    if (r === rows.length - 1) {
-      rowEl.appendChild(makeKbKey('⌫', 'Backspace', 'wide'));
-    }
-    challengeKeyboardEl.appendChild(rowEl);
-  }
-}
-
-function makeKbKey(label, key, extraClass) {
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.className = 'key' + (extraClass ? ` ${extraClass}` : '');
-  // Special keys render glyphs/labels that don't read well to screen
-  // readers — "⌫" is a private-use character with no semantic name in
-  // most assistive-tech voices, and "Enter" without context can be
-  // ambiguous. Provide an explicit accessible name for the special
-  // keys; alphabet keys already announce their letter via textContent.
-  if (key === 'Backspace') {
-    // Same Backspace pattern as buildKeyboard: hide the glyph from AT
-    // so the only accessible name is the aria-label.
-    const glyph = document.createElement('span');
-    glyph.setAttribute('aria-hidden', 'true');
-    glyph.textContent = label;
-    btn.appendChild(glyph);
-    btn.setAttribute('aria-label', 'Backspace');
-  } else if (key === 'Enter') {
-    btn.textContent = label;
-    btn.setAttribute('aria-label', 'Submit guess');
-  } else {
-    btn.textContent = label;
-    btn.setAttribute('aria-label', label);
-  }
-  btn.addEventListener('click', () => onChallengeKey(key));
-  return btn;
+  renderKeyboardInto(challengeKeyboardEl, { onKey: onChallengeKey });
 }
 
 function onChallengeKey(key) {
@@ -2430,7 +2407,7 @@ function onChallengeKey(key) {
   const active = activePuzzle();
   if (!active) return;
   const length = active.length || (challengeState.activeChallenge?.wordLength || 5);
-  if (key === 'Enter') {
+  if (key === 'ENTER') {
     if (challengeState.pendingGuess.length !== length) {
       setChallengePlayStatus(
         window.i18n ? window.i18n.t("play.guessTooShort", { length }) : `Guess must be ${length} letters.`,
@@ -2441,7 +2418,7 @@ function onChallengeKey(key) {
     submitChallengeGuess();
     return;
   }
-  if (key === 'Backspace') {
+  if (key === 'BACK') {
     challengeState.pendingGuess = challengeState.pendingGuess.slice(0, -1);
     renderChallengeBoard();
     return;
@@ -2458,10 +2435,10 @@ document.addEventListener('keydown', (event) => {
   const k = event.key;
   if (k === 'Enter') {
     event.preventDefault();
-    onChallengeKey('Enter');
+    onChallengeKey('ENTER');
   } else if (k === 'Backspace') {
     event.preventDefault();
-    onChallengeKey('Backspace');
+    onChallengeKey('BACK');
   } else if (/^[a-zA-Z]$/.test(k)) {
     event.preventDefault();
     onChallengeKey(k.toUpperCase());


### PR DESCRIPTION
Partially addresses #163. **Keyboard render dedupe only** — board / profile / leaderboard / HTML scaffold are deferred to follow-up PRs (each has legitimate behavioral differences that warrant standalone review; see "Out of scope" below).

## What was duplicated

| | Play | Challenge |
|---|---|---|
| Function | `buildKeyboard()` | `renderChallengeKeyboard()` + `makeKbKey()` |
| Layout source | `KEYBOARD_LAYOUT` const | inline `['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM']` literal + ENTER/BACK appended in render code |
| Special-key aria | copy-pasted block (BACK `<span aria-hidden>⌫</span>` + aria-label "Backspace"; ENTER aria-label "Submit guess") | copy-pasted same logic |
| Handler | `handleKey(key)` | `onChallengeKey(key)` |

Every keyboard-a11y fix this campaign shipped — wide-key sizing, BACK glyph aria-hidden wrap, ENTER aria-label "Submit guess" — had to be reasoned about across both paths, with the obvious risk of drift.

## What changed

Two shared helpers near `buildBoard()`:

**`makeKeyButton(key, { onClick })`** — single source of truth for per-key DOM:
- `.wide` class for ENTER/BACK
- BACK: `<span aria-hidden="true">⌫</span>` + `aria-label="Backspace"`
- ENTER: textContent `"ENTER"` + `aria-label="Submit guess"`
- Letters: textContent = key + `aria-label` = key
- `data-key="..."` on every button
- Optional click handler attaches when `onClick` is provided

**`renderKeyboardInto(rootEl, { onKey, captureRefMap })`** — iterates `KEYBOARD_LAYOUT`, builds each row, applies `.offset` to row 1, calls `makeKeyButton`. Optional `captureRefMap` (a `Map`) gets populated with single-letter keys → button refs.

**Callers collapsed:**
- `buildKeyboard()` — was ~45 lines, now one `renderKeyboardInto()` call
- `renderChallengeKeyboard()` — was ~20 lines + `makeKbKey` ~25 lines, now one `renderKeyboardInto()` call
- `makeKbKey` — deleted entirely

**Key-name unification:** `onChallengeKey` previously branched on `'Enter'/'Backspace'/letter`. To use the shared helper which speaks `KEYBOARD_LAYOUT`'s vocabulary, it now branches on `'ENTER'/'BACK'/letter`. The single keydown handler was updated in the same commit so `event.key === 'Enter'` → `onChallengeKey('ENTER')` and `'Backspace'` → `'BACK'`.

## User-visible changes to the challenge keyboard (intentional alignment)

The unification means the challenge keyboard now matches the play keyboard exactly. Diffs in the challenge panel's rendered DOM:

| Surface | Before | After | Rationale |
|---|---|---|---|
| ENTER button text | `"Enter"` | `"ENTER"` | matches play keyboard (which has always used all-caps) |
| Row 2 (`ASDFGHJKL`) | no class | `.offset` | matches play keyboard's visual layout (the classic Wordle row-2 indent) |
| All button `data-key` | absent | `data-key="<key>"` | matches play keyboard; useful for tests + future event-delegation |

These aren't regressions — they're the **point** of issue #163: one source of truth for the keyboard. Pre-refactor, the challenge keyboard was inconsistent with the play keyboard in these three details. The shared helper picks the play keyboard's conventions because the play keyboard has more test/visual-QA history and there's no UX reason for the challenge keyboard to diverge.

Earlier PR description said "byte-identical DOM" — that was overstated for the challenge side; corrected here.

## Out of scope (deferred to follow-up PRs)

Issue #163's full acceptance also asks for collapsing:
- **Board render** (`buildBoard` / `renderChallengeBoard`) — different state strategies (init+patch with tile refs vs stateful re-render from server feedback). Higher-risk merge.
- **Profile name input** (`#profileNameInput` / `#challengeProfileInput`) — different state stores + different `maxlength` constraints.
- **Leaderboard tables** — different column sets (play has 7 cols; challenge has 5).
- **HTML `<header class="play-head">`** scaffold — small change but separable.

Each warrants its own focused review. Issue #163 stays open after merge for the remaining work.

## Verification

- `npm run schema:check` ✓
- `npm run markdown:check` ✓
- `scripts/i18n-coverage.js` ✓ — 143 references, 177 keys at parity
- `npx playwright test tests/ui/{keyboard-wide-key,create-play,share-modal-inert-fallback}.spec.js` → **21/21**

The `keyboard-wide-key.spec.js` suite covers ENTER button sizing across desktop / tablet / mobile — same fixture as before, now exercising the new `renderKeyboardInto` path on the play keyboard. The challenge keyboard render goes through the same helper; visual parity with the play keyboard is the structural assertion.

## Diff

`+61 / -84` (net **-23 lines**) in one file (`public/app.js`).

## Doesn't touch

`public/index.html`, `public/styles.css`, `public/locales/*` — JS only. The play keyboard's DOM is unchanged; the challenge keyboard's DOM aligns to match.

https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored on-screen keyboard rendering to use shared helper functions, improving code maintainability.
  * Aligned keyboard behavior between physical keyboard and on-screen challenge keyboard for consistent user interaction.
  * Enhanced accessibility features for special keyboard keys (Backspace, Enter).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/171)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->