### PR TITLE
html: use `<header>` consistently for both play-head blocks (closes #173)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -127,7 +127,7 @@
       </section>
 
       <section id="playPanel" class="panel hidden">
-        <div class="play-head">
+        <header class="play-head">
           <div>
             <h2 data-i18n="play.heading">Play</h2>
             <!-- #playMeta is runtime-owned: initPlay() builds `baseMeta`
@@ -139,7 +139,7 @@
             <p id="playMeta">Loading puzzle…</p>
           </div>
           <a class="admin-link" href="/" data-i18n="play.createYours">Create yours</a>
-        </div>
+        </header>
         <section id="profilePanel" class="profile-panel hidden" aria-live="polite">
           <div class="profile-head">
             <h3 data-i18n="play.familyPlayerHeading">Player</h3>


### PR DESCRIPTION
Closes #173.

## Summary

Tiny semantic fix. Both `.play-head` blocks now use `<header>` consistently.

```diff
- <div    class="play-head"> ... </div>
+ <header class="play-head"> ... </header>
```

The challenge panel already used `<header>`; the play panel didn't. `<header>` is the correct HTML5 semantic element for a panel-heading section. Same `.play-head` CSS applies to both either way.

## Why this is the whole PR (option 1 from #173's two-option spec)

The two blocks' right-side content legitimately differs:

| | Right-side content |
|---|---|
| Play | single `<a class="admin-link">` "Create yours" CTA |
| Challenge | timer + score + Quit button HUD |

Manufacturing parity by wrapping the play side's single anchor in a `<div class="play-head-actions">` (or similar) would be artificial — `.play-meta-right` (the challenge side's wrapper class) has **zero CSS rules attached**, confirming the wrapper is purely structural for the multi-element case.

#173 explicitly offered this as the choice between options. Shipping option 1 (the small honest fix); option 2 (slot-style cleanup) isn't worth the noise.

## Verification

- `npm run schema:check` ✓
- `npm run markdown:check` ✓
- `scripts/i18n-coverage.js` ✓
- Playwright `tests/ui/{create-play, keyboard-wide-key}.spec.js` → **19/19**

## Diff

**+1 / -1** in `public/index.html` only.

## Doesn't touch

- CSS — same `.play-head` rules apply.
- JS — no selectors target `div.play-head` or `header.play-head` specifically.
- Other panels — only the play panel is touched; challenge was already correct.

https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restructured internal HTML markup in the play panel header for improved semantic structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/177)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->