### PR TITLE
ui: extract renderLeaderboardTable shared partial (closes #175)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -571,13 +571,14 @@ function setProfileStatus(text) {
 
 // Shared leaderboard-table partial (issue #175). Both the play
 // (daily) leaderboard and the challenge leaderboard render the same
-// `<table>.<tbody>` shape with different column sets — 7 cols for
-// play (rank/name/wins/played/win%/best/streak) and 5 cols for
-// challenge (rank/name/score/solved/time). The shared helper builds
-// rows from a `cols` config so the row-construction code lives in
-// one place; each caller passes its own column accessors + empty-
-// state copy. Caller is responsible for showing/hiding the panel
-// chrome around the table.
+// <tbody> shape (one <tr> per row, one <td> per column) with
+// different column sets — 7 cols for play (rank/name/wins/played/
+// win%/best/streak) and 5 cols for challenge (rank/name/score/
+// solved/time). The shared helper builds rows from a `cols` config
+// so the row-construction code lives in one place; each caller
+// passes its own column accessors + empty-state copy. Caller is
+// responsible for the surrounding <table><thead> chrome and for
+// showing/hiding the panel around it.
 function renderLeaderboardTable(tbodyEl, options) {
   const { rows, cols, emptyText, emptyClass } = options;
   tbodyEl.innerHTML = "";

--- a/public/app.js
+++ b/public/app.js
@@ -2647,12 +2647,17 @@ async function showChallengeLeaderboard(challengeId) {
     renderLeaderboardTable(challengeLeaderboardTbodyEl, {
       rows,
       emptyText: window.i18n ? window.i18n.t("challenge.noCompleted") : 'No completed sessions yet.',
+      // Defensive fallbacks match the play leaderboard's style — `||` for
+      // strings (covers null/undefined/empty), `??` for numerics (covers
+      // null/undefined but lets a legitimate 0 through). Without these,
+      // malformed server payloads surface as literal "undefined" / "null" /
+      // "NaN" in the leaderboard cells. Caught by CodeRabbit on PR #178.
       cols: [
         { value: (_, i) => `#${i + 1}` },
-        { value: (row) => row.profileName || row.profileId },
-        { value: (row) => String(row.score) },
-        { value: (row) => `${row.solvedCount}/${row.totalPuzzles}` },
-        { value: (row) => `${row.elapsedSeconds}s` }
+        { value: (row) => row.profileName || row.profileId || "-" },
+        { value: (row) => String(row.score ?? 0) },
+        { value: (row) => `${row.solvedCount ?? 0}/${row.totalPuzzles ?? 0}` },
+        { value: (row) => `${row.elapsedSeconds ?? 0}s` }
       ]
     });
   } catch (err) {

--- a/public/app.js
+++ b/public/app.js
@@ -569,6 +569,41 @@ function setProfileStatus(text) {
   profileStatusEl.textContent = text;
 }
 
+// Shared leaderboard-table partial (issue #175). Both the play
+// (daily) leaderboard and the challenge leaderboard render the same
+// `<table>.<tbody>` shape with different column sets — 7 cols for
+// play (rank/name/wins/played/win%/best/streak) and 5 cols for
+// challenge (rank/name/score/solved/time). The shared helper builds
+// rows from a `cols` config so the row-construction code lives in
+// one place; each caller passes its own column accessors + empty-
+// state copy. Caller is responsible for showing/hiding the panel
+// chrome around the table.
+function renderLeaderboardTable(tbodyEl, options) {
+  const { rows, cols, emptyText, emptyClass } = options;
+  tbodyEl.innerHTML = "";
+  if (!rows.length) {
+    const tr = document.createElement("tr");
+    const td = document.createElement("td");
+    if (emptyClass) td.className = emptyClass;
+    td.colSpan = cols.length;
+    td.textContent = emptyText;
+    tr.appendChild(td);
+    tbodyEl.appendChild(tr);
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  rows.forEach((row, index) => {
+    const tr = document.createElement("tr");
+    cols.forEach((col) => {
+      const cell = document.createElement("td");
+      cell.textContent = String(col.value(row, index));
+      tr.appendChild(cell);
+    });
+    fragment.appendChild(tr);
+  });
+  tbodyEl.appendChild(fragment);
+}
+
 function renderLeaderboard() {
   if (!leaderboardPanelEl || !leaderboardBodyEl || !leaderboardRangeEl || !leaderboardMetaEl) return;
   if (!dailyMode || statsServiceUnavailable) {
@@ -585,36 +620,20 @@ function renderLeaderboard() {
   const renderTimer = startPerfMeasure("ui.render.leaderboard");
   const rows = Array.isArray(leaderboardState.rows) ? leaderboardState.rows : [];
 
-  leaderboardBodyEl.innerHTML = "";
-  if (!rows.length) {
-    const row = document.createElement("tr");
-    row.innerHTML = '<td class="leaderboard-empty" colspan="7">No games in this period yet.</td>';
-    leaderboardBodyEl.appendChild(row);
-    endPerfMeasure(renderTimer, "rows=0");
-    return;
-  }
-
-  const fragment = document.createDocumentFragment();
-  rows.forEach((row, index) => {
-    const tr = document.createElement("tr");
-    const safeBest = row.bestAttempts ? String(row.bestAttempts) : "-";
-    const values = [
-      String(row.rank || index + 1),
-      String(row.name || "-"),
-      String(row.wins || 0),
-      String(row.played || 0),
-      `${Number.isFinite(row.winRate) ? row.winRate : 0}%`,
-      safeBest,
-      String(row.streak || 0)
-    ];
-    values.forEach((value) => {
-      const cell = document.createElement("td");
-      cell.textContent = value;
-      tr.appendChild(cell);
-    });
-    fragment.appendChild(tr);
+  renderLeaderboardTable(leaderboardBodyEl, {
+    rows,
+    emptyText: "No games in this period yet.",
+    emptyClass: "leaderboard-empty",
+    cols: [
+      { value: (row, i) => String(row.rank || i + 1) },
+      { value: (row) => String(row.name || "-") },
+      { value: (row) => String(row.wins || 0) },
+      { value: (row) => String(row.played || 0) },
+      { value: (row) => `${Number.isFinite(row.winRate) ? row.winRate : 0}%` },
+      { value: (row) => (row.bestAttempts ? String(row.bestAttempts) : "-") },
+      { value: (row) => String(row.streak || 0) }
+    ]
   });
-  leaderboardBodyEl.appendChild(fragment);
   endPerfMeasure(renderTimer, `rows=${rows.length}`);
 }
 
@@ -2623,26 +2642,18 @@ async function showChallengeLeaderboard(challengeId) {
         ? window.i18n.t("challenge.leaderboardHeader", { name: headerName, policy: headerPolicy })
         : `${headerName} · ${headerPolicy} replay`;
     }
-    if (!Array.isArray(json.rows) || json.rows.length === 0) {
-      const tr = document.createElement('tr');
-      const td = document.createElement('td');
-      td.colSpan = 5;
-      td.textContent = window.i18n ? window.i18n.t("challenge.noCompleted") : 'No completed sessions yet.';
-      tr.appendChild(td);
-      challengeLeaderboardTbodyEl.appendChild(tr);
-      return;
-    }
-    let rank = 1;
-    for (const row of json.rows) {
-      const tr = document.createElement('tr');
-      tr.appendChild(td(`#${rank}`));
-      tr.appendChild(td(row.profileName || row.profileId));
-      tr.appendChild(td(String(row.score)));
-      tr.appendChild(td(`${row.solvedCount}/${row.totalPuzzles}`));
-      tr.appendChild(td(`${row.elapsedSeconds}s`));
-      challengeLeaderboardTbodyEl.appendChild(tr);
-      rank += 1;
-    }
+    const rows = Array.isArray(json.rows) ? json.rows : [];
+    renderLeaderboardTable(challengeLeaderboardTbodyEl, {
+      rows,
+      emptyText: window.i18n ? window.i18n.t("challenge.noCompleted") : 'No completed sessions yet.',
+      cols: [
+        { value: (_, i) => `#${i + 1}` },
+        { value: (row) => row.profileName || row.profileId },
+        { value: (row) => String(row.score) },
+        { value: (row) => `${row.solvedCount}/${row.totalPuzzles}` },
+        { value: (row) => `${row.elapsedSeconds}s` }
+      ]
+    });
   } catch (err) {
     if (challengeLeaderboardNameEl) {
       challengeLeaderboardNameEl.textContent = window.i18n
@@ -2650,7 +2661,6 @@ async function showChallengeLeaderboard(challengeId) {
         : `Error: ${err.message}`;
     }
   }
-  function td(text) { const c = document.createElement('td'); c.textContent = text; return c; }
 }
 
 // Route the player to the challenge list when /challenges is in the URL,


### PR DESCRIPTION
Closes #175.

## Summary

Extract a shared `renderLeaderboardTable(tbodyEl, { rows, cols, emptyText, emptyClass })` partial. Both `renderLeaderboard` (play, 7 cols) and `showChallengeLeaderboard` (challenge, 5 cols) now delegate to it. Sub-issue of #163.

## What was duplicated

| Concern | Play | Challenge |
|---|---|---|
| Renderer | `renderLeaderboard` (`app.js:572`) | `showChallengeLeaderboard` (`app.js:2598`) |
| Columns | 7 (rank / name / wins / played / win% / best / streak) | 5 (rank / name / score / solved / time) |
| Empty state | colspan=7, hardcoded copy, `.leaderboard-empty` class | colspan=5, i18n `challenge.noCompleted`, no class |
| Row build | inline `forEach` + `createElement` per cell | inline `for-of` + local `td(text)` helper fn |

The structural code (clear tbody, empty-state, fragment + per-row build) was byte-identical except for the column accessors. Any future leaderboard a11y/style/sort fix had to be applied twice.

## What changed

```js
function renderLeaderboardTable(tbodyEl, { rows, cols, emptyText, emptyClass }) {
  // Clear tbody.
  // If rows empty: single <tr><td colspan={cols.length}>{emptyText}</td></tr>,
  // optional emptyClass for callers that style empty differently.
  // Else: documentFragment + per-row build, cols.forEach → <td>.
}
```

Each caller passes its own `cols`:

```js
// Play
renderLeaderboardTable(leaderboardBodyEl, {
  rows: leaderboardState.rows,
  emptyText: "No games in this period yet.",
  emptyClass: "leaderboard-empty",
  cols: [
    { value: (row, i) => String(row.rank || i + 1) },
    { value: (row) => String(row.name || "-") },
    // ... 5 more
  ]
});

// Challenge
renderLeaderboardTable(challengeLeaderboardTbodyEl, {
  rows: json.rows,
  emptyText: i18n.t("challenge.noCompleted"),
  cols: [
    { value: (_, i) => `#${i + 1}` },
    { value: (row) => row.profileName || row.profileId },
    // ... 3 more
  ]
});
```

The play caller still owns its panel chrome (range selector, header copy, perf measure). The challenge caller still owns the header-name update + error handling. Only `<tbody>` content goes through the partial.

## Out of scope

- Show/hide of panel chrome (both callers still own their panel-level state).
- Sorting / pagination — partial preserves current behavior (none of either).
- Column-config externalization (e.g. moving to i18n keys or a data layer).

## Verification

- `npm run schema:check` ✓
- `npm run markdown:check` ✓
- `scripts/i18n-coverage.js` ✓ — 143 references, 177 keys at parity
- Playwright `tests/ui/{create-play, stats-backend}.spec.js` → **21/21**
- Jest `tests/leaderboard-store.test.js` + `tests/stats-leaderboard.test.js` → **37/37**

## Diff

`+60 / -50` in one file (`public/app.js`). Net **+10 lines** (helper adds ~30 including comments; the two callers shrink by ~20). Single source of truth gained.

## Doesn't touch

- HTML — `<table>` structure unchanged.
- CSS — `.leaderboard-table`, `.leaderboard-empty` styles unchanged.
- Backend / data flow — pure render-side refactor.

https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined leaderboard rendering so daily, play, and challenge leaderboards behave consistently.
  * Improved empty-state and row rendering so leaderboards show correct columns, counts, and messages across views.
  * Preserved existing panel descriptions and performance displays while simplifying underlying rendering logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/178)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->