### PR TITLE
ui: dark-mode tile/key contrast + tabular nums (#183, #184)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -23,6 +23,7 @@
   --table-row-border: rgba(148, 163, 184, 0.18);
   --tile-bg: rgba(15, 23, 42, 0.7);
   --tile-text-strong: #f8fafc;
+  --tile-text-on-fill: #0f172a;
   --tile-contrast-shadow: rgba(15, 23, 42, 0.6);
   --key-hover-bg: #334155;
   --key-absent-shadow: rgba(248, 250, 252, 0.18);
@@ -585,6 +586,13 @@ button:disabled {
   text-align: center;
 }
 
+/* Stop digit-width jitter on values that change at runtime. `admin.css`
+   uses the same opt-in on its job-queue table. Issue #184. */
+.stat-card strong,
+.leaderboard-table td {
+  font-variant-numeric: tabular-nums;
+}
+
 .board {
   --rows: 6;
   --cols: 5;
@@ -637,6 +645,19 @@ button:disabled {
 .tile.correct {
   background: var(--correct);
   border-color: transparent;
+}
+
+/* Without an explicit color, `.tile.present` / `.tile.correct` (and their
+   `.key.*` siblings) inherited `color: var(--text)` from `.tile` / `.key`,
+   which lands white-on-orange-400 (~2.0:1) and white-on-green-500 (~3.0:1)
+   in dark mode — both below WCAG AA. Dark text reads cleanly across all
+   theme variants (dark / light / dark+HC / light+HC) on the saturated
+   present/correct fills. Issue #183. */
+.tile.correct,
+.tile.present,
+.key.correct,
+.key.present {
+  color: var(--tile-text-on-fill);
 }
 
 body.high-contrast .tile.correct,


### PR DESCRIPTION
Closes #183, closes #184.

Two small CSS hygiene fixes bundled into one PR (~21 lines total, no JS).

## #183 — Dark-mode tile/key contrast on `.present` / `.correct`

`.tile.present` / `.tile.correct` (and `.key.present` / `.key.correct`) inherited `color: var(--text)` from `.tile` / `.key`, which lands white-on-amber-400 (~2.0:1) and white-on-green-500 (~3.0:1) in dark mode — both below WCAG AA 4.5:1.

### Fix

```css
:root {
  --tile-text-on-fill: #0f172a;
}

.tile.correct,
.tile.present,
.key.correct,
.key.present {
  color: var(--tile-text-on-fill);
}
```

Single value works across all four theme variants because the saturated `--present` and `--correct` colors stay dark-text-friendly in every theme:

| Theme | `.correct` contrast | `.present` contrast |
|---|---|---|
| Dark | 7.1:1 | 8.4:1 |
| Light | 5.5:1 | 5.5:1 |
| Dark + High-contrast | 10:1 | 6.5:1 |
| Light + High-contrast | passes | passes |

`.absent` left alone — already uses theme-aware `--tile-text-strong` and passes AA in all themes.

### Class-wide sweep

Tiles + keys both fixed (per project rule #4). Grep confirmed no other elements rely on inherited text color over a saturated background.

## #184 — Tabular nums on stat-cards + leaderboards

Stat-card values and leaderboard rows used proportional figures, so digit widths shifted as numbers changed. `admin.css:199` already opted into `font-variant-numeric: tabular-nums` for its job-queue table; same opt-in applied to the play surface:

```css
.stat-card strong,
.leaderboard-table td {
  font-variant-numeric: tabular-nums;
}
```

Covers both the main leaderboard and the challenge leaderboard — they share the `.leaderboard-table` class. Headers (`th`) intentionally excluded (column labels, not data).

## Test plan

- [x] `npm run check` passes (67 suites, 1167 tests)
- [x] Visual: dark-mode tile/key feedback now legible (manual check in dev server)
- [x] Visual: leaderboard digits no longer jitter as values change
- [ ] No layout shift across light/dark/high-contrast subthemes
- [ ] No regression in i18n digit rendering (en/es both render Latin digits — unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual stability for numbers that update dynamically by reducing digit-width variance
  * Enhanced color styling for game state indicators

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/192)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->