### PR TITLE
test(analytics): pin Date.now() to a known fixture moment (closes #169)

### DIFF
--- a/tests/analytics-endpoint.integration.test.js
+++ b/tests/analytics-endpoint.integration.test.js
@@ -7,6 +7,42 @@ const request = require("supertest");
 
 const ORIGINAL_ENV = { ...process.env };
 
+// Pin Date.now() / new Date() to a fixed moment INSIDE the fixtures'
+// rolling-window range. Without this, the seeded result dates
+// (`2026-05-06` etc.) fall outside `Date.now() - 7d` once the wall
+// clock rolls forward, and assertions like `gamesInWindow: 2` flip
+// to `0`. Fixes #169. Only `Date` is faked — every other timer
+// surface (setTimeout, setImmediate, hrtime, performance, …) stays
+// real so supertest's HTTP plumbing + the perf test's
+// `process.hrtime.bigint()` measurements keep working.
+const PINNED_NOW = new Date("2026-05-08T12:00:00.000Z");
+
+beforeAll(() => {
+  jest.useFakeTimers({
+    doNotFake: [
+      "setTimeout",
+      "clearTimeout",
+      "setInterval",
+      "clearInterval",
+      "setImmediate",
+      "clearImmediate",
+      "queueMicrotask",
+      "requestAnimationFrame",
+      "cancelAnimationFrame",
+      "requestIdleCallback",
+      "cancelIdleCallback",
+      "hrtime",
+      "performance",
+      "nextTick"
+    ],
+    now: PINNED_NOW
+  });
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
 function resetEnv() {
   Object.keys(process.env).forEach((key) => {
     if (!(key in ORIGINAL_ENV)) {
@@ -275,6 +311,14 @@ describe("GET /api/admin/analytics", () => {
     await request(app).get("/api/admin/analytics?window=30d");
     const samples = [];
     for (let i = 0; i < 50; i += 1) {
+      // Advance the (faked) `Date.now()` past the 1ms cache TTL so the
+      // next request misses. Without this, the suite-level pinned
+      // clock would never advance and the cache would stay HIT for
+      // every iteration (originally, the cache expired naturally
+      // because each supertest call took >1ms of wall clock; the
+      // time-pinning fix for #169 froze that). 100ms keeps a generous
+      // margin over the 1ms TTL.
+      jest.setSystemTime(new Date(Date.now() + 100));
       const start = process.hrtime.bigint();
       const res = await request(app).get("/api/admin/analytics?window=30d");
       const elapsedMs = Number(process.hrtime.bigint() - start) / 1_000_000;


### PR DESCRIPTION
Closes #169.

## Problem

`tests/analytics-endpoint.integration.test.js` seeds leaderboard entries dated `2026-05-06` and asserts they fall inside `Date.now() - 7d`. Once the wall clock rolled past `2026-05-13`, those entries dropped out of the window and `gamesInWindow: 2` flipped to `0`. **Every PR in this campaign (PR #168, #170, #171) tripped on this in CI** — the failure was reproduced on bare `main` with the diff stashed, confirming it was pre-existing.

## Fix

**Pin `Date.now()` and `new Date()` to `2026-05-08T12:00:00.000Z`** (two days after the seeded result date, well inside both the 7-day and 30-day rolling windows used across the suite).

```js
beforeAll(() => {
  jest.useFakeTimers({
    doNotFake: [
      "setTimeout", "clearTimeout",
      "setInterval", "clearInterval",
      "setImmediate", "clearImmediate",
      "queueMicrotask",
      "requestAnimationFrame", "cancelAnimationFrame",
      "requestIdleCallback", "cancelIdleCallback",
      "hrtime", "performance", "nextTick"
    ],
    now: new Date("2026-05-08T12:00:00.000Z")
  });
});
afterAll(() => { jest.useRealTimers(); });
```

**Only `Date` is faked.** Every other timer surface stays real:
- supertest's HTTP plumbing (setImmediate + nextTick) keeps working
- the p99 perf test's `process.hrtime.bigint()` measurements stay on the real wall clock, so latency numbers are honest

## Perf-test compatibility fix

`p99 latency < 100ms` uses `cacheTtlMs: 1` so that each sequential supertest call's wall-clock delay (always >1ms) expires the cache between requests, forcing every measured request to be a `MISS` — that way the test measures aggregation latency, not cache-hit latency.

With `Date.now()` frozen, the cache's expiry check `now > entry.expires` is always false and every request would HIT.

**Fix inside the loop:** `jest.setSystemTime(new Date(Date.now() + 100))` between iterations to advance the faked clock past the 1ms TTL. The `MISS` invariant holds; the `process.hrtime.bigint()` measurements (unfaked) still give real latency samples.

## Verification

- `npx jest tests/analytics-endpoint.integration.test.js` → **9/9** ✓
- `npx jest` (full suite) → **66 suites / 1111 tests / 1 skipped / 0 failed** ✓

**First time in this session the full Jest suite is green.**

## Diff

`+44 / -0` in one file (`tests/analytics-endpoint.integration.test.js`).

## Doesn't touch

- Production code — test-only change.
- Anything in `public/`, `lib/`, `server.js`, `routes/`.
- Other test files — date drift may exist elsewhere too (issue #169 flagged this as an optional sweep, deferred).

https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated analytics endpoint integration tests to use fixed timestamps for deterministic test execution. Modified latency measurement tests to explicitly advance time between requests, ensuring cache behavior is consistently measured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/172)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->