### PR TITLE
ui: playful tile reactions + keyboard :active (#182, #185)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1025,6 +1025,99 @@ function updateKeyboard(result, guess) {
   });
 }
 
+/* ─── Play-surface motion (#182) + key press flash (#185) ──────────────
+   All five animations are gated CSS-side by
+   `prefers-reduced-motion: no-preference`. The JS helpers below mirror
+   that on the trigger side so we don't dangle .is-* classes when the
+   animation won't fire (animationend never reaches us under reduced
+   motion; without this guard the class would stick and break a future
+   re-trigger). Scope: main play board only. Challenge surface is left
+   un-animated for now — same render code, different feature lifecycle;
+   filed as a follow-up rather than dragged into this PR.            */
+const prefersReducedMotionMql = typeof window.matchMedia === "function"
+  ? window.matchMedia("(prefers-reduced-motion: reduce)")
+  : null;
+
+function shouldAnimate() {
+  return !(prefersReducedMotionMql && prefersReducedMotionMql.matches);
+}
+
+function triggerOneShotAnim(el, className) {
+  if (!el || !shouldAnimate()) return;
+  /* Remove + force reflow + re-add so a second trigger on the same
+     element (e.g. pop on letter, pop on backspace of that letter)
+     restarts the animation cleanly. */
+  el.classList.remove(className);
+  void el.offsetWidth;
+  el.classList.add(className);
+  const onEnd = () => {
+    el.classList.remove(className);
+    el.removeEventListener("animationend", onEnd);
+    el.removeEventListener("animationcancel", onEnd);
+  };
+  el.addEventListener("animationend", onEnd);
+  el.addEventListener("animationcancel", onEnd);
+}
+
+function triggerRowReveal(row, onSolveComplete) {
+  /* Under reduced motion: skip the animation, but still fire the win
+     chain immediately so callers can rely on it. Without this, a solve
+     under reduced-motion would never get the post-reveal hook. */
+  if (!shouldAnimate()) {
+    if (onSolveComplete) onSolveComplete();
+    return;
+  }
+  let lastTile = null;
+  for (let col = 0; col < cols; col += 1) {
+    const tile = getTile(row, col);
+    if (!tile) continue;
+    tile.style.setProperty("--col", String(col));
+    triggerOneShotAnim(tile, "is-reveal");
+    if (col === cols - 1) lastTile = tile;
+  }
+  if (onSolveComplete && lastTile) {
+    const chain = () => {
+      lastTile.removeEventListener("animationend", chain);
+      onSolveComplete();
+    };
+    lastTile.addEventListener("animationend", chain);
+  }
+}
+
+function triggerRowShake(row) {
+  /* Reach the `.row` parent via tile 0. Cheaper than a `:nth-child`
+     query and survives any future restructuring of the board grid. */
+  const tile = getTile(row, 0);
+  const rowEl = tile ? tile.parentElement : null;
+  triggerOneShotAnim(rowEl, "is-shake");
+}
+
+function triggerRowWin(row) {
+  if (!shouldAnimate()) return;
+  for (let col = 0; col < cols; col += 1) {
+    const tile = getTile(row, col);
+    if (!tile) continue;
+    tile.style.setProperty("--col", String(col));
+    triggerOneShotAnim(tile, "is-win");
+  }
+}
+
+function triggerTilePop(tile) {
+  triggerOneShotAnim(tile, "is-pop");
+}
+
+function flashKey(letter) {
+  /* `.key:active` covers pointer/touch; this helper fires the same
+     visual flash on a physical-keyboard keydown so typists see the
+     button depress. setTimeout (not animationend) because the press
+     effect is a `transition`, not a keyframe animation. */
+  if (!shouldAnimate()) return;
+  const btn = keyboardKeyEls.get(letter);
+  if (!btn) return;
+  btn.classList.add("is-pressed");
+  setTimeout(() => btn.classList.remove("is-pressed"), 100);
+}
+
 function resetConstraints() {
   fixedPositions = Array(cols).fill(null);
   bannedPositions = Array.from({ length: cols }, () => new Set());
@@ -1106,6 +1199,7 @@ function guessComplete() {
 async function submitGuess() {
   if (!guessComplete()) {
     setMessage("Not enough letters.");
+    triggerRowShake(currentRow);
     return;
   }
   if (busy) return;
@@ -1115,6 +1209,7 @@ async function submitGuess() {
     const strictError = validateStrictGuess(guess);
     if (strictError) {
       setMessage(strictError);
+      triggerRowShake(currentRow);
       return;
     }
   }
@@ -1133,6 +1228,7 @@ async function submitGuess() {
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
       setMessage(data.error || "Invalid guess.");
+      triggerRowShake(currentRow);
       return;
     }
 
@@ -1140,6 +1236,14 @@ async function submitGuess() {
     updateKeyboard(data.result, guess);
     updateConstraints(guess, data.result);
     setSrStatus(`Guess ${currentRow + 1}: ${describeResult(guess, data.result)}`);
+    /* Reveal animation runs alongside the existing background-color
+       transition on `.tile` — color slides in as the tile punches.
+       On the solve row the win celebration chains off the last tile's
+       `animationend`. */
+    triggerRowReveal(
+      currentRow,
+      data.isCorrect ? () => triggerRowWin(currentRow) : null
+    );
 
     if (data.isCorrect) {
       locked = true;
@@ -1203,6 +1307,7 @@ function handleKey(rawKey) {
       currentCol -= 1;
       guesses[currentRow][currentCol] = "";
       updateTile(currentRow, currentCol, "", false);
+      triggerTilePop(getTile(currentRow, currentCol));
     }
     return;
   }
@@ -1211,6 +1316,7 @@ function handleKey(rawKey) {
 
   guesses[currentRow][currentCol] = key;
   updateTile(currentRow, currentCol, key, true);
+  triggerTilePop(getTile(currentRow, currentCol));
   currentCol += 1;
 }
 
@@ -1234,13 +1340,21 @@ function handlePhysicalKey(event) {
   if (isTextInputTarget) {
     return;
   }
+  let mappedKey = null;
   if (event.key === "Enter") {
-    handleKey("ENTER");
+    mappedKey = "ENTER";
   } else if (event.key === "Backspace") {
-    handleKey("BACK");
+    mappedKey = "BACK";
   } else if (/^[a-zA-Z]$/.test(event.key)) {
-    handleKey(event.key);
+    mappedKey = event.key.toUpperCase();
   }
+  if (mappedKey === null) return;
+  /* Physical-keystroke parity for the on-screen keyboard (#185).
+     `:active` covers pointer interaction; this fires the same
+     `.is-pressed` flash for typists who never touch the screen
+     buttons. */
+  flashKey(mappedKey);
+  handleKey(mappedKey);
 }
 
 function buildShareLink(code, lang, guessesCount, options = {}) {

--- a/public/app.js
+++ b/public/app.js
@@ -1087,13 +1087,19 @@ function triggerRowReveal(row, onSolveComplete) {
   if (onSolveComplete && lastTile) {
     /* Filter by animationName — without this, an unrelated animation
        on `lastTile` (e.g. a stale pop) could fire the chain before
-       the reveal completes. Codex P2 on PR #196. */
+       the reveal completes. Codex P2 on PR #196.
+       Listen for `animationcancel` too so the listener doesn't leak
+       if the reveal is interrupted (e.g. a fast re-init wipes the
+       board); matches `triggerOneShotAnim`'s dual-event cleanup
+       pattern. CodeRabbit nit on PR #196. */
     const chain = (event) => {
       if (event.animationName !== "tile-reveal") return;
       lastTile.removeEventListener("animationend", chain);
-      onSolveComplete();
+      lastTile.removeEventListener("animationcancel", chain);
+      if (event.type === "animationend") onSolveComplete();
     };
     lastTile.addEventListener("animationend", chain);
+    lastTile.addEventListener("animationcancel", chain);
   }
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -949,7 +949,11 @@ function renderKeyboardInto(rootEl, opts = {}) {
     rowKeys.forEach((key) => {
       const button = makeKeyButton(key, { onClick: onKey });
       rowEl.appendChild(button);
-      if (captureRefMap && key.length === 1) {
+      if (captureRefMap) {
+        /* Capture ALL keys including `"ENTER"` and `"BACK"`. Without
+           this `flashKey("ENTER")` / `flashKey("BACK")` would silently
+           no-op — wide keys would never visually depress on physical
+           Enter/Backspace. CodeRabbit on PR #196. */
         captureRefMap.set(key, button);
       }
     });
@@ -1042,7 +1046,7 @@ function shouldAnimate() {
   return !(prefersReducedMotionMql && prefersReducedMotionMql.matches);
 }
 
-function triggerOneShotAnim(el, className) {
+function triggerOneShotAnim(el, className, animationName) {
   if (!el || !shouldAnimate()) return;
   /* Remove + force reflow + re-add so a second trigger on the same
      element (e.g. pop on letter, pop on backspace of that letter)
@@ -1050,7 +1054,12 @@ function triggerOneShotAnim(el, className) {
   el.classList.remove(className);
   void el.offsetWidth;
   el.classList.add(className);
-  const onEnd = () => {
+  const onEnd = (event) => {
+    /* Filter by animation name — without this, an unrelated still-
+       in-flight animation on the same element (e.g. a pop ending
+       just as a reveal starts on the last-typed tile) would fire
+       this handler and strip the wrong class. Codex P2 on PR #196. */
+    if (animationName && event.animationName !== animationName) return;
     el.classList.remove(className);
     el.removeEventListener("animationend", onEnd);
     el.removeEventListener("animationcancel", onEnd);
@@ -1072,11 +1081,15 @@ function triggerRowReveal(row, onSolveComplete) {
     const tile = getTile(row, col);
     if (!tile) continue;
     tile.style.setProperty("--col", String(col));
-    triggerOneShotAnim(tile, "is-reveal");
+    triggerOneShotAnim(tile, "is-reveal", "tile-reveal");
     if (col === cols - 1) lastTile = tile;
   }
   if (onSolveComplete && lastTile) {
-    const chain = () => {
+    /* Filter by animationName — without this, an unrelated animation
+       on `lastTile` (e.g. a stale pop) could fire the chain before
+       the reveal completes. Codex P2 on PR #196. */
+    const chain = (event) => {
+      if (event.animationName !== "tile-reveal") return;
       lastTile.removeEventListener("animationend", chain);
       onSolveComplete();
     };
@@ -1089,7 +1102,7 @@ function triggerRowShake(row) {
      query and survives any future restructuring of the board grid. */
   const tile = getTile(row, 0);
   const rowEl = tile ? tile.parentElement : null;
-  triggerOneShotAnim(rowEl, "is-shake");
+  triggerOneShotAnim(rowEl, "is-shake", "row-shake");
 }
 
 function triggerRowWin(row) {
@@ -1098,12 +1111,12 @@ function triggerRowWin(row) {
     const tile = getTile(row, col);
     if (!tile) continue;
     tile.style.setProperty("--col", String(col));
-    triggerOneShotAnim(tile, "is-win");
+    triggerOneShotAnim(tile, "is-win", "tile-win");
   }
 }
 
 function triggerTilePop(tile) {
-  triggerOneShotAnim(tile, "is-pop");
+  triggerOneShotAnim(tile, "is-pop", "tile-pop");
 }
 
 function flashKey(letter) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -852,6 +852,77 @@ body.high-contrast .key.absent {
   outline-offset: 2px;
 }
 
+/* Play-surface motion (issue #182) + on-screen-keyboard press flash
+   (issue #185). All animations live inside a
+   `prefers-reduced-motion: no-preference` block so users who've asked
+   for less motion get none. The blanket `* { animation: none }` reset
+   below is the secondary safety net; gating per-rule makes intent
+   explicit at the source. Transform/opacity only so the compositor
+   can run these on the GPU with no layout cost. */
+@media (prefers-reduced-motion: no-preference) {
+  /* A. Reveal — per-tile scale + slight rotate as the feedback color
+     arrives. Column stagger via `--col` (set in JS at submit time). The
+     existing `transition: background 0.2s ease` on `.tile` carries the
+     color in parallel; this animation is transform-only. */
+  @keyframes tile-reveal {
+    0%   { transform: scale(0.4) rotate(-6deg); }
+    60%  { transform: scale(1.08) rotate(2deg); }
+    100% { transform: scale(1) rotate(0); }
+  }
+  .tile.is-reveal {
+    animation: tile-reveal 280ms ease-out both;
+    animation-delay: calc(var(--col, 0) * 60ms);
+  }
+
+  /* B. Shake — active row on rejected guess (HTTP non-OK, strict-mode
+     violation, or premature submit). Asymmetric peaks deliver the
+     "physical jolt then settle" feel. */
+  @keyframes row-shake {
+    0%, 100% { transform: translateX(0); }
+    16%      { transform: translateX(-8px); }
+    33%      { transform: translateX(8px); }
+    50%      { transform: translateX(-6px); }
+    66%      { transform: translateX(6px); }
+    83%      { transform: translateX(-3px); }
+  }
+  .row.is-shake {
+    animation: row-shake 380ms ease-out both;
+  }
+
+  /* C. Win — fires only on the solved row, chained off the reveal
+     animation completing. Bounce up + full Y rotation; stagger via
+     `--col` × 80ms. */
+  @keyframes tile-win {
+    0%   { transform: translateY(0) rotateY(0); }
+    50%  { transform: translateY(-12px) rotateY(180deg); }
+    100% { transform: translateY(0) rotateY(360deg); }
+  }
+  .tile.is-win {
+    animation: tile-win 600ms ease-out both;
+    animation-delay: calc(var(--col, 0) * 80ms);
+  }
+
+  /* D. Capture pop — brief scale punch when a letter fills, or when
+     backspace clears. Independent per tile; fast typing stacks (each
+     tile is its own surface). */
+  @keyframes tile-pop {
+    0%, 100% { transform: scale(1); }
+    50%      { transform: scale(1.08); }
+  }
+  .tile.is-pop {
+    animation: tile-pop 120ms ease-out;
+  }
+
+  /* E. On-screen key press (#185). `:active` covers pointer
+     interaction natively; `.is-pressed` is JS-applied on physical
+     keystroke for parity. Short enough not to lag fast typists. */
+  .key:active,
+  .key.is-pressed {
+    transform: scale(0.95);
+    transition: transform 60ms ease-out;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   * {
     transition: none !important;

--- a/public/styles.css
+++ b/public/styles.css
@@ -618,9 +618,15 @@ button:disabled {
   transition: transform 0.15s ease, border-color 0.15s ease, background 0.2s ease;
 }
 
+/* `.tile.filled` keeps the accent border as the "captured" affordance.
+   The previous `translateY(-2px)` here was the capture lift; the new
+   `tile-pop` keyframe animation (issue #182) replaces it with a brief
+   scale punch on capture. Keeping the translate alongside the new
+   transform-based animations caused filled tiles to visually "drop"
+   during reveal/win/pop because animations override `transform`
+   wholesale. Copilot on PR #196. */
 .tile.filled {
   border-color: var(--accent);
-  transform: translateY(-2px);
 }
 
 .tile.absent {

--- a/public/sw.js
+++ b/public/sw.js
@@ -51,9 +51,15 @@
 // challengesEnabled flags from /api/meta and hides the matching header
 // nav links when each is false.
 //
+// v11: invalidates stale app.js + styles.css for the playful tile
+// reactions (#182) + keyboard `:active` flash (#185) — adds five
+// keyframes + JS triggers + a CSS scale on `.key:active`/.is-pressed.
+// SW is cache-first for non-API, so without the bump returning users
+// keep getting the pre-motion app.js/styles.css.
+//
 // v3: adds `push` + `notificationclick` listeners for the daily-puzzle
 // Web Push notification flow (#92).
-const CACHE_NAME = 'wordle-cache-v9';
+const CACHE_NAME = 'wordle-cache-v11';
 const STATIC_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
Closes #182, closes #185.

Five short, GPU-composited animations on the main play board plus a physical-keystroke parity flash on the on-screen keyboard.

## Animations

| Reaction | Effect | Duration | Stagger | Trigger |
|---|---|---|---|---|
| **Reveal** | `scale(.4 → 1.08 → 1)` + `rotate(-6deg → 0)` per tile | 280ms | 60ms × col | row submit succeeds |
| **Shake** | row `translateX(0 → ±8 → ±6 → ±3 → 0)` | 380ms | — | rejected guess (HTTP / strict-mode / short) |
| **Win** | per-tile `translateY(0 → -12 → 0)` + `rotateY(0 → 360°)` | 600ms | 80ms × col | solve row, chained off reveal `animationend` |
| **Capture pop** | `scale(1 → 1.08 → 1)` | 120ms | — | letter fill or backspace, per tile (stacks) |
| **Key flash** | on-screen `.key` `scale(.95)` | 60ms transition | — | physical keystroke (`.is-pressed`); pointer gets `:active` natively |

All transform/opacity only — no layout cost. The existing `transition: background 0.2s` on `.tile` carries the feedback color in parallel with the reveal punch.

## Reduced-motion handling

Two layers of safety:
- **CSS**: all animation rules wrapped in `@media (prefers-reduced-motion: no-preference)`
- **JS**: every `trigger*` helper short-circuits on `matchMedia("(prefers-reduced-motion: reduce)").matches`. Without this, `.is-*` classes would dangle (animationend never fires when there's no animation) and break subsequent re-triggers

The win chain (which depends on the reveal's `animationend`) fires immediately under reduced motion so callers don't lose the hook.

## Scope

**Main play board only.** The challenge mode (`#challengeBoard`) uses the same `buildBoardGrid` partial but lives in a different state machine. Wiring motion through there is filed as a follow-up rather than dragged into this PR.

## Test plan

- [x] `npm run check` passes (67 suites, 1167 tests)
- [x] Manual: reveal staggers left→right after submit
- [x] Manual: shake fires on "Not in word list" without the reveal
- [x] Manual: win bounce + 360° spins after reveal completes on solve
- [x] Manual: typing fast → each tile pops independently (stack)
- [x] Manual: physical keys flash the on-screen buttons
- [ ] `prefers-reduced-motion: reduce` set in OS → no animations, solve still flows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smooth animations for tile reveals, row shakes, win bounces, and tile pops with staggered staggered timing; animations honor reduced-motion preferences.
  * Visual key-press feedback for both on-screen and physical keyboards, including Enter/Back keys; keys briefly flash on physical presses.
  * Win animation now chains after reveal completion.

* **Bug Fixes**
  * Rows now shake on failed submissions (insufficient letters, validation failure, or server rejection).
  * Tile pop on entry/backspace to improve input feedback.

* **Chores**
  * Updated offline cache to improve offline support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/196)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->