### PR TITLE
style: border-radius token scale (#190)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -67,6 +67,15 @@
   --space-xl: 1.5rem;
   --space-2xl: 2rem;
 
+  /* Radius scale (issue #190). Following the #162 precedent: dominant
+     clusters get a token. Singletons (0.4rem breakpoint tile, 0.75rem
+     stat-card, 0.9rem sub-panel, 1rem modal/admin panels) intentionally
+     stay as literals until a second clean use case appears. */
+  --radius-sm: 0.5rem;
+  --radius-md: 0.6rem;
+  --radius-xl: 1.2rem;
+  --radius-pill: 999px;
+
   color-scheme: dark;
 }
 
@@ -161,7 +170,7 @@ html {
   padding: 0.5rem 0.75rem;
   background: var(--accent);
   color: var(--text-on-accent);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm);
   transform: translateY(-200%);
   transition: transform 0.2s ease;
   z-index: 10;
@@ -256,7 +265,7 @@ p {
   background: transparent;
   border: none;
   padding: 0.2rem 0.4rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
 }
 
@@ -270,7 +279,7 @@ p {
   border: 1px solid var(--field-border);
   background: var(--field-bg);
   color: var(--text);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 0.2rem 0.5rem;
   font-size: 0.86rem;
 }
@@ -284,7 +293,7 @@ p {
   border: 1px solid var(--chip-border);
   min-height: var(--touch-target-min);
   padding: 0.6rem 1.2rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   transition: transform 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
@@ -307,7 +316,7 @@ p {
   width: min(56rem, 95vw);
   background: var(--panel-bg);
   border: 1px solid var(--panel-border);
-  border-radius: 1.2rem;
+  border-radius: var(--radius-xl);
   padding: 2rem;
   display: grid;
   gap: var(--space-xl);
@@ -332,7 +341,7 @@ p {
 .create-form input,
 .create-form select {
   padding: 0.6rem 0.8rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--field-border);
   background: var(--field-bg);
   color: var(--text);
@@ -373,7 +382,7 @@ p {
 .admin-form button:not(.ghost) {
   padding: 0.75rem 1rem;
   border: none;
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   background: var(--accent);
   color: var(--text-on-accent);
   font-weight: 700;
@@ -388,7 +397,7 @@ p {
 
 .btn-danger {
   padding: 0.6rem 1rem;
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--danger);
   background: transparent;
   color: var(--danger);
@@ -410,7 +419,7 @@ p {
 
 .ghost {
   padding: 0.6rem 1rem;
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--chip-border);
   background: transparent;
   color: var(--text);
@@ -492,7 +501,7 @@ button:disabled {
 .profile-form input,
 .leaderboard-head select {
   padding: 0.55rem 0.75rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--field-border);
   background: var(--field-bg);
   color: var(--text);
@@ -520,7 +529,7 @@ button:disabled {
 
 .player-chip {
   border: 1px solid var(--chip-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 0.35rem 0.75rem;
   background: var(--chip-bg);
   color: var(--text);
@@ -607,7 +616,7 @@ button:disabled {
   aspect-ratio: 1 / 1;
   max-width: 4rem;
   border: 2px solid var(--tile-border);
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   display: grid;
   place-items: center;
   text-transform: uppercase;
@@ -679,7 +688,7 @@ body.high-contrast .tile.absent {
   flex-shrink: 0;
   padding: 0.7rem 0.3rem;
   border: none;
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   background: var(--bg-accent);
   color: var(--text);
   font-weight: 600;
@@ -742,7 +751,7 @@ body.high-contrast .tile.absent {
 
 .share input {
   padding: 0.6rem 0.8rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--field-border);
   background: var(--field-bg);
   color: var(--text);
@@ -788,7 +797,7 @@ body.high-contrast .key.absent {
   font-size: var(--fs-base);
   min-height: var(--touch-target-min);
   padding: 0.45rem 0.9rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -886,7 +895,7 @@ body.high-contrast .key.absent {
 
 .admin-form input {
   padding: 0.6rem 0.8rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--field-border);
   background: var(--field-bg);
   color: var(--text);
@@ -895,7 +904,7 @@ body.high-contrast .key.absent {
 
 .admin-form select {
   padding: 0.6rem 0.8rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--field-border);
   background: var(--field-bg);
   color: var(--text);
@@ -1193,7 +1202,7 @@ body.high-contrast .key.absent {
   .tile {
     font-size: 1.4rem;
     max-width: 2.8rem;
-    border-radius: 0.5rem;
+    border-radius: var(--radius-sm);
   }
 
   .board {
@@ -1210,7 +1219,7 @@ body.high-contrast .key.absent {
     font-size: 0.8rem;
     min-width: 2.76rem;
     min-height: 2.76rem;
-    border-radius: 0.5rem;
+    border-radius: var(--radius-sm);
   }
 
   .keyboard {


### PR DESCRIPTION
Closes #190.

Mechanical refactor following the #162 fs/space token rollout precedent: dominant clusters get a token, singletons stay as literals until a second clean use appears.

## Tokens introduced

```css
:root {
  --radius-sm: 0.5rem;      /* fields, skip-link, breakpoint tile/key */
  --radius-md: 0.6rem;      /* tiles, keys, all buttons */
  --radius-xl: 1.2rem;      /* main panel */
  --radius-pill: 999px;     /* pills */
}
```

## Migration summary

| Token | Uses migrated | Surface |
|---|---|---|
| `--radius-sm` | 8 | form inputs, skip-link, breakpoint tile/key |
| `--radius-md` | 5 | `.tile`, `.key`, `.btn-primary`, `.btn-danger`, `.ghost` |
| `--radius-xl` | 1 | `.panel` |
| `--radius-pill` | 5 | `.toggle`, `.admin-link`, `.player-chip`, `.link-button`, etc. |
| **Total** | **19 of 26** | |

## Left as literals (deferred per #162 spirit)

| Value | Uses | Element |
|---|---|---|
| 0.4rem | 2 | breakpoint tile/key radii at 320px (responsive scope, may want independent tuning) |
| 0.75rem | 1 | `.stat-card` |
| 0.9rem | 1 | `.profile-panel` / `.leaderboard-panel` |
| 1rem | 3 | `.modal-card`, `.admin-form`, `.admin-current` |

The 1rem cluster (3 uses) is borderline — a follow-up could introduce `--radius-lg: 1rem` if a fourth use case appears or if the existing three need to ratchet together.

## Test plan

- [x] `npm run check` passes (67 suites, 1167 tests)
- [x] Zero visual change verified by diff: only `border-radius:` declarations changed, no shape/size changes
- [x] Pixel-identical rendering — token values match the migrated literals exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized corner radius styling throughout the application interface. Hardcoded border-radius values across buttons, inputs, form fields, tiles, and other components have been replaced with reusable design tokens, improving design consistency and enabling easier future styling updates across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/194)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->