### PR TITLE
ui+server: unify profile name validator + random default name (closes #174)

### DIFF
--- a/data/challenge-results.schema.json
+++ b/data/challenge-results.schema.json
@@ -39,7 +39,12 @@
             "minLength": 1,
             "maxLength": 64
           },
-          "profileName": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "profileName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32,
+            "pattern": "^\\p{L}[\\p{L}\\p{M}' \\-]{0,31}$"
+          },
           "status": {
             "type": "string",
             "enum": ["pending", "in-progress", "completed", "timed-out", "abandoned"]

--- a/data/leaderboard.schema.json
+++ b/data/leaderboard.schema.json
@@ -30,7 +30,7 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 64,
+            "maxLength": 32,
             "pattern": "^\\p{L}[\\p{L}\\p{M}' \\-]{0,31}$"
           },
           "createdAt": {

--- a/data/leaderboard.schema.json
+++ b/data/leaderboard.schema.json
@@ -30,8 +30,8 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 24,
-            "pattern": "^[A-Za-z][A-Za-z '\\-]*$"
+            "maxLength": 64,
+            "pattern": "^\\p{L}[\\p{L}\\p{M}' \\-]{0,31}$"
           },
           "createdAt": {
             "type": "string",

--- a/lib/challenge-results-store.js
+++ b/lib/challenge-results-store.js
@@ -265,7 +265,21 @@ class ChallengeResultsStore {
       startedAt: typeof startedAt === "string" && startedAt ? startedAt : this.now().toISOString(),
       puzzles: puzzles.map(normalizePuzzle)
     };
-    if (typeof profileName === "string" && profileName) session.profileName = profileName;
+    // Validate profileName at the createSession boundary, not just in
+    // normalizeStore. Without this, a non-empty invalid name would
+    // round-trip out to the route handler (which would return it in
+    // the response) while the persisted state had it stripped during
+    // normalizeStore — caller's in-memory session and disk state
+    // would diverge. Reject up-front so both stay consistent.
+    if (typeof profileName === "string" && profileName) {
+      if (!isValidProfileName(profileName)) {
+        throw new ChallengeResultsStoreError(
+          "INVALID_REQUEST",
+          "profileName must be a 1-32 codepoint string of letters/spaces/apostrophes/hyphens starting with a letter."
+        );
+      }
+      session.profileName = profileName;
+    }
     let resolved = session;
     let resumed = false;
     await this.#commit((state) => {

--- a/lib/challenge-results-store.js
+++ b/lib/challenge-results-store.js
@@ -4,6 +4,7 @@ const fsp = require("node:fs/promises");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { isValidProfileName } = require("./profile-name");
 
 const STORE_VERSION = 1;
 const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -84,7 +85,7 @@ function normalizeSession(raw) {
     startedAt: raw.startedAt,
     puzzles: raw.puzzles.map(normalizePuzzle)
   };
-  if (typeof raw.profileName === "string" && raw.profileName.length >= 1 && raw.profileName.length <= 64) {
+  if (isValidProfileName(raw.profileName)) {
     out.profileName = raw.profileName;
   }
   if (typeof raw.finishedAt === "string" && raw.finishedAt) out.finishedAt = raw.finishedAt;
@@ -341,11 +342,7 @@ class ChallengeResultsStore {
       if (patch.profileName !== undefined) {
         if (patch.profileName === null) {
           delete merged.profileName;
-        } else if (
-          typeof patch.profileName === "string"
-          && patch.profileName.length >= 1
-          && patch.profileName.length <= 64
-        ) {
+        } else if (isValidProfileName(patch.profileName)) {
           merged.profileName = patch.profileName;
         } else {
           // Previously this branch fell through silently — an invalid

--- a/lib/challenge-results-store.js
+++ b/lib/challenge-results-store.js
@@ -346,14 +346,15 @@ class ChallengeResultsStore {
           merged.profileName = patch.profileName;
         } else {
           // Previously this branch fell through silently — an invalid
-          // profileName (wrong type, empty, or > 64 chars) was just
-          // ignored. Every other patch field throws INVALID_REQUEST in
-          // that case, so callers can't distinguish "ignored" from
-          // "applied" without re-fetching. Bring this in line so the
-          // contract is uniform: invalid → throw.
+          // profileName was just ignored. Every other patch field
+          // throws INVALID_REQUEST in that case, so callers can't
+          // distinguish "ignored" from "applied" without re-fetching.
+          // Bring this in line so the contract is uniform: invalid →
+          // throw. The shared validator (lib/profile-name.js, #174)
+          // defines the rule.
           throw new ChallengeResultsStoreError(
             "INVALID_REQUEST",
-            "profileName must be a 1-64 character string, or null to clear."
+            "profileName must be a 1-32 codepoint string of letters/spaces/apostrophes/hyphens starting with a letter, or null to clear."
           );
         }
       }

--- a/lib/challenge-results-store.js
+++ b/lib/challenge-results-store.js
@@ -275,7 +275,7 @@ class ChallengeResultsStore {
       if (!isValidProfileName(profileName)) {
         throw new ChallengeResultsStoreError(
           "INVALID_REQUEST",
-          "profileName must be a 1-32 codepoint string of letters/spaces/apostrophes/hyphens starting with a letter."
+          "profileName must be 1-32 characters starting with a letter and using only letters, spaces, apostrophes, or hyphens."
         );
       }
       session.profileName = profileName;
@@ -368,7 +368,7 @@ class ChallengeResultsStore {
           // defines the rule.
           throw new ChallengeResultsStoreError(
             "INVALID_REQUEST",
-            "profileName must be a 1-32 codepoint string of letters/spaces/apostrophes/hyphens starting with a letter, or null to clear."
+            "profileName must be 1-32 characters starting with a letter and using only letters, spaces, apostrophes, or hyphens, or null to clear."
           );
         }
       }

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -21,7 +21,7 @@ class LeaderboardStoreError extends Error {
   }
 }
 
-const PROFILE_NAME_PATTERN = /^[A-Za-z][A-Za-z '-]*$/;
+const { NAME_LENGTH_MAX: PROFILE_NAME_MAX, isValidProfileName } = require("./profile-name");
 const DAILY_KEY_PATTERN = /^(\d{4}-\d{2}-\d{2})\|([^|]+)\|([^|]+)$/;
 const ISO_DATE_TIME_PATTERN =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}:\d{2})$/;
@@ -114,7 +114,11 @@ function normalizeProfile(rawProfile) {
 
   const rawName = typeof rawProfile.name === "string" ? rawProfile.name : "";
   const name = rawName.trim();
-  if (!name || name.length > 24 || rawName !== name || !PROFILE_NAME_PATTERN.test(name)) {
+  // Shared validator (issue #174) — Unicode-letter-aware regex +
+  // 32-codepoint max, applied identically on the challenge side. The
+  // `rawName !== name` guard catches leading/trailing whitespace that
+  // the regex itself permits (internal spaces only).
+  if (rawName !== name || name.length > PROFILE_NAME_MAX || !isValidProfileName(name)) {
     return null;
   }
 
@@ -754,7 +758,6 @@ module.exports = {
   normalizeLeaderboardState,
   parseDailyKey,
   resolveMergeConflict,
-  PROFILE_NAME_PATTERN,
   DEFAULT_FILE_PATH,
   DEFAULT_MAX_PROFILES,
   DEFAULT_MAX_RESULTS_PER_PROFILE

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -117,8 +117,13 @@ function normalizeProfile(rawProfile) {
   // Shared validator (issue #174) — Unicode-letter-aware regex +
   // 32-codepoint max, applied identically on the challenge side. The
   // `rawName !== name` guard catches leading/trailing whitespace that
-  // the regex itself permits (internal spaces only).
-  if (rawName !== name || name.length > PROFILE_NAME_MAX || !isValidProfileName(name)) {
+  // the regex itself permits (internal spaces only). Length check
+  // uses Array.from(...).length for codepoint accuracy: bare
+  // `.length` is UTF-16 units and would over-count astral-plane
+  // letters that NAME_PATTERN's `{0,31}` codepoint quantifier accepts.
+  if (rawName !== name
+      || Array.from(name).length > PROFILE_NAME_MAX
+      || !isValidProfileName(name)) {
     return null;
   }
 

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -21,7 +21,7 @@ class LeaderboardStoreError extends Error {
   }
 }
 
-const { NAME_LENGTH_MAX: PROFILE_NAME_MAX, isValidProfileName } = require("./profile-name");
+const { isValidProfileName } = require("./profile-name");
 const DAILY_KEY_PATTERN = /^(\d{4}-\d{2}-\d{2})\|([^|]+)\|([^|]+)$/;
 const ISO_DATE_TIME_PATTERN =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}:\d{2})$/;
@@ -117,13 +117,12 @@ function normalizeProfile(rawProfile) {
   // Shared validator (issue #174) — Unicode-letter-aware regex +
   // 32-codepoint max, applied identically on the challenge side. The
   // `rawName !== name` guard catches leading/trailing whitespace that
-  // the regex itself permits (internal spaces only). Length check
-  // uses Array.from(...).length for codepoint accuracy: bare
-  // `.length` is UTF-16 units and would over-count astral-plane
-  // letters that NAME_PATTERN's `{0,31}` codepoint quantifier accepts.
-  if (rawName !== name
-      || Array.from(name).length > PROFILE_NAME_MAX
-      || !isValidProfileName(name)) {
+  // trim() removed (the regex itself permits internal spaces only;
+  // we don't want to silently accept names that had outer whitespace
+  // stripped). isValidProfileName's regex already enforces the
+  // length cap correctly via codepoint quantifier; no separate
+  // length check needed.
+  if (rawName !== name || !isValidProfileName(name)) {
     return null;
   }
 

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -115,13 +115,15 @@ function normalizeProfile(rawProfile) {
   const rawName = typeof rawProfile.name === "string" ? rawProfile.name : "";
   const name = rawName.trim();
   // Shared validator (issue #174) — Unicode-letter-aware regex +
-  // 32-codepoint max, applied identically on the challenge side. The
-  // `rawName !== name` guard catches leading/trailing whitespace that
-  // trim() removed (the regex itself permits internal spaces only;
-  // we don't want to silently accept names that had outer whitespace
-  // stripped). isValidProfileName's regex already enforces the
-  // length cap correctly via codepoint quantifier; no separate
-  // length check needed.
+  // 32-UTF-16-unit max, applied identically on the challenge side.
+  // The `rawName !== name` guard catches leading/trailing whitespace
+  // that trim() removed (the regex itself permits internal spaces
+  // only; we don't want to silently accept names that had outer
+  // whitespace stripped). `isValidProfileName` enforces BOTH the
+  // length cap (`name.length <= NAME_LENGTH_MAX`, matching HTML
+  // maxlength and the JSON schema's maxLength) AND the regex's
+  // character-class + codepoint quantifier — no separate length
+  // check needed here.
   if (rawName !== name || !isValidProfileName(name)) {
     return null;
   }

--- a/lib/profile-name.js
+++ b/lib/profile-name.js
@@ -1,0 +1,34 @@
+"use strict";
+
+// Profile name validator — shared between the leaderboard store (play
+// daily mode) and the challenge stores so both paths apply the same
+// rule. Pre-#174 the two diverged: leaderboard capped at 24 chars
+// with an ASCII-only regex `^[A-Za-z][A-Za-z '-]*$` (rejected `José`,
+// `李明`, etc.); challenge capped at 64 chars with no regex.
+//
+// Unified rule (option C from #174):
+//   - First char: any Unicode letter (\p{L}).
+//   - Remaining 0-31 chars: letters, combining marks (for decomposed
+//     accents like é = e + ́), spaces, apostrophes, hyphens.
+//   - No digits, no symbols, no emojis.
+//   - Total length 1-32 codepoints (regex anchors enforce both).
+//
+// This accepts the international names the old leaderboard regex
+// rejected (`José`, `李明`, `محمد`, `Pavlína`) while still excluding
+// arbitrary `<script>` / digit / emoji content. Server-side rendering
+// also uses `textContent` everywhere a name appears, so even if a
+// future code path bypasses this validator the rendered output stays
+// XSS-safe.
+
+const NAME_LENGTH_MAX = 32;
+const NAME_PATTERN = /^\p{L}[\p{L}\p{M}' -]{0,31}$/u;
+
+function isValidProfileName(name) {
+  return typeof name === "string" && NAME_PATTERN.test(name);
+}
+
+module.exports = {
+  NAME_LENGTH_MAX,
+  NAME_PATTERN,
+  isValidProfileName
+};

--- a/lib/profile-name.js
+++ b/lib/profile-name.js
@@ -21,7 +21,14 @@
 // XSS-safe.
 
 const NAME_LENGTH_MAX = 32;
-const NAME_PATTERN = /^\p{L}[\p{L}\p{M}' -]{0,31}$/u;
+// Regex quantifier derived from the constant so changing the cap in
+// one place updates both. The pattern requires one leading letter +
+// up to NAME_LENGTH_MAX-1 following chars (total 1..NAME_LENGTH_MAX).
+// CodeRabbit suggestion on PR #180.
+const NAME_PATTERN = new RegExp(
+  `^\\p{L}[\\p{L}\\p{M}' -]{0,${NAME_LENGTH_MAX - 1}}$`,
+  "u"
+);
 
 function isValidProfileName(name) {
   return typeof name === "string" && NAME_PATTERN.test(name);

--- a/lib/profile-name.js
+++ b/lib/profile-name.js
@@ -11,7 +11,12 @@
 //   - Remaining 0-31 chars: letters, combining marks (for decomposed
 //     accents like é = e + ́), spaces, apostrophes, hyphens.
 //   - No digits, no symbols, no emojis.
-//   - Total length 1-32 codepoints (regex anchors enforce both).
+//   - Total length 1-32 codepoints AND 1-32 UTF-16 code units (both
+//     caps enforced; see below). The HTML `maxlength="32"` attribute
+//     on both profile inputs caps typed input at 32 UTF-16 units, and
+//     `data/leaderboard.schema.json` enforces the same on stored
+//     data — so the validator matches that contract to keep API
+//     callers from writing names a later schema check rejects.
 //
 // This accepts the international names the old leaderboard regex
 // rejected (`José`, `李明`, `محمد`, `Pavlína`) while still excluding
@@ -31,7 +36,18 @@ const NAME_PATTERN = new RegExp(
 );
 
 function isValidProfileName(name) {
-  return typeof name === "string" && NAME_PATTERN.test(name);
+  // Both caps enforced:
+  //   - `name.length`: UTF-16 code units (matches HTML maxlength and
+  //     `data/leaderboard.schema.json` maxLength, both 32). For
+  //     supplementary-plane letters (surrogate pairs) this is the
+  //     binding constraint — a 17-astral-codepoint name passes the
+  //     regex's codepoint quantifier but exceeds 32 UTF-16 units.
+  //   - NAME_PATTERN: character class + codepoint quantifier under /u.
+  // The regex cap is redundant for BMP-only input (codepoint count ==
+  // UTF-16 count) but kept as defense-in-depth.
+  return typeof name === "string"
+    && name.length <= NAME_LENGTH_MAX
+    && NAME_PATTERN.test(name);
 }
 
 module.exports = {

--- a/lib/profile-name.js
+++ b/lib/profile-name.js
@@ -11,12 +11,18 @@
 //   - Remaining 0-31 chars: letters, combining marks (for decomposed
 //     accents like é = e + ́), spaces, apostrophes, hyphens.
 //   - No digits, no symbols, no emojis.
-//   - Total length 1-32 codepoints AND 1-32 UTF-16 code units (both
-//     caps enforced; see below). The HTML `maxlength="32"` attribute
-//     on both profile inputs caps typed input at 32 UTF-16 units, and
-//     `data/leaderboard.schema.json` enforces the same on stored
-//     data — so the validator matches that contract to keep API
-//     callers from writing names a later schema check rejects.
+//   - Total length 1-32 Unicode codepoints (regex anchors enforce
+//     both bounds; the `/u` flag makes the quantifier count
+//     codepoints rather than UTF-16 code units). Matches the
+//     `maxLength: 32` constraint in `data/leaderboard.schema.json`
+//     and `data/challenge-results.schema.json` (JSON Schema
+//     `maxLength` also counts codepoints per spec).
+//
+//   HTML `maxlength="32"` on the profile inputs is a UI cap measured
+//   in UTF-16 code units, which is tighter than the codepoint cap
+//   here for astral letters (16 surrogate pairs = 32 UTF-16 = 16
+//   codepoints). That's intentional — astral content > 16 codepoints
+//   can only enter via API or backup-restore, never typed input.
 //
 // This accepts the international names the old leaderboard regex
 // rejected (`José`, `李明`, `محمد`, `Pavlína`) while still excluding
@@ -36,18 +42,12 @@ const NAME_PATTERN = new RegExp(
 );
 
 function isValidProfileName(name) {
-  // Both caps enforced:
-  //   - `name.length`: UTF-16 code units (matches HTML maxlength and
-  //     `data/leaderboard.schema.json` maxLength, both 32). For
-  //     supplementary-plane letters (surrogate pairs) this is the
-  //     binding constraint — a 17-astral-codepoint name passes the
-  //     regex's codepoint quantifier but exceeds 32 UTF-16 units.
-  //   - NAME_PATTERN: character class + codepoint quantifier under /u.
-  // The regex cap is redundant for BMP-only input (codepoint count ==
-  // UTF-16 count) but kept as defense-in-depth.
-  return typeof name === "string"
-    && name.length <= NAME_LENGTH_MAX
-    && NAME_PATTERN.test(name);
+  // Cap is enforced by NAME_PATTERN's `{0,31}` codepoint quantifier
+  // under `/u`. Matches the JSON-schema `maxLength` (also codepoints
+  // per spec / AJV impl), so a name accepted here will also pass
+  // schema validation on the persisted file — no silent drops on
+  // load. Codex P2 on PR #180 caught the prior UTF-16-cap mismatch.
+  return typeof name === "string" && NAME_PATTERN.test(name);
 }
 
 module.exports = {

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -1081,7 +1081,15 @@ async function mergeProfileFlow(sourceId) {
   });
   const targetName = window.prompt(promptLines.join("\n"));
   if (targetName === null) return;
-  const target = others.find((profile) => profile.name === targetName.trim());
+  // NFC-normalize both sides (and case-fold) so user-typed `José`
+  // matches a stored NFD `José` (post-#174 the server writes
+  // NFC, but the merge-profiles flow can run against legacy data
+  // that hasn't been re-written yet). Without this, the merge
+  // prompt silently fails to find visually-identical targets.
+  const targetKey = targetName.trim().normalize("NFC").toLowerCase();
+  const target = others.find(
+    (profile) => profile.name.normalize("NFC").toLowerCase() === targetKey
+  );
   if (!target) {
     setStatus(profilesStatusEl, "Merge cancelled — target name did not match.", "admin-status-off");
     return;

--- a/public/app.js
+++ b/public/app.js
@@ -403,12 +403,12 @@ function enableStatsDegradedMode() {
 //     `\s+`, so embedded tabs/newlines survive trim() and get
 //     rejected by the regex rather than silently flattening to a
 //     valid space.
-//   - Length cap uses `cleaned.length` (UTF-16 code units) to match
-//     HTML `maxlength="32"`, `data/leaderboard.schema.json`
-//     `maxLength: 32`, and the shared validator's internal check.
-//     The /u regex's `{0,31}` codepoint quantifier is the looser
-//     character-class anchor; UTF-16 length is the binding
-//     constraint for astral-plane characters.
+//   - Length cap uses `Array.from(cleaned).length` (Unicode
+//     codepoints) to match the validator + JSON-schema `maxLength`
+//     (both codepoints). Bare `.length` would be UTF-16 units and
+//     too strict for astral-plane letters that the schema accepts.
+//     Codex P2 on PR #180. The HTML `maxlength="32"` UI cap is
+//     UTF-16 (tighter for astral typing — intentional UI choice).
 //   - The regex quantifier is derived from PROFILE_NAME_LENGTH_MAX
 //     so the cap is defined in one place (matches lib/profile-name.js).
 const PROFILE_NAME_LENGTH_MAX = 32;
@@ -424,9 +424,9 @@ function normalizeProfileName(rawName) {
   // `\p{L}` letters and `\p{M}` combining marks separately).
   const cleaned = String(rawName || "").trim().replace(/ +/g, " ").normalize("NFC");
   if (!cleaned) return "";
-  // UTF-16 code units, matching HTML maxlength=32 and the validator
-  // in lib/profile-name.js (which uses the same cap).
-  if (cleaned.length > PROFILE_NAME_LENGTH_MAX) return "";
+  // Codepoint cap — matches the validator + JSON schema. See block
+  // comment above for the rationale.
+  if (Array.from(cleaned).length > PROFILE_NAME_LENGTH_MAX) return "";
   if (!PROFILE_NAME_PATTERN.test(cleaned)) return "";
   return cleaned;
 }

--- a/public/app.js
+++ b/public/app.js
@@ -2396,7 +2396,15 @@ async function startChallenge(challengeId) {
   // P2 on PR #180.
   const rawValue = (challengeProfileInputEl?.value || '').trim();
   const normalized = normalizeProfileName(rawValue);
-  const finalName = normalized || profile.name || pickRandomName();
+  // Validate every step of the fallback chain — the input handler
+  // persists trim+space-collapse+clamp but doesn't run the regex,
+  // so `profile.name` from localStorage may itself be invalid (e.g.
+  // user typed "Alice123" earlier, "Alice123" hit localStorage, the
+  // regex rejects it on next session). Without normalizing the
+  // fallback, we'd POST the invalid stored name and get 400
+  // INVALID_PROFILE_NAME — same blocker the submit-normalize fix
+  // was supposed to close. Caught by Codex P2 on PR #180.
+  const finalName = normalized || normalizeProfileName(profile.name) || pickRandomName();
   // Mirror the chosen name back into the field + storage so the
   // user sees what's actually being submitted and a refresh shows
   // the same value (not the rejected raw input).

--- a/public/app.js
+++ b/public/app.js
@@ -388,19 +388,24 @@ function enableStatsDegradedMode() {
 // (issue #174). Must stay in sync — the server rejects identically
 // so a name accepted here will always be accepted on submit. Without
 // this mirror, the client would block server-valid names (`José`,
-// `李明`, 25-32 char) before the request leaves the page. Codex P2
-// review on PR #180.
+// `李明`, 25-32 char) before the request leaves the page.
 //
-// Whitespace normalization collapses only LITERAL spaces (` +`, not
-// `\s+`) so embedded tabs/newlines survive trim() and get rejected
-// by NAME_PATTERN rather than silently flattening to a valid space.
-// Length check uses Array.from(...).length to count Unicode
-// codepoints — bare `.length` is UTF-16 units and would over-count
-// any astral-plane letter (e.g. CJK Extension B) that the regex's
-// `{0,31}` codepoint quantifier would accept. Same fix as the two
-// server callers (server.js + lib/leaderboard-store.js).
+// Notes:
+//   - Whitespace normalization collapses only LITERAL spaces, not
+//     `\s+`, so embedded tabs/newlines survive trim() and get
+//     rejected by the regex rather than silently flattening to a
+//     valid space.
+//   - Length check uses Array.from(...).length to count Unicode
+//     codepoints — bare `.length` is UTF-16 units and would
+//     over-count astral-plane letters (e.g. CJK Extension B) that
+//     the regex's codepoint quantifier accepts.
+//   - The regex quantifier is derived from PROFILE_NAME_LENGTH_MAX
+//     so the cap is defined in one place (matches lib/profile-name.js).
 const PROFILE_NAME_LENGTH_MAX = 32;
-const PROFILE_NAME_PATTERN = /^\p{L}[\p{L}\p{M}' -]{0,31}$/u;
+const PROFILE_NAME_PATTERN = new RegExp(
+  `^\\p{L}[\\p{L}\\p{M}' -]{0,${PROFILE_NAME_LENGTH_MAX - 1}}$`,
+  "u"
+);
 function normalizeProfileName(rawName) {
   const cleaned = String(rawName || "").trim().replace(/ +/g, " ");
   if (!cleaned) return "";
@@ -760,7 +765,7 @@ async function createOrSelectProfile(rawName) {
   if (!normalizedName) {
     return {
       ok: false,
-      error: "Use letters, spaces, apostrophes, or hyphens (max 24 chars)."
+      error: `Use letters, spaces, apostrophes, or hyphens (max ${PROFILE_NAME_LENGTH_MAX} chars).`
     };
   }
 
@@ -2198,46 +2203,36 @@ function setChallengeProfileName(name) {
   try { localStorage.setItem(CHALLENGE_PROFILE_NAME_KEY, name); } catch (_e) { /* ignore */ }
 }
 
-// Adjective + Animal random name generator (issue #174). Both
-// profile inputs prefill from this when the value + localStorage are
-// both empty, giving the user a regex-clean starting point. Every
-// `<Adjective> <Animal>` combination passes the shared NAME_PATTERN
-// in lib/profile-name.js (ASCII letters + one internal space, well
-// under the 32-codepoint cap). Curated lists; no profanity sweep
-// needed at this size.
-const RANDOM_NAME_ADJECTIVES = Object.freeze([
-  "Brave", "Bold", "Calm", "Clever", "Curious", "Daring", "Eager",
-  "Friendly", "Gentle", "Happy", "Jolly", "Keen", "Kind", "Lively",
-  "Lucky", "Merry", "Nimble", "Plucky", "Proud", "Quiet", "Quick",
-  "Sharp", "Silly", "Smart", "Steady", "Sunny", "Swift", "Witty"
-]);
-const RANDOM_NAME_ANIMALS = Object.freeze([
-  "Badger", "Beaver", "Falcon", "Ferret", "Fox", "Hare", "Hawk",
-  "Heron", "Jaguar", "Lynx", "Magpie", "Marten", "Mongoose", "Otter",
-  "Owl", "Panda", "Penguin", "Raven", "Robin", "Seal", "Shark",
-  "Sparrow", "Stoat", "Stork", "Tiger", "Toucan", "Vixen", "Walrus"
-]);
-function pickRandomName() {
-  const adj = RANDOM_NAME_ADJECTIVES[Math.floor(Math.random() * RANDOM_NAME_ADJECTIVES.length)];
-  const animal = RANDOM_NAME_ANIMALS[Math.floor(Math.random() * RANDOM_NAME_ANIMALS.length)];
-  return `${adj} ${animal}`;
-}
+// `pickRandomName` is loaded as a UMD-style global from
+// public/js/random-name.js (issue #174). It's also exported as a
+// CommonJS module so tests/profile-name.test.js can iterate every
+// adjective/animal combination through the validator. The inline
+// definition used to live here; extracted so a single source of
+// truth governs the default-name lists.
 
 if (challengeProfileInputEl) {
-  // Prefill: keep any stored localStorage name; otherwise drop in a
-  // regex-clean random default so the input isn't blank on first
-  // visit. User can edit or replace freely; once they type, normal
-  // input listener takes over.
+  // Prefill: keep any stored localStorage name IF it still passes
+  // the unified validator; otherwise drop in a regex-clean random
+  // default. The validator-on-load step matters because localStorage
+  // may carry over a legacy 25-64 char name or one with characters
+  // the old regex allowed but the new one doesn't (digits in older
+  // challenge sessions). Starting in an invalid state would 400 on
+  // submit until the user manually edits. Caught by Copilot on
+  // PR #180.
   const storedChallengeName = getChallengeProfile().name;
-  challengeProfileInputEl.value = storedChallengeName || pickRandomName();
-  if (!storedChallengeName) {
-    // Persist the default so a refresh shows the same name rather
-    // than re-rolling (avoids the surprise of "wait, I had a different
-    // name a second ago"). User can still overwrite.
-    setChallengeProfileName(challengeProfileInputEl.value);
+  const initialName = normalizeProfileName(storedChallengeName) || pickRandomName();
+  challengeProfileInputEl.value = initialName;
+  if (initialName !== storedChallengeName) {
+    // Persist the default (or the normalized stored value) so a
+    // refresh shows the same name rather than re-rolling, and so a
+    // legacy invalid stored value is overwritten with one that
+    // submits cleanly.
+    setChallengeProfileName(initialName);
   }
   challengeProfileInputEl.addEventListener('input', () => {
-    setChallengeProfileName(String(challengeProfileInputEl.value || '').trim().slice(0, 32));
+    setChallengeProfileName(
+      String(challengeProfileInputEl.value || '').trim().slice(0, PROFILE_NAME_LENGTH_MAX)
+    );
   });
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -390,12 +390,21 @@ function enableStatsDegradedMode() {
 // this mirror, the client would block server-valid names (`José`,
 // `李明`, 25-32 char) before the request leaves the page. Codex P2
 // review on PR #180.
+//
+// Whitespace normalization collapses only LITERAL spaces (` +`, not
+// `\s+`) so embedded tabs/newlines survive trim() and get rejected
+// by NAME_PATTERN rather than silently flattening to a valid space.
+// Length check uses Array.from(...).length to count Unicode
+// codepoints — bare `.length` is UTF-16 units and would over-count
+// any astral-plane letter (e.g. CJK Extension B) that the regex's
+// `{0,31}` codepoint quantifier would accept. Same fix as the two
+// server callers (server.js + lib/leaderboard-store.js).
 const PROFILE_NAME_LENGTH_MAX = 32;
 const PROFILE_NAME_PATTERN = /^\p{L}[\p{L}\p{M}' -]{0,31}$/u;
 function normalizeProfileName(rawName) {
-  const cleaned = String(rawName || "").trim().replace(/\s+/g, " ");
+  const cleaned = String(rawName || "").trim().replace(/ +/g, " ");
   if (!cleaned) return "";
-  if (cleaned.length > PROFILE_NAME_LENGTH_MAX) return "";
+  if (Array.from(cleaned).length > PROFILE_NAME_LENGTH_MAX) return "";
   if (!PROFILE_NAME_PATTERN.test(cleaned)) return "";
   return cleaned;
 }

--- a/public/app.js
+++ b/public/app.js
@@ -2238,8 +2238,18 @@ if (challengeProfileInputEl) {
     setChallengeProfileName(initialName);
   }
   challengeProfileInputEl.addEventListener('input', () => {
+    // Match the same trim + space-collapse + slice that
+    // normalizeProfileName() does on load, so the persisted value
+    // is byte-identical to what the next page-load will display.
+    // Without this collapse, a user typing "Mary  Jane" (double
+    // space) would see one thing in the field, get something else
+    // persisted on submit, and see a third thing (collapsed by
+    // normalizeProfileName) after refresh. Caught by Copilot.
     setChallengeProfileName(
-      String(challengeProfileInputEl.value || '').trim().slice(0, PROFILE_NAME_LENGTH_MAX)
+      String(challengeProfileInputEl.value || '')
+        .trim()
+        .replace(/ +/g, ' ')
+        .slice(0, PROFILE_NAME_LENGTH_MAX)
     );
   });
 }

--- a/public/app.js
+++ b/public/app.js
@@ -2181,11 +2181,57 @@ function setChallengeProfileName(name) {
   try { localStorage.setItem(CHALLENGE_PROFILE_NAME_KEY, name); } catch (_e) { /* ignore */ }
 }
 
+// Adjective + Animal random name generator (issue #174). Both
+// profile inputs prefill from this when the value + localStorage are
+// both empty, giving the user a regex-clean starting point. Every
+// `<Adjective> <Animal>` combination passes the shared NAME_PATTERN
+// in lib/profile-name.js (ASCII letters + one internal space, well
+// under the 32-codepoint cap). Curated lists; no profanity sweep
+// needed at this size.
+const RANDOM_NAME_ADJECTIVES = Object.freeze([
+  "Brave", "Bold", "Calm", "Clever", "Curious", "Daring", "Eager",
+  "Friendly", "Gentle", "Happy", "Jolly", "Keen", "Kind", "Lively",
+  "Lucky", "Merry", "Nimble", "Plucky", "Proud", "Quiet", "Quick",
+  "Sharp", "Silly", "Smart", "Steady", "Sunny", "Swift", "Witty"
+]);
+const RANDOM_NAME_ANIMALS = Object.freeze([
+  "Badger", "Beaver", "Falcon", "Ferret", "Fox", "Hare", "Hawk",
+  "Heron", "Jaguar", "Lynx", "Magpie", "Marten", "Mongoose", "Otter",
+  "Owl", "Panda", "Penguin", "Raven", "Robin", "Seal", "Shark",
+  "Sparrow", "Stoat", "Stork", "Tiger", "Toucan", "Vixen", "Walrus"
+]);
+function pickRandomName() {
+  const adj = RANDOM_NAME_ADJECTIVES[Math.floor(Math.random() * RANDOM_NAME_ADJECTIVES.length)];
+  const animal = RANDOM_NAME_ANIMALS[Math.floor(Math.random() * RANDOM_NAME_ANIMALS.length)];
+  return `${adj} ${animal}`;
+}
+
 if (challengeProfileInputEl) {
-  challengeProfileInputEl.value = getChallengeProfile().name;
+  // Prefill: keep any stored localStorage name; otherwise drop in a
+  // regex-clean random default so the input isn't blank on first
+  // visit. User can edit or replace freely; once they type, normal
+  // input listener takes over.
+  const storedChallengeName = getChallengeProfile().name;
+  challengeProfileInputEl.value = storedChallengeName || pickRandomName();
+  if (!storedChallengeName) {
+    // Persist the default so a refresh shows the same name rather
+    // than re-rolling (avoids the surprise of "wait, I had a different
+    // name a second ago"). User can still overwrite.
+    setChallengeProfileName(challengeProfileInputEl.value);
+  }
   challengeProfileInputEl.addEventListener('input', () => {
-    setChallengeProfileName(String(challengeProfileInputEl.value || '').trim().slice(0, 64));
+    setChallengeProfileName(String(challengeProfileInputEl.value || '').trim().slice(0, 32));
   });
+}
+
+if (profileNameInputEl) {
+  // Same prefill for the play (daily) name input. The leaderboard
+  // form uses multi-profile semantics so we don't persist the default
+  // here — it's just a typing-into starting point. User can edit
+  // before clicking "Use this name" to submit.
+  if (!profileNameInputEl.value) {
+    profileNameInputEl.value = pickRandomName();
+  }
 }
 
 // Wrap fetch() so challenge endpoints — the only routes wired into

--- a/public/app.js
+++ b/public/app.js
@@ -2260,9 +2260,16 @@ if (challengeProfileInputEl) {
     // counts code points, so `.slice` would either truncate astral
     // letters too aggressively or cut a surrogate pair and produce
     // an invalid string. Caught by Copilot on PR #180.
+    // NFC-normalize here too — matches normalizeProfileName() so a
+    // user typing decomposed accents (NFD `José` = `e` + combining
+    // acute) stores the same bytes the next page-load prefill will
+    // display after running through normalizeProfileName. Without
+    // NFC here, the persisted value drifts after refresh. Caught by
+    // Copilot on PR #180.
     const cleaned = String(challengeProfileInputEl.value || '')
       .trim()
-      .replace(/ +/g, ' ');
+      .replace(/ +/g, ' ')
+      .normalize('NFC');
     setChallengeProfileName(
       Array.from(cleaned).slice(0, PROFILE_NAME_LENGTH_MAX).join('')
     );

--- a/public/app.js
+++ b/public/app.js
@@ -422,7 +422,9 @@ function normalizeProfileName(rawName) {
   // `\p{L}` letters and `\p{M}` combining marks separately).
   const cleaned = String(rawName || "").trim().replace(/ +/g, " ").normalize("NFC");
   if (!cleaned) return "";
-  if (Array.from(cleaned).length > PROFILE_NAME_LENGTH_MAX) return "";
+  // UTF-16 code units, matching HTML maxlength=32 and the validator
+  // in lib/profile-name.js (which uses the same cap).
+  if (cleaned.length > PROFILE_NAME_LENGTH_MAX) return "";
   if (!PROFILE_NAME_PATTERN.test(cleaned)) return "";
   return cleaned;
 }

--- a/public/app.js
+++ b/public/app.js
@@ -403,10 +403,12 @@ function enableStatsDegradedMode() {
 //     `\s+`, so embedded tabs/newlines survive trim() and get
 //     rejected by the regex rather than silently flattening to a
 //     valid space.
-//   - Length check uses Array.from(...).length to count Unicode
-//     codepoints — bare `.length` is UTF-16 units and would
-//     over-count astral-plane letters (e.g. CJK Extension B) that
-//     the regex's codepoint quantifier accepts.
+//   - Length cap uses `cleaned.length` (UTF-16 code units) to match
+//     HTML `maxlength="32"`, `data/leaderboard.schema.json`
+//     `maxLength: 32`, and the shared validator's internal check.
+//     The /u regex's `{0,31}` codepoint quantifier is the looser
+//     character-class anchor; UTF-16 length is the binding
+//     constraint for astral-plane characters.
 //   - The regex quantifier is derived from PROFILE_NAME_LENGTH_MAX
 //     so the cap is defined in one place (matches lib/profile-name.js).
 const PROFILE_NAME_LENGTH_MAX = 32;

--- a/public/app.js
+++ b/public/app.js
@@ -1,3 +1,11 @@
+/* global pickRandomName */
+// `pickRandomName` is provided by public/js/random-name.js, loaded
+// via `<script defer>` before this file in public/index.html. The
+// ESLint global directive above tells the linter to expect it as a
+// browser global rather than a missing identifier. Same UMD pattern
+// as escapeHtml from public/js/escape-html.js (which app.js doesn't
+// currently consume, but the script-tag loading chain is identical).
+
 const createPanel = document.getElementById("createPanel");
 const playPanel = document.getElementById("playPanel");
 

--- a/public/app.js
+++ b/public/app.js
@@ -384,11 +384,19 @@ function enableStatsDegradedMode() {
   renderDailyPlayerPanels();
 }
 
+// Mirror of the server-side validator in lib/profile-name.js
+// (issue #174). Must stay in sync — the server rejects identically
+// so a name accepted here will always be accepted on submit. Without
+// this mirror, the client would block server-valid names (`José`,
+// `李明`, 25-32 char) before the request leaves the page. Codex P2
+// review on PR #180.
+const PROFILE_NAME_LENGTH_MAX = 32;
+const PROFILE_NAME_PATTERN = /^\p{L}[\p{L}\p{M}' -]{0,31}$/u;
 function normalizeProfileName(rawName) {
   const cleaned = String(rawName || "").trim().replace(/\s+/g, " ");
   if (!cleaned) return "";
-  if (cleaned.length > 24) return "";
-  if (!/^[A-Za-z][A-Za-z '-]*$/.test(cleaned)) return "";
+  if (cleaned.length > PROFILE_NAME_LENGTH_MAX) return "";
+  if (!PROFILE_NAME_PATTERN.test(cleaned)) return "";
   return cleaned;
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -2238,18 +2238,24 @@ if (challengeProfileInputEl) {
     setChallengeProfileName(initialName);
   }
   challengeProfileInputEl.addEventListener('input', () => {
-    // Match the same trim + space-collapse + slice that
+    // Match the same trim + space-collapse + codepoint-clamp that
     // normalizeProfileName() does on load, so the persisted value
     // is byte-identical to what the next page-load will display.
     // Without this collapse, a user typing "Mary  Jane" (double
     // space) would see one thing in the field, get something else
     // persisted on submit, and see a third thing (collapsed by
     // normalizeProfileName) after refresh. Caught by Copilot.
+    //
+    // Truncate by Unicode code points (Array.from) not UTF-16 code
+    // units (.slice); the validator's `{0,31}` quantifier under /u
+    // counts code points, so `.slice` would either truncate astral
+    // letters too aggressively or cut a surrogate pair and produce
+    // an invalid string. Caught by Copilot on PR #180.
+    const cleaned = String(challengeProfileInputEl.value || '')
+      .trim()
+      .replace(/ +/g, ' ');
     setChallengeProfileName(
-      String(challengeProfileInputEl.value || '')
-        .trim()
-        .replace(/ +/g, ' ')
-        .slice(0, PROFILE_NAME_LENGTH_MAX)
+      Array.from(cleaned).slice(0, PROFILE_NAME_LENGTH_MAX).join('')
     );
   });
 }

--- a/public/app.js
+++ b/public/app.js
@@ -2386,10 +2386,24 @@ function renderChallengeList() {
 
 async function startChallenge(challengeId) {
   const profile = getChallengeProfile();
-  if (!profile.name && challengeProfileInputEl?.value) {
-    setChallengeProfileName(challengeProfileInputEl.value.trim());
+  // Normalize the field through the same validator the server uses.
+  // The input handler only clamps the localStorage copy; the field's
+  // own .value stays as the user typed it (clamping on every keystroke
+  // jumps the caret). Without this normalize-at-submit, a user typing
+  // 33+ codepoints (allowed up to maxlength=64 as a worst-case astral
+  // soft-cap) would POST the raw over-limit value and get a 400
+  // INVALID_PROFILE_NAME until they manually edited. Caught by Codex
+  // P2 on PR #180.
+  const rawValue = (challengeProfileInputEl?.value || '').trim();
+  const normalized = normalizeProfileName(rawValue);
+  const finalName = normalized || profile.name || pickRandomName();
+  // Mirror the chosen name back into the field + storage so the
+  // user sees what's actually being submitted and a refresh shows
+  // the same value (not the rejected raw input).
+  if (challengeProfileInputEl && challengeProfileInputEl.value !== finalName) {
+    challengeProfileInputEl.value = finalName;
   }
-  const finalName = challengeProfileInputEl?.value?.trim() || profile.name || 'Player';
+  setChallengeProfileName(finalName);
   try {
     const res = await challengeFetch(`/api/challenges/${encodeURIComponent(challengeId)}/start`, {
       method: 'POST',

--- a/public/app.js
+++ b/public/app.js
@@ -415,7 +415,12 @@ const PROFILE_NAME_PATTERN = new RegExp(
   "u"
 );
 function normalizeProfileName(rawName) {
-  const cleaned = String(rawName || "").trim().replace(/ +/g, " ");
+  // NFC-normalize so `José` (composed) and `José` (decomposed `e` +
+  // combining-acute) produce identical bytes — otherwise the server's
+  // dedup comparison sees them as distinct profiles. Codex P2 on
+  // PR #180. Both forms still pass the validator (the regex accepts
+  // `\p{L}` letters and `\p{M}` combining marks separately).
+  const cleaned = String(rawName || "").trim().replace(/ +/g, " ").normalize("NFC");
   if (!cleaned) return "";
   if (Array.from(cleaned).length > PROFILE_NAME_LENGTH_MAX) return "";
   if (!PROFILE_NAME_PATTERN.test(cleaned)) return "";
@@ -2387,13 +2392,13 @@ function renderChallengeList() {
 async function startChallenge(challengeId) {
   const profile = getChallengeProfile();
   // Normalize the field through the same validator the server uses.
-  // The input handler only clamps the localStorage copy; the field's
-  // own .value stays as the user typed it (clamping on every keystroke
-  // jumps the caret). Without this normalize-at-submit, a user typing
-  // 33+ codepoints (allowed up to maxlength=64 as a worst-case astral
-  // soft-cap) would POST the raw over-limit value and get a 400
-  // INVALID_PROFILE_NAME until they manually edited. Caught by Codex
-  // P2 on PR #180.
+  // HTML `maxlength=32` caps user typing at 32 UTF-16 code units, but
+  // a programmatic .value assignment (e.g. legacy localStorage prefill
+  // from before the cap tightened) can still load a longer/invalid
+  // value; the input handler only clamps the localStorage copy, the
+  // field's own .value stays as-loaded. Without normalize-at-submit
+  // that legacy value would POST and 400 INVALID_PROFILE_NAME until
+  // the user manually edited. Codex P2 on PR #180.
   const rawValue = (challengeProfileInputEl?.value || '').trim();
   const normalized = normalizeProfileName(rawValue);
   // Validate every step of the fallback chain — the input handler

--- a/public/index.html
+++ b/public/index.html
@@ -156,6 +156,7 @@
                 id="profileNameInput"
                 name="profileName"
                 autocomplete="off"
+                maxlength="64"
                 data-i18n-attr="placeholder:play.namePlaceholder"
               />
             </label>
@@ -245,7 +246,7 @@
         <div id="challengeProfileRow" class="form-row">
           <label>
             <span data-i18n="challenge.profileNameLabel">Profile name</span>
-            <input id="challengeProfileInput" type="text" autocomplete="off" data-i18n-attr="placeholder:challenge.profileNamePlaceholder" />
+            <input id="challengeProfileInput" type="text" maxlength="64" autocomplete="off" data-i18n-attr="placeholder:challenge.profileNamePlaceholder" />
             <span class="hint" data-i18n="challenge.profileNameHint">Used on the leaderboard. Stored on this device.</span>
           </label>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -155,7 +155,7 @@
                 id="profileNameInput"
                 name="profileName"
                 autocomplete="off"
-                maxlength="24"
+                maxlength="32"
                 data-i18n-attr="placeholder:play.namePlaceholder"
               />
             </label>
@@ -245,7 +245,7 @@
         <div id="challengeProfileRow" class="form-row">
           <label>
             <span data-i18n="challenge.profileNameLabel">Profile name</span>
-            <input id="challengeProfileInput" type="text" maxlength="64" autocomplete="off" data-i18n-attr="placeholder:challenge.profileNamePlaceholder" />
+            <input id="challengeProfileInput" type="text" maxlength="32" autocomplete="off" data-i18n-attr="placeholder:challenge.profileNamePlaceholder" />
             <span class="hint" data-i18n="challenge.profileNameHint">Used on the leaderboard. Stored on this device.</span>
           </label>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -156,7 +156,7 @@
                 id="profileNameInput"
                 name="profileName"
                 autocomplete="off"
-                maxlength="64"
+                maxlength="32"
                 data-i18n-attr="placeholder:play.namePlaceholder"
               />
             </label>
@@ -246,7 +246,7 @@
         <div id="challengeProfileRow" class="form-row">
           <label>
             <span data-i18n="challenge.profileNameLabel">Profile name</span>
-            <input id="challengeProfileInput" type="text" maxlength="64" autocomplete="off" data-i18n-attr="placeholder:challenge.profileNamePlaceholder" />
+            <input id="challengeProfileInput" type="text" maxlength="32" autocomplete="off" data-i18n-attr="placeholder:challenge.profileNamePlaceholder" />
             <span class="hint" data-i18n="challenge.profileNameHint">Used on the leaderboard. Stored on this device.</span>
           </label>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,7 @@
          dynamic-HTML callsites; the current shell uses textContent +
          DOM APIs and doesn't reference window.escapeHtml. -->
     <script src="/js/escape-html.js" defer></script>
+    <script src="/js/random-name.js" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main" data-i18n="common.skipToMain">Skip to main content</a>
@@ -155,7 +156,6 @@
                 id="profileNameInput"
                 name="profileName"
                 autocomplete="off"
-                maxlength="32"
                 data-i18n-attr="placeholder:play.namePlaceholder"
               />
             </label>
@@ -245,7 +245,7 @@
         <div id="challengeProfileRow" class="form-row">
           <label>
             <span data-i18n="challenge.profileNameLabel">Profile name</span>
-            <input id="challengeProfileInput" type="text" maxlength="32" autocomplete="off" data-i18n-attr="placeholder:challenge.profileNamePlaceholder" />
+            <input id="challengeProfileInput" type="text" autocomplete="off" data-i18n-attr="placeholder:challenge.profileNamePlaceholder" />
             <span class="hint" data-i18n="challenge.profileNameHint">Used on the leaderboard. Stored on this device.</span>
           </label>
         </div>

--- a/public/js/random-name.js
+++ b/public/js/random-name.js
@@ -1,0 +1,46 @@
+"use strict";
+
+// Adjective + Animal random name generator (issue #174). Pre-fills
+// both profile inputs with a regex-clean default so the input isn't
+// blank on first visit. Every `<Adjective> <Animal>` combination
+// passes the shared NAME_PATTERN in lib/profile-name.js (ASCII
+// letters + one internal space, well under the 32-codepoint cap).
+//
+// Curated lists; no profanity sweep needed at this size. The
+// `tests/profile-name.test.js` contract test iterates every entry
+// and asserts isValidProfileName() accepts it — a bad list edit
+// fails the test before it can ship a broken default.
+//
+// UMD-ish shape (same pattern as public/js/escape-html.js) so this
+// same source works both as a CommonJS module (Node tests) and as a
+// global on `window` when loaded as a plain script in the player
+// shell.
+
+const RANDOM_NAME_ADJECTIVES = Object.freeze([
+  "Brave", "Bold", "Calm", "Clever", "Curious", "Daring", "Eager",
+  "Friendly", "Gentle", "Happy", "Jolly", "Keen", "Kind", "Lively",
+  "Lucky", "Merry", "Nimble", "Plucky", "Proud", "Quiet", "Quick",
+  "Sharp", "Silly", "Smart", "Steady", "Sunny", "Swift", "Witty"
+]);
+
+const RANDOM_NAME_ANIMALS = Object.freeze([
+  "Badger", "Beaver", "Falcon", "Ferret", "Fox", "Hare", "Hawk",
+  "Heron", "Jaguar", "Lynx", "Magpie", "Marten", "Mongoose", "Otter",
+  "Owl", "Panda", "Penguin", "Raven", "Robin", "Seal", "Shark",
+  "Sparrow", "Stoat", "Stork", "Tiger", "Toucan", "Vixen", "Walrus"
+]);
+
+function pickRandomName() {
+  const adj = RANDOM_NAME_ADJECTIVES[Math.floor(Math.random() * RANDOM_NAME_ADJECTIVES.length)];
+  const animal = RANDOM_NAME_ANIMALS[Math.floor(Math.random() * RANDOM_NAME_ANIMALS.length)];
+  return `${adj} ${animal}`;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { RANDOM_NAME_ADJECTIVES, RANDOM_NAME_ANIMALS, pickRandomName };
+}
+if (typeof window !== "undefined") {
+  window.pickRandomName = pickRandomName;
+  window.RANDOM_NAME_ADJECTIVES = RANDOM_NAME_ADJECTIVES;
+  window.RANDOM_NAME_ANIMALS = RANDOM_NAME_ANIMALS;
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,3 +1,11 @@
+// v9: adds /js/random-name.js to the precache so the new pickRandomName
+// global (PR #180) is available offline. app.js calls pickRandomName()
+// during startup for both the daily and challenge profile defaults;
+// without this entry, a returning offline PWA visitor would fetch a
+// fresh /app.js from cache while /js/random-name.js 404s, leaving the
+// `pickRandomName` global undefined and the daily/challenge UI broken
+// with a ReferenceError before initialization. Codex P2 on PR #180.
+//
 // v8: invalidates stale app.js so the leaderboard-disabled gate
 // (Codex finding on PR #160) and the ensureMetaReady retry-on-failure
 // fix (Copilot finding on PR #160) reach returning visitors. Without
@@ -45,12 +53,15 @@
 //
 // v3: adds `push` + `notificationclick` listeners for the daily-puzzle
 // Web Push notification flow (#92).
-const CACHE_NAME = 'wordle-cache-v8';
+const CACHE_NAME = 'wordle-cache-v9';
 const STATIC_ASSETS = [
   '/',
   '/index.html',
   '/styles.css',
   '/app.js',
+  '/js/escape-html.js',
+  '/js/i18n.js',
+  '/js/random-name.js',
   '/manifest.json',
   '/icons/icon-192.png',
   '/icons/icon-512.png',

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -308,7 +308,15 @@ function createAdminRouter(deps) {
           throw new StatsApiError(404, "Player profile not found.");
         }
         const duplicate = draft.profiles.find(
-          (item) => item.id !== profileId && item.name.toLowerCase() === nextName.toLowerCase()
+          // NFC-normalize the persisted side — older rows written
+          // before the NFC fix may be NFD, and `nextName` is already
+          // NFC via `normalizeProfileNameInput`. Without this, a
+          // rename to NFC `José` wouldn't see an existing NFD
+          // `José` row and would silently create a duplicate.
+          // Codex P2 on PR #180.
+          (item) =>
+            item.id !== profileId
+            && item.name.normalize("NFC").toLowerCase() === nextName.toLowerCase()
         );
         if (duplicate) {
           throw new StatsApiError(409, "Another player already uses that name.");
@@ -2436,7 +2444,10 @@ function createAdminRouter(deps) {
     }
     const existingProfileByLowerName = new Map();
     for (const profile of leaderboardSnapshotForPrecheck.profiles) {
-      existingProfileByLowerName.set(profile.name.toLowerCase(), profile.id);
+      // NFC-normalize the persisted side (see the rename duplicate
+      // check above) so a legacy NFD row matches an NFC bulk-add
+      // candidate. Codex P2 on PR #180.
+      existingProfileByLowerName.set(profile.name.normalize("NFC").toLowerCase(), profile.id);
     }
     const targetMemberSet = new Set(target.memberProfileIds);
     let projectedNetNew = 0;
@@ -2489,7 +2500,10 @@ function createAdminRouter(deps) {
       await withSlot(() => leaderboardStore.mutate((draft) => {
         const nowIso = new Date().toISOString();
         const existingByLowerName = new Map(
-          draft.profiles.map((profile) => [profile.name.toLowerCase(), profile])
+          // NFC-normalize the persisted side (see the rename
+          // duplicate check above) so a legacy NFD row matches an
+          // NFC bulk-add candidate. Codex P2 on PR #180.
+          draft.profiles.map((profile) => [profile.name.normalize("NFC").toLowerCase(), profile])
         );
         for (const name of normalizedNames) {
           const key = name.toLowerCase();

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -193,7 +193,7 @@ function createChallengesRouter(deps) {
     }
     if (profile.error === "INVALID_PROFILE_NAME") {
       return res.status(400).json({
-        error: "profileName must start with a letter and contain only letters, spaces, apostrophes, or hyphens (1-32 codepoints).",
+        error: "profileName must be 1-32 characters starting with a letter and using only letters, spaces, apostrophes, or hyphens.",
         code: "INVALID_PROFILE_NAME"
       });
     }

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -104,7 +104,13 @@ function createChallengesRouter(deps) {
   function resolveProfile(body) {
     const profileId = typeof body?.profileId === "string" ? body.profileId.trim() : "";
     const profileName = typeof body?.profileName === "string" ? body.profileName.trim() : "";
-    if (!profileId || profileId.length > 64) return null;
+    if (!profileId) return { error: "PROFILE_ID_REQUIRED" };
+    // Distinct sentinel for present-but-too-long profileId so the
+    // route handler can return a more specific 400 than the generic
+    // "profileId is required." (the prior code returned plain null
+    // for both missing AND too-long, so the user got a misleading
+    // error). Caught by Copilot on PR #180.
+    if (profileId.length > 64) return { error: "PROFILE_ID_TOO_LONG" };
     // Present-but-invalid profileName → reject (caller 400s on the
     // INVALID_PROFILE_NAME sentinel). Previously this branch silently
     // dropped to undefined, so a user typing `Alice<script>` would
@@ -173,8 +179,11 @@ function createChallengesRouter(deps) {
   router.post("/api/challenges/:id/start", async (req, res) => {
     if (!ensureEnabled(req, res)) return;
     const profile = resolveProfile(req.body);
-    if (!profile) {
+    if (profile.error === "PROFILE_ID_REQUIRED") {
       return res.status(400).json({ error: "profileId is required.", code: "INVALID_REQUEST" });
+    }
+    if (profile.error === "PROFILE_ID_TOO_LONG") {
+      return res.status(400).json({ error: "profileId must be 1-64 characters.", code: "INVALID_REQUEST" });
     }
     if (profile.error === "INVALID_PROFILE_NAME") {
       return res.status(400).json({

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -103,7 +103,13 @@ function createChallengesRouter(deps) {
   // we accept that same shape here.
   function resolveProfile(body) {
     const profileId = typeof body?.profileId === "string" ? body.profileId.trim() : "";
-    const profileName = typeof body?.profileName === "string" ? body.profileName.trim() : "";
+    // NFC-normalize so `José` (composed) and `José` (decomposed)
+    // store as identical bytes; without this, two visually-identical
+    // names create two profile records on the challenge side too.
+    // Codex P2 on PR #180.
+    const profileName = typeof body?.profileName === "string"
+      ? body.profileName.trim().normalize("NFC")
+      : "";
     if (!profileId) return { error: "PROFILE_ID_REQUIRED" };
     // Distinct sentinel for present-but-too-long profileId so the
     // route handler can return a more specific 400 than the generic

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -106,9 +106,13 @@ function createChallengesRouter(deps) {
     const profileName = typeof body?.profileName === "string" ? body.profileName.trim() : "";
     if (!profileId || profileId.length > 64) return null;
     // Shared validator (issue #174): same regex + 32-cp cap as the
-    // leaderboard side. Reject malformed names rather than silently
-    // dropping; the client pre-fills with a regex-clean default so
-    // legitimate submissions always pass.
+    // leaderboard side. A profileName that doesn't pass is silently
+    // dropped to `undefined` — the session is recorded against the
+    // profileId, the leaderboard row just has no display name on it.
+    // Hard-rejecting (400) would block the gameplay path entirely on
+    // a name typo; this preserves the result while losing only the
+    // label. The client pre-fills with a regex-clean default so
+    // legitimate submissions always carry a valid name through.
     return {
       profileId,
       profileName: isValidProfileName(profileName) ? profileName : undefined

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -187,7 +187,7 @@ function createChallengesRouter(deps) {
     }
     if (profile.error === "INVALID_PROFILE_NAME") {
       return res.status(400).json({
-        error: "profileName must be a valid profile name (1-32 codepoints, letters + spaces/apostrophes/hyphens).",
+        error: "profileName must start with a letter and contain only letters, spaces, apostrophes, or hyphens (1-32 codepoints).",
         code: "INVALID_PROFILE_NAME"
       });
     }

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -3,6 +3,7 @@
 const express = require("express");
 const challengeEngine = require("../lib/challenge-engine");
 const { translateForRequest } = require("../lib/server-i18n");
+const { isValidProfileName } = require("../lib/profile-name");
 const { logger } = require("../lib/logger");
 
 /**
@@ -104,7 +105,14 @@ function createChallengesRouter(deps) {
     const profileId = typeof body?.profileId === "string" ? body.profileId.trim() : "";
     const profileName = typeof body?.profileName === "string" ? body.profileName.trim() : "";
     if (!profileId || profileId.length > 64) return null;
-    return { profileId, profileName: profileName.length >= 1 && profileName.length <= 64 ? profileName : undefined };
+    // Shared validator (issue #174): same regex + 32-cp cap as the
+    // leaderboard side. Reject malformed names rather than silently
+    // dropping; the client pre-fills with a regex-clean default so
+    // legitimate submissions always pass.
+    return {
+      profileId,
+      profileName: isValidProfileName(profileName) ? profileName : undefined
+    };
   }
 
   // Server-authoritative timeout settle: if the session has run out of

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -105,17 +105,21 @@ function createChallengesRouter(deps) {
     const profileId = typeof body?.profileId === "string" ? body.profileId.trim() : "";
     const profileName = typeof body?.profileName === "string" ? body.profileName.trim() : "";
     if (!profileId || profileId.length > 64) return null;
-    // Shared validator (issue #174): same regex + 32-cp cap as the
-    // leaderboard side. A profileName that doesn't pass is silently
-    // dropped to `undefined` — the session is recorded against the
-    // profileId, the leaderboard row just has no display name on it.
-    // Hard-rejecting (400) would block the gameplay path entirely on
-    // a name typo; this preserves the result while losing only the
-    // label. The client pre-fills with a regex-clean default so
+    // Present-but-invalid profileName → reject (caller 400s on the
+    // INVALID_PROFILE_NAME sentinel). Previously this branch silently
+    // dropped to undefined, so a user typing `Alice<script>` would
+    // play the entire challenge anonymously without realizing — the
+    // name they intended to be recorded under was thrown away after
+    // the request landed. Now the contract matches the leaderboard
+    // side (which always throws on invalid). The client prefills
+    // with a regex-clean default (#174 Adj+Animal generator) so
     // legitimate submissions always carry a valid name through.
+    if (profileName && !isValidProfileName(profileName)) {
+      return { error: "INVALID_PROFILE_NAME" };
+    }
     return {
       profileId,
-      profileName: isValidProfileName(profileName) ? profileName : undefined
+      profileName: profileName || undefined
     };
   }
 
@@ -171,6 +175,12 @@ function createChallengesRouter(deps) {
     const profile = resolveProfile(req.body);
     if (!profile) {
       return res.status(400).json({ error: "profileId is required.", code: "INVALID_REQUEST" });
+    }
+    if (profile.error === "INVALID_PROFILE_NAME") {
+      return res.status(400).json({
+        error: "profileName must be a valid profile name (1-32 codepoints, letters + spaces/apostrophes/hyphens).",
+        code: "INVALID_PROFILE_NAME"
+      });
     }
     try {
       const now = new Date();

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -93,7 +93,13 @@ function createStatsRouter(deps) {
 
       const snapshot = await withSlot(() => leaderboardStore.mutate((draft) => {
         const existing = draft.profiles.find(
-          (profile) => profile.name.toLowerCase() === profileName.toLowerCase()
+          // NFC-normalize the persisted side too — older rows written
+          // before the normalize-on-write fix may be in NFD form, so
+          // a fresh NFC submission of the visually-identical name
+          // would create a duplicate without this. The fresh
+          // profileName is already NFC via normalizeProfileNameInput.
+          // Codex P2 on PR #180.
+          (profile) => profile.name.normalize("NFC").toLowerCase() === profileName.toLowerCase()
         );
         if (existing) {
           createdProfileId = existing.id;

--- a/scripts/build-assets.js
+++ b/scripts/build-assets.js
@@ -8,8 +8,21 @@ const distDir = path.join(publicDir, "dist");
 const adminDir = path.join(publicDir, "admin");
 const distAdminDir = path.join(distDir, "admin");
 
-fs.rmSync(distDir, { recursive: true, force: true });
-fs.mkdirSync(distDir, { recursive: true });
+// Wipe dist/ but PRESERVE vendor/ — it's the one subdir of public/dist
+// that's committed to git (chart.umd.min.js et al, see .gitignore's
+// `!public/dist/vendor/`). A blanket rmSync would delete those tracked
+// files and dirty the working tree on every build, which previously
+// happened. The /dist/vendor express mount in server.js reads from
+// PUBLIC_ROOT/dist/vendor regardless of dist mode, so the directory
+// must continue to exist.
+if (fs.existsSync(distDir)) {
+  for (const entry of fs.readdirSync(distDir)) {
+    if (entry === "vendor") continue;
+    fs.rmSync(path.join(distDir, entry), { recursive: true, force: true });
+  }
+} else {
+  fs.mkdirSync(distDir, { recursive: true });
+}
 fs.mkdirSync(distAdminDir, { recursive: true });
 
 async function build() {
@@ -53,6 +66,17 @@ async function build() {
   // to ship them alongside the minified app.js. Without this, any
   // /js/*.js URL 404s in dist mode. Codex P1 on PR #180 (#174).
   fs.cpSync(path.join(publicDir, "js"), path.join(distDir, "js"), { recursive: true });
+
+  // Copy PWA assets: the service worker, web app manifest, and icon
+  // set. PUBLIC_PATH flips to public/dist when dist/index.html exists,
+  // so the express.static mount at server.js:3562 will 404 any of
+  // these if they aren't present in dist — breaking PWA install on
+  // production (Vercel) and the pwa.test.js suite locally. Codex P2
+  // on PR #180 about the new pickRandomName precache only matters
+  // if sw.js itself reaches dist, so this copy was always required.
+  fs.copyFileSync(path.join(publicDir, "sw.js"), path.join(distDir, "sw.js"));
+  fs.copyFileSync(path.join(publicDir, "manifest.json"), path.join(distDir, "manifest.json"));
+  fs.cpSync(path.join(publicDir, "icons"), path.join(distDir, "icons"), { recursive: true });
 }
 
 build().catch((err) => {

--- a/scripts/build-assets.js
+++ b/scripts/build-assets.js
@@ -45,6 +45,14 @@ async function build() {
 
   fs.copyFileSync(path.join(publicDir, "index.html"), path.join(distDir, "index.html"));
   fs.copyFileSync(path.join(adminDir, "index.html"), path.join(distAdminDir, "index.html"));
+
+  // Copy public/js/ verbatim — these are UMD-style helper scripts
+  // (escape-html.js, i18n.js, random-name.js) loaded by `<script>`
+  // tags in index.html. They're not bundled into app.js because each
+  // is independently re-usable; the build pipeline therefore needs
+  // to ship them alongside the minified app.js. Without this, any
+  // /js/*.js URL 404s in dist mode. Codex P1 on PR #180 (#174).
+  fs.cpSync(path.join(publicDir, "js"), path.join(distDir, "js"), { recursive: true });
 }
 
 build().catch((err) => {

--- a/scripts/build-assets.js
+++ b/scripts/build-assets.js
@@ -77,6 +77,18 @@ async function build() {
   fs.copyFileSync(path.join(publicDir, "sw.js"), path.join(distDir, "sw.js"));
   fs.copyFileSync(path.join(publicDir, "manifest.json"), path.join(distDir, "manifest.json"));
   fs.cpSync(path.join(publicDir, "icons"), path.join(distDir, "icons"), { recursive: true });
+
+  // Warn if dist/vendor is missing — those are tracked runtime assets
+  // (chart.umd.min.js et al, see .gitignore's `!public/dist/vendor/`)
+  // served via the `/dist/vendor` express mount in server.js. If a
+  // user wipes public/dist before building (e.g. `rm -rf public/dist
+  // && npm run build`), vendor won't be re-created and the admin
+  // shell's chart will 404. Caught by Copilot on PR #180.
+  if (!fs.existsSync(path.join(distDir, "vendor"))) {
+    console.warn(
+      "WARN: public/dist/vendor/ is missing. Run `git checkout -- public/dist/vendor/` to restore the tracked vendor bundles before serving."
+    );
+  }
 }
 
 build().catch((err) => {

--- a/server.js
+++ b/server.js
@@ -2411,12 +2411,14 @@ function normalizeProfileNameInput(rawName) {
   // tabs / newlines survive trim() and get rejected by NAME_PATTERN
   // rather than silently collapsing to a valid space.
   //
-  // Length cap uses `cleaned.length` (UTF-16 code units) to match
-  // HTML `maxlength="32"`, `data/leaderboard.schema.json`
-  // `maxLength: 32`, and the shared validator's internal check.
-  // NAME_PATTERN's `{0,31}` codepoint quantifier (under /u) adds a
-  // character-class anchor but is the looser of the two — UTF-16
-  // length is the binding constraint for astral-plane characters.
+  // Length cap uses `Array.from(cleaned).length` (Unicode codepoints)
+  // to match the validator's regex `{0,31}` codepoint quantifier and
+  // the JSON-schema `maxLength: 32` on stored data (both codepoints).
+  // Bare `.length` is UTF-16 code units — using it here would reject
+  // valid astral-plane names that the schema accepts, causing silent
+  // drops on backup-restore. Codex P2 on PR #180. The HTML
+  // `maxlength="32"` UI cap is UTF-16 (tighter for astral typing,
+  // intentional UI choice — see lib/profile-name.js comment).
   //
   // NFC-normalize so `José` (composed) and `José` (decomposed `e` +
   // combining-acute) produce identical bytes for storage and the
@@ -2427,13 +2429,9 @@ function normalizeProfileNameInput(rawName) {
   if (!cleaned) {
     throw new StatsApiError(400, "Player name is required.");
   }
-  if (cleaned.length > NAME_LENGTH_MAX) {
-    // UTF-16 code units, matching `data/leaderboard.schema.json`'s
-    // `maxLength: 32`. The validator's `isValidProfileName` also
-    // checks this internally; the early throw here surfaces a
-    // length-specific 400 message instead of the generic
-    // "letters/spaces/apostrophes/hyphens" one from the regex
-    // branch below.
+  if (Array.from(cleaned).length > NAME_LENGTH_MAX) {
+    // Codepoint cap, matching `isValidProfileName` and JSON schema.
+    // Surfaces a length-specific 400 before the generic regex error.
     throw new StatsApiError(400, `Player name must be ${NAME_LENGTH_MAX} characters or fewer.`);
   }
   if (!isValidProfileName(cleaned)) {

--- a/server.js
+++ b/server.js
@@ -6,11 +6,11 @@ const nodeCrypto = require("node:crypto");
 const compression = require("compression");
 const helmet = require("helmet");
 const rateLimit = require("express-rate-limit");
+const { NAME_LENGTH_MAX, isValidProfileName } = require("./lib/profile-name");
 const {
   LeaderboardStore,
   LeaderboardStoreError,
-  parseDailyKey,
-  PROFILE_NAME_PATTERN
+  parseDailyKey
 } = require("./lib/leaderboard-store");
 const { AdminJobsStore } = require("./lib/admin-jobs-store");
 const { ClassesStore, ClassesStoreError } = require("./lib/classes-store");
@@ -2407,14 +2407,18 @@ class StatsApiError extends Error {
 }
 
 function normalizeProfileNameInput(rawName) {
+  // Single-space normalization first (collapses any internal runs of
+  // whitespace into one ASCII space — matches what NAME_PATTERN
+  // actually allows). Then validate via the shared rule from
+  // lib/profile-name.js (issue #174).
   const cleaned = String(rawName || "").trim().replace(/\s+/g, " ");
   if (!cleaned) {
     throw new StatsApiError(400, "Player name is required.");
   }
-  if (cleaned.length > 24) {
-    throw new StatsApiError(400, "Player name must be 24 characters or fewer.");
+  if (cleaned.length > NAME_LENGTH_MAX) {
+    throw new StatsApiError(400, `Player name must be ${NAME_LENGTH_MAX} characters or fewer.`);
   }
-  if (!PROFILE_NAME_PATTERN.test(cleaned)) {
+  if (!isValidProfileName(cleaned)) {
     throw new StatsApiError(
       400,
       "Player name must start with a letter and use only letters, spaces, apostrophes, or hyphens."

--- a/server.js
+++ b/server.js
@@ -2407,15 +2407,19 @@ class StatsApiError extends Error {
 }
 
 function normalizeProfileNameInput(rawName) {
-  // Single-space normalization first (collapses any internal runs of
-  // whitespace into one ASCII space — matches what NAME_PATTERN
-  // actually allows). Then validate via the shared rule from
-  // lib/profile-name.js (issue #174).
-  const cleaned = String(rawName || "").trim().replace(/\s+/g, " ");
+  // Collapse only LITERAL spaces (not all whitespace) so embedded
+  // tabs / newlines survive trim() and get rejected by NAME_PATTERN
+  // rather than silently collapsing to a valid space. Length check
+  // uses Array.from(...).length to count Unicode codepoints — bare
+  // `.length` returns UTF-16 units, which would over-count any
+  // astral-plane letter (e.g. a CJK Extension B character) and
+  // reject a name that NAME_PATTERN's `{0,31}` codepoint quantifier
+  // would accept. Codex/Copilot review on PR #180.
+  const cleaned = String(rawName || "").trim().replace(/ +/g, " ");
   if (!cleaned) {
     throw new StatsApiError(400, "Player name is required.");
   }
-  if (cleaned.length > NAME_LENGTH_MAX) {
+  if (Array.from(cleaned).length > NAME_LENGTH_MAX) {
     throw new StatsApiError(400, `Player name must be ${NAME_LENGTH_MAX} characters or fewer.`);
   }
   if (!isValidProfileName(cleaned)) {

--- a/server.js
+++ b/server.js
@@ -2425,7 +2425,13 @@ function normalizeProfileNameInput(rawName) {
   if (!cleaned) {
     throw new StatsApiError(400, "Player name is required.");
   }
-  if (Array.from(cleaned).length > NAME_LENGTH_MAX) {
+  if (cleaned.length > NAME_LENGTH_MAX) {
+    // UTF-16 code units, matching `data/leaderboard.schema.json`'s
+    // `maxLength: 32`. The validator's `isValidProfileName` also
+    // checks this internally; the early throw here surfaces a
+    // length-specific 400 message instead of the generic
+    // "letters/spaces/apostrophes/hyphens" one from the regex
+    // branch below.
     throw new StatsApiError(400, `Player name must be ${NAME_LENGTH_MAX} characters or fewer.`);
   }
   if (!isValidProfileName(cleaned)) {

--- a/server.js
+++ b/server.js
@@ -2409,12 +2409,14 @@ class StatsApiError extends Error {
 function normalizeProfileNameInput(rawName) {
   // Collapse only LITERAL spaces (not all whitespace) so embedded
   // tabs / newlines survive trim() and get rejected by NAME_PATTERN
-  // rather than silently collapsing to a valid space. Length check
-  // uses Array.from(...).length to count Unicode codepoints — bare
-  // `.length` returns UTF-16 units, which would over-count any
-  // astral-plane letter (e.g. a CJK Extension B character) and
-  // reject a name that NAME_PATTERN's `{0,31}` codepoint quantifier
-  // would accept.
+  // rather than silently collapsing to a valid space.
+  //
+  // Length cap uses `cleaned.length` (UTF-16 code units) to match
+  // HTML `maxlength="32"`, `data/leaderboard.schema.json`
+  // `maxLength: 32`, and the shared validator's internal check.
+  // NAME_PATTERN's `{0,31}` codepoint quantifier (under /u) adds a
+  // character-class anchor but is the looser of the two — UTF-16
+  // length is the binding constraint for astral-plane characters.
   //
   // NFC-normalize so `José` (composed) and `José` (decomposed `e` +
   // combining-acute) produce identical bytes for storage and the

--- a/server.js
+++ b/server.js
@@ -2414,8 +2414,14 @@ function normalizeProfileNameInput(rawName) {
   // `.length` returns UTF-16 units, which would over-count any
   // astral-plane letter (e.g. a CJK Extension B character) and
   // reject a name that NAME_PATTERN's `{0,31}` codepoint quantifier
-  // would accept. Codex/Copilot review on PR #180.
-  const cleaned = String(rawName || "").trim().replace(/ +/g, " ");
+  // would accept.
+  //
+  // NFC-normalize so `José` (composed) and `José` (decomposed `e` +
+  // combining-acute) produce identical bytes for storage and the
+  // case-insensitive dedup comparison in routes/stats.js. Without
+  // this, two visually-identical names create two profile rows.
+  // Codex/Copilot review on PR #180.
+  const cleaned = String(rawName || "").trim().replace(/ +/g, " ").normalize("NFC");
   if (!cleaned) {
     throw new StatsApiError(400, "Player name is required.");
   }

--- a/tests/challenge-config-store.concurrency.test.js
+++ b/tests/challenge-config-store.concurrency.test.js
@@ -327,7 +327,9 @@ describe("challenge-config-store: admin-vs-user TOCTOU contract", () => {
           result: await resultsStore.createSession({
             challengeId,
             profileId: `user-${i}`,
-            profileName: `User${i}`,
+            // Letter-suffix instead of `User${i}` — the unified
+            // profile-name validator (issue #174) rejects digits.
+            profileName: `User ${String.fromCharCode(65 + (i % 26))}`,
             puzzles: [
               { index: 0, word: "ALPHA", guesses: [], solved: false }
             ]

--- a/tests/challenge-results-store.concurrency.test.js
+++ b/tests/challenge-results-store.concurrency.test.js
@@ -156,7 +156,9 @@ describe("challenge-results-store: single-in-flight invariant under concurrency"
         store.createSession({
           challengeId: makeChallengeId(),
           profileId: `p-${i}`,
-          profileName: `Tester${i}`,
+          // Letter-suffix instead of `Tester${i}` — the unified
+          // profile-name validator (issue #174) rejects digits.
+          profileName: `Tester ${String.fromCharCode(65 + (i % 26))}`,
           puzzles: basePuzzles()
         }),
       invariants: [

--- a/tests/helpers/arbitraries.js
+++ b/tests/helpers/arbitraries.js
@@ -123,12 +123,18 @@ const classId = stringFromPool([...HEX_LOWER, "-"], 12, 32).map(
   (body) => `class-${body}`
 );
 
-// Leaderboard profile name. Schema: `^[A-Za-z][A-Za-z '\\-]*$`,
-// max 24 chars. Start with a letter then letters/spaces/hyphens/quotes.
-// Codex P2 PR #133 round 3 caught that names ending in a space pass
-// the schema but `normalizeProfile` trims and rejects when
-// `raw !== trimmed`. We anchor the LAST char to be non-space too —
-// the middle can have spaces/hyphens/quotes freely.
+// Leaderboard profile name. Schema (post-#174):
+// `^\\p{L}[\\p{L}\\p{M}' \\-]{0,31}$`, max 64 UTF-16 units (≤ 32
+// codepoints). Start with a Unicode letter then letters / combining
+// marks / spaces / hyphens / apostrophes. We restrict the arbitrary
+// to ASCII letters here (subset of valid inputs) for generation
+// stability and shrinking; the Unicode acceptance is pinned by the
+// dedicated lib/profile-name validator tests in
+// tests/profile-name.test.js. Codex P2 PR #133 round 3 caught that
+// names ending in a space pass the schema but `normalizeProfile`
+// trims and rejects when `raw !== trimmed`. We anchor the LAST char
+// to be non-space too — the middle can have spaces/hyphens/quotes
+// freely.
 const NAME_LETTERS = [
   ..."ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 ];
@@ -136,7 +142,7 @@ const NAME_MIDDLE_CHARS = [...NAME_LETTERS, " ", "'", "-"];
 const leaderboardProfileName = fc
   .tuple(
     fc.constantFrom(...NAME_LETTERS),
-    stringFromPool(NAME_MIDDLE_CHARS, 0, 22),
+    stringFromPool(NAME_MIDDLE_CHARS, 0, 30),
     fc.constantFrom(...NAME_LETTERS)
   )
   .map(([first, middle, last]) => `${first}${middle}${last}`);
@@ -516,7 +522,8 @@ const classesState = fc
 // Per data/leaderboard.schema.json (Copilot PR #133 caught the prior
 // generator's missing `updatedAt` and over-permissive `name`):
 //   - profiles entries require id, name, createdAt, updatedAt
-//   - name pattern `^[A-Za-z][A-Za-z '\\-]*$`, max 24 chars
+//   - name pattern `^\\p{L}[\\p{L}\\p{M}' \\-]{0,31}$`,
+//     max 64 UTF-16 units (≤ 32 codepoints, PR #180 / issue #174)
 //   - resultsByProfile is a map of profileId -> { dateKey -> result }
 //
 // Each per-date result entry must satisfy the schema's allOf

--- a/tests/helpers/arbitraries.js
+++ b/tests/helpers/arbitraries.js
@@ -124,10 +124,12 @@ const classId = stringFromPool([...HEX_LOWER, "-"], 12, 32).map(
 );
 
 // Leaderboard profile name. Schema (post-#174):
-// `^\\p{L}[\\p{L}\\p{M}' \\-]{0,31}$`, max 64 UTF-16 units (≤ 32
-// codepoints). Start with a Unicode letter then letters / combining
-// marks / spaces / hyphens / apostrophes. We restrict the arbitrary
-// to ASCII letters here (subset of valid inputs) for generation
+// `^\\p{L}[\\p{L}\\p{M}' \\-]{0,31}$`, max 32 UTF-16 units (matches
+// HTML maxlength and the validator's `name.length <= 32` check). The
+// validator's regex quantifier `{0,31}` under /u counts codepoints
+// (redundant for BMP-only input; UTF-16 cap is the binding
+// constraint for astral characters). We restrict the arbitrary to
+// ASCII letters here (subset of valid inputs) for generation
 // stability and shrinking; the Unicode acceptance is pinned by the
 // dedicated lib/profile-name validator tests in
 // tests/profile-name.test.js. Codex P2 PR #133 round 3 caught that
@@ -523,7 +525,7 @@ const classesState = fc
 // generator's missing `updatedAt` and over-permissive `name`):
 //   - profiles entries require id, name, createdAt, updatedAt
 //   - name pattern `^\\p{L}[\\p{L}\\p{M}' \\-]{0,31}$`,
-//     max 64 UTF-16 units (≤ 32 codepoints, PR #180 / issue #174)
+//     max 32 UTF-16 units (PR #180 / issue #174)
 //   - resultsByProfile is a map of profileId -> { dateKey -> result }
 //
 // Each per-date result entry must satisfy the schema's allOf

--- a/tests/profile-name.test.js
+++ b/tests/profile-name.test.js
@@ -172,4 +172,31 @@ describe("profile-name validator", () => {
       expect(nfcJose.normalize("NFC")).toBe(nfdJose.normalize("NFC"));
     });
   });
+
+  describe("UTF-16 length cap (codepoint vs UTF-16 disagreement)", () => {
+    // The validator caps at 32 UTF-16 code units (matches HTML
+    // `maxlength="32"` and `data/leaderboard.schema.json`'s
+    // `maxLength: 32`). The regex quantifier `{0,31}` under /u counts
+    // codepoints, which is the redundant looser check for BMP input
+    // and a no-op constraint relative to UTF-16 for astral input.
+    // Pinned here because the only practical case where the two
+    // disagree is supplementary-plane (astral) letters.
+
+    test("17 astral letters (17 codepoints, 34 UTF-16) rejected", () => {
+      // U+20BB7 (𠮷, CJK UNIFIED IDEOGRAPH-20BB7) is `\p{L}` and a
+      // single supplementary-plane codepoint = 2 UTF-16 units.
+      const astralLetter = String.fromCodePoint(0x20BB7);
+      const name17astral = astralLetter.repeat(17);
+      expect(Array.from(name17astral).length).toBe(17);
+      expect(name17astral.length).toBe(34);
+      expect(isValidProfileName(name17astral)).toBe(false);
+    });
+
+    test("16 astral letters (16 codepoints, 32 UTF-16) accepted", () => {
+      const astralLetter = String.fromCodePoint(0x20BB7);
+      const name16astral = astralLetter.repeat(16);
+      expect(name16astral.length).toBe(32);
+      expect(isValidProfileName(name16astral)).toBe(true);
+    });
+  });
 });

--- a/tests/profile-name.test.js
+++ b/tests/profile-name.test.js
@@ -39,13 +39,12 @@ describe("profile-name validator", () => {
       "अनिता",
       // Min length 1
       "X",
-      // Exactly 32 codepoints (the regex cap)
+      // Exactly 32 chars (the cap), BMP-only so codepoint count
+      // and UTF-16 code unit count coincide.
       "A" + "b".repeat(31),
-      // Astral-plane letter (CJK Extension B). `.length` for this
-      // single character is 2 (UTF-16 surrogate pair) but it's one
-      // codepoint — the validator must use the regex (which counts
-      // codepoints in /u mode) and not bare `.length` for the cap.
-      // 𠀀 = U+20000 = "𠀀".
+      // Single astral-plane letter (CJK Extension B, 1 codepoint =
+      // 2 UTF-16 units, under both caps).
+      // 𠀀 = U+20000.
       "𠀀",
       // Internal apostrophes
       "O'Brien",
@@ -88,7 +87,7 @@ describe("profile-name validator", () => {
       // Newlines / tabs (regex only allows space among whitespace)
       "Alice\nBob",
       "Alice\tBob",
-      // Over the 32-codepoint cap
+      // Over the 32-char cap (33 BMP letters = 33 UTF-16 units)
       "A" + "b".repeat(32),
       // Way over
       "A".repeat(100)

--- a/tests/profile-name.test.js
+++ b/tests/profile-name.test.js
@@ -151,4 +151,25 @@ describe("profile-name validator", () => {
       }
     });
   });
+
+  describe("NFC normalization contract", () => {
+    // The dedup comparison in routes/stats.js is case-insensitive but
+    // not Unicode-aware, so `José` (NFC: "José") and `José` (NFD:
+    // "José") would create duplicate profile rows unless
+    // both forms are normalized to NFC before write/compare. Codex P2
+    // on PR #180. Tests pin both the validator's form-agnostic accept
+    // behavior and the NFC equivalence callers rely on.
+    const nfcJose = "José";
+    const nfdJose = "José";
+
+    test("both NFC and NFD `José` pass isValidProfileName", () => {
+      expect(isValidProfileName(nfcJose)).toBe(true);
+      expect(isValidProfileName(nfdJose)).toBe(true);
+    });
+
+    test("NFC and NFD `José` render identically but differ in bytes", () => {
+      expect(nfcJose).not.toBe(nfdJose);
+      expect(nfcJose.normalize("NFC")).toBe(nfdJose.normalize("NFC"));
+    });
+  });
 });

--- a/tests/profile-name.test.js
+++ b/tests/profile-name.test.js
@@ -172,30 +172,31 @@ describe("profile-name validator", () => {
     });
   });
 
-  describe("UTF-16 length cap (codepoint vs UTF-16 disagreement)", () => {
-    // The validator caps at 32 UTF-16 code units (matches HTML
-    // `maxlength="32"` and `data/leaderboard.schema.json`'s
-    // `maxLength: 32`). The regex quantifier `{0,31}` under /u counts
-    // codepoints, which is the redundant looser check for BMP input
-    // and a no-op constraint relative to UTF-16 for astral input.
-    // Pinned here because the only practical case where the two
-    // disagree is supplementary-plane (astral) letters.
+  describe("codepoint length cap (astral acceptance)", () => {
+    // The validator caps at 32 Unicode codepoints (regex `{0,31}`
+    // under /u). This matches the JSON-schema `maxLength: 32`
+    // (codepoints per spec) so a name accepted here also passes
+    // schema validation on the persisted file — no silent drops on
+    // load. The HTML `maxlength="32"` UI cap is UTF-16 (tighter for
+    // astral typing); astral content > 16 codepoints can only enter
+    // via API or backup-restore, never typed input. Codex P2 on
+    // PR #180 caught the prior UTF-16-cap mismatch.
 
-    test("17 astral letters (17 codepoints, 34 UTF-16) rejected", () => {
+    test("32 astral letters (32 codepoints, 64 UTF-16) accepted", () => {
       // U+20BB7 (𠮷, CJK UNIFIED IDEOGRAPH-20BB7) is `\p{L}` and a
       // single supplementary-plane codepoint = 2 UTF-16 units.
       const astralLetter = String.fromCodePoint(0x20BB7);
-      const name17astral = astralLetter.repeat(17);
-      expect(Array.from(name17astral).length).toBe(17);
-      expect(name17astral.length).toBe(34);
-      expect(isValidProfileName(name17astral)).toBe(false);
+      const name32astral = astralLetter.repeat(32);
+      expect(Array.from(name32astral).length).toBe(32);
+      expect(name32astral.length).toBe(64);
+      expect(isValidProfileName(name32astral)).toBe(true);
     });
 
-    test("16 astral letters (16 codepoints, 32 UTF-16) accepted", () => {
+    test("33 astral letters (33 codepoints, 66 UTF-16) rejected", () => {
       const astralLetter = String.fromCodePoint(0x20BB7);
-      const name16astral = astralLetter.repeat(16);
-      expect(name16astral.length).toBe(32);
-      expect(isValidProfileName(name16astral)).toBe(true);
+      const name33astral = astralLetter.repeat(33);
+      expect(Array.from(name33astral).length).toBe(33);
+      expect(isValidProfileName(name33astral)).toBe(false);
     });
   });
 });

--- a/tests/profile-name.test.js
+++ b/tests/profile-name.test.js
@@ -1,0 +1,105 @@
+"use strict";
+
+// Unit tests for the shared profile-name validator (issue #174).
+// The validator is now imported by both `lib/leaderboard-store.js`
+// and `routes/challenges.js` + `lib/challenge-results-store.js`, so
+// any change to its accept/reject behavior would break both paths
+// uniformly — these tests pin the contract.
+
+const {
+  NAME_LENGTH_MAX,
+  NAME_PATTERN,
+  isValidProfileName
+} = require("../lib/profile-name");
+
+describe("profile-name validator", () => {
+  describe("isValidProfileName: accepts", () => {
+    const accepted = [
+      // English first names
+      "Alice",
+      "Bob",
+      "Mary",
+      // Compound and hyphenated names
+      "Mary-Jane",
+      "Mary Jane",
+      "Mary-Jane O'Brien",
+      "Jean-Luc",
+      // International / Unicode letters
+      "José",
+      "Pavlína",
+      "García",
+      "Müller",
+      "Łukasz",
+      // CJK
+      "李明",
+      "山田",
+      // Arabic
+      "محمد",
+      // Devanagari (Indic)
+      "अनिता",
+      // Min length 1
+      "X",
+      // Exactly 32 codepoints (the regex cap)
+      "A" + "b".repeat(31),
+      // Internal apostrophes
+      "O'Brien",
+      "D'Angelo",
+      // Multi-word names
+      "Anne Marie",
+      "Van Der Berg"
+    ];
+    test.each(accepted)("accepts %p", (name) => {
+      expect(isValidProfileName(name)).toBe(true);
+    });
+  });
+
+  describe("isValidProfileName: rejects", () => {
+    const rejected = [
+      // Empty / non-string
+      "",
+      null,
+      undefined,
+      42,
+      // Leading whitespace / hyphen / apostrophe (must start with letter)
+      " Alice",
+      "-Mary",
+      "'Pat",
+      // Digits
+      "Alice123",
+      "Bob2",
+      "1Mary",
+      // Symbols
+      "Alice!",
+      "Bob<script>",
+      "Mary&Pat",
+      "Alice@home",
+      "Alice/Bob",
+      // Emojis
+      "🎉",
+      "Alice🎉",
+      // Underscores
+      "Alice_Bob",
+      // Newlines / tabs (regex only allows space among whitespace)
+      "Alice\nBob",
+      "Alice\tBob",
+      // Over the 32-codepoint cap
+      "A" + "b".repeat(32),
+      // Way over
+      "A".repeat(100)
+    ];
+    test.each(rejected)("rejects %p", (name) => {
+      expect(isValidProfileName(name)).toBe(false);
+    });
+  });
+
+  describe("constants", () => {
+    test("NAME_LENGTH_MAX is 32", () => {
+      expect(NAME_LENGTH_MAX).toBe(32);
+    });
+
+    test("NAME_PATTERN is a unicode-mode regex", () => {
+      expect(NAME_PATTERN).toBeInstanceOf(RegExp);
+      expect(NAME_PATTERN.flags).toContain("u");
+    });
+  });
+});

--- a/tests/profile-name.test.js
+++ b/tests/profile-name.test.js
@@ -41,6 +41,12 @@ describe("profile-name validator", () => {
       "X",
       // Exactly 32 codepoints (the regex cap)
       "A" + "b".repeat(31),
+      // Astral-plane letter (CJK Extension B). `.length` for this
+      // single character is 2 (UTF-16 surrogate pair) but it's one
+      // codepoint — the validator must use the regex (which counts
+      // codepoints in /u mode) and not bare `.length` for the cap.
+      // 𠀀 = U+20000 = "𠀀".
+      "𠀀",
       // Internal apostrophes
       "O'Brien",
       "D'Angelo",

--- a/tests/profile-name.test.js
+++ b/tests/profile-name.test.js
@@ -108,4 +108,47 @@ describe("profile-name validator", () => {
       expect(NAME_PATTERN.flags).toContain("u");
     });
   });
+
+  // Contract test for the client-side default-name generator. A bad
+  // adjective or animal edit (introducing a digit, accent the regex
+  // doesn't allow, etc.) would silently ship a default name that
+  // gets rejected on submit. This test pins the invariant: every
+  // single token must pass on its own, every Adjective × Animal
+  // cross-product must pass, and a random sample of 1000
+  // pickRandomName() calls must always pass.
+  describe("pickRandomName contract", () => {
+    const {
+      RANDOM_NAME_ADJECTIVES,
+      RANDOM_NAME_ANIMALS,
+      pickRandomName
+    } = require("../public/js/random-name");
+
+    test("every adjective passes isValidProfileName", () => {
+      RANDOM_NAME_ADJECTIVES.forEach((adj) => {
+        expect(isValidProfileName(adj)).toBe(true);
+      });
+    });
+
+    test("every animal passes isValidProfileName", () => {
+      RANDOM_NAME_ANIMALS.forEach((animal) => {
+        expect(isValidProfileName(animal)).toBe(true);
+      });
+    });
+
+    test("every Adjective × Animal combination passes isValidProfileName", () => {
+      RANDOM_NAME_ADJECTIVES.forEach((adj) => {
+        RANDOM_NAME_ANIMALS.forEach((animal) => {
+          const name = `${adj} ${animal}`;
+          expect(isValidProfileName(name)).toBe(true);
+        });
+      });
+    });
+
+    test("1000 pickRandomName() draws all pass isValidProfileName", () => {
+      for (let i = 0; i < 1000; i += 1) {
+        const name = pickRandomName();
+        expect(isValidProfileName(name)).toBe(true);
+      }
+    });
+  });
 });


### PR DESCRIPTION
Closes #174.

Sub-issue of #163. Option C from the design discussion: unified Unicode-aware validator + Adjective+Animal default name generator.

## Shared validator

New `lib/profile-name.js`:

```js
const NAME_LENGTH_MAX = 32;
const NAME_PATTERN = /^\p{L}[\p{L}\p{M}' -]{0,31}$/u;
function isValidProfileName(name) { ... }
```

- First char: any Unicode letter (`\p{L}`)
- Remaining 0-31 chars: letters, combining marks (for decomposed accents like `é = e + ́`), apostrophes, internal spaces, hyphens
- No digits, no symbols, no emojis, no newlines/tabs
- Total length 1-32 codepoints (regex anchors enforce both)

## Server callers wired through the new module

| File | Before | After |
|---|---|---|
| `lib/leaderboard-store.js` | `name.length > 24` + `/^[A-Za-z][A-Za-z '-]*$/` (rejected `José`, `李明`, `Mary-Jane O'Brien`) | `isValidProfileName` + 32 cap |
| `routes/challenges.js:107` | `length >= 1 && length <= 64`, no regex | `isValidProfileName` |
| `lib/challenge-results-store.js` (×2 callsites) | same loose check | `isValidProfileName` |
| `server.js:2417` (`normalizeProfileNameInput` for `POST /api/stats/profile`) | local `PROFILE_NAME_PATTERN` import + 24-char cap | `isValidProfileName` + `NAME_LENGTH_MAX` |

The old `PROFILE_NAME_PATTERN` export on `leaderboard-store.js` is removed (nothing else consumed it).

**Net result:** one validator definition; every server entry point that accepts a name applies the same rule.

## Client changes

- `public/index.html`: `maxlength="24"` and `maxlength="64"` both → `maxlength="32"`.
- `public/app.js`:
  - `RANDOM_NAME_ADJECTIVES` (28 entries) + `RANDOM_NAME_ANIMALS` (28 entries) + `pickRandomName()` returning `"<Adjective> <Animal>"` (e.g. `"Brave Falcon"`, `"Quiet Otter"`). All **784 combinations** pass `NAME_PATTERN` by construction (ASCII letters + single internal space, well under 32 codepoints).
  - `#challengeProfileInput` prefills from localStorage if present, otherwise from `pickRandomName()` (persisted on first roll so a refresh shows the same name; user can edit freely).
  - `#profileNameInput` prefills from `pickRandomName()` if empty (not persisted — the play form uses multi-profile semantics, this is just a typing-into starting point).
  - `setChallengeProfileName` truncation `.slice(0, 64)` → `.slice(0, 32)`.

## Tests

New `tests/profile-name.test.js` — **46 tests**:

**Accepts:** `Alice`, `Bob`, `Mary-Jane O'Brien`, `José`, `Pavlína`, `García`, `Müller`, `Łukasz`, `李明`, `山田`, `محمد`, `अनिता`, single-letter (`X`), 32-codepoint boundary, internal apostrophes, multi-word names.

**Rejects:** empty/null/undefined/number, leading space/hyphen/apostrophe, digits (`Alice123`, `1Mary`), symbols (`!`, `<`, `&`, `@`, `/`), emojis (`🎉`), underscores, newlines/tabs, over-cap (33+ chars), way-over (100 chars).

## Verification

- **Full Jest: 67 suites, 1157 passed, 1 skipped, 0 failed** (the 1 skip is `tests/server.test.js:2686` — intentionally skipped when running as root, pre-existing).
- Playwright `tests/ui/{create-play, stats-backend, xss-lockin}.spec.js` → **26/26**
- `scripts/i18n-coverage.js` ✓
- `npm run schema:check` ✓
- `npm run markdown:check` ✓
- `tests/profile-name.test.js` → **46/46**

## Out of scope (deferred)

- **Localized adjective/animal lists** (Spanish, etc.) — first cut is ASCII-only English; localization is a follow-up.
- **Migrating > 32-char data** — no current deployment, no data exists yet.
- **Profanity filtering** on the adjective/animal lists — curated lists are small enough to vet by hand at PR time.

## Diff

`+216 / -19` across 7 files + 2 new (`lib/profile-name.js`, `tests/profile-name.test.js`).

Single source of truth for the name rule across the entire product.

https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q4czvgwDddthLPDRb83YX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a random adjective‑animal name generator; empty profile fields are auto-filled (challenge names persist locally; other flows do not persist defaults).

* **Bug Fixes**
  * Client/server profile-name validation unified and enforced at request boundaries; clearer, specific error responses; names capped to 32 characters and trimming/space rules tightened; explicit handling to clear profile names.

* **Refactor**
  * Consolidated profile-name rules into a shared, Unicode-aware validator.

* **Tests**
  * Expanded validator tests, boundary checks, random-name invariants, and updated concurrency expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/180)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->