### PR TITLE
ui: skeleton 6×5 pulse for play board (#191)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -909,12 +909,16 @@ function buildBoard() {
    - `aria-busy` marks the board as in-flight so AT doesn't announce
      30 bogus "Empty" cells during the skeleton window. Copilot on PR
      #197. */
-function mountSkeletonBoard(expectedRows) {
+function mountSkeletonBoard(expectedRows, expectedCols) {
   if (!boardEl) return;
   const rows = Math.max(3, Math.min(10, Number(expectedRows) || defaultGuesses));
+  /* The puzzle code is one ciphertext character per plaintext letter,
+     so `code.length` is also the column count. Falls back to 5 when
+     the caller doesn't pass it. CodeRabbit on PR #197. */
+  const cols = Math.max(3, Math.min(12, Number(expectedCols) || 5));
   const refs = buildBoardGrid(boardEl, {
     rows,
-    cols: 5,
+    cols,
     captureRefs: true
   });
   boardEl.setAttribute("aria-busy", "true");
@@ -1701,7 +1705,11 @@ async function initPlay(code, lang, guessesCount, options = {}) {
      `resetGame()` rebuilds. The existing grid stays visible until
      real data arrives. Copilot on PR #197. */
   if (boardEl && !boardEl.firstChild) {
-    mountSkeletonBoard(guessesCount);
+    /* `code.length` matches the eventual column count (puzzle codes
+       are one ciphertext character per plaintext letter), so the
+       skeleton lands on the right shape and the real board doesn't
+       reflow on data arrival. CodeRabbit on PR #197. */
+    mountSkeletonBoard(guessesCount, code ? code.length : null);
   }
   if (!physicalKeyboardBound) {
     document.addEventListener("keydown", handlePhysicalKey);

--- a/public/app.js
+++ b/public/app.js
@@ -895,6 +895,28 @@ function buildBoard() {
   });
 }
 
+/* Default 6×5 skeleton mounted between `showPlay()` and the
+   `/api/puzzle` response (typically <100ms). Replaces the empty-area
+   gap below "Loading puzzle…" with a softly pulsing grid. `buildBoard()`
+   in `resetGame()` clears this when real dimensions arrive. The
+   skeleton dims are the most-common Wordle shape; if the real puzzle
+   is 3- or 8-letter the grid resizes briefly when data lands —
+   acceptable for a sub-100ms transition. Issue #191. */
+function mountSkeletonBoard() {
+  if (!boardEl) return;
+  const refs = buildBoardGrid(boardEl, {
+    rows: 6,
+    cols: 5,
+    captureRefs: true
+  });
+  if (!refs) return;
+  for (const row of refs) {
+    for (const tile of row) {
+      if (tile) tile.classList.add("is-skeleton");
+    }
+  }
+}
+
 // Shared keyboard build helpers (issue #163, partial). Both the
 // play (#keyboard) and the challenge (#challengeKeyboard) on-screen
 // keyboards used to have parallel build code with copy-pasted
@@ -1658,6 +1680,7 @@ function applyTheme(preference, options = {}) {
 async function initPlay(code, lang, guessesCount, options = {}) {
   const initTimer = startPerfMeasure("ui.initPlay");
   showPlay();
+  mountSkeletonBoard();
   if (!physicalKeyboardBound) {
     document.addEventListener("keydown", handlePhysicalKey);
     physicalKeyboardBound = true;

--- a/public/app.js
+++ b/public/app.js
@@ -893,22 +893,31 @@ function buildBoard() {
     // cellAt omitted — initial board is all empty; updateTile() and
     // paintRow() patch tiles incrementally as the user plays.
   });
+  /* Clear the skeleton's `aria-busy` marker — the real board is
+     announceable now. */
+  boardEl.removeAttribute("aria-busy");
 }
 
-/* Default 6×5 skeleton mounted between `showPlay()` and the
+/* Cold-load skeleton mounted between `showPlay()` and the
    `/api/puzzle` response (typically <100ms). Replaces the empty-area
    gap below "Loading puzzle…" with a softly pulsing grid. `buildBoard()`
-   in `resetGame()` clears this when real dimensions arrive. The
-   skeleton dims are the most-common Wordle shape; if the real puzzle
-   is 3- or 8-letter the grid resizes briefly when data lands —
-   acceptable for a sub-100ms transition. Issue #191. */
-function mountSkeletonBoard() {
+   in `resetGame()` clears this when real dimensions arrive. Issue #191.
+
+   - `expectedRows` uses the guessesCount the caller already knows, so
+     a non-default guesses puzzle doesn't get a 6→N reshape on data
+     arrival. CodeRabbit on PR #197.
+   - `aria-busy` marks the board as in-flight so AT doesn't announce
+     30 bogus "Empty" cells during the skeleton window. Copilot on PR
+     #197. */
+function mountSkeletonBoard(expectedRows) {
   if (!boardEl) return;
+  const rows = Math.max(3, Math.min(10, Number(expectedRows) || defaultGuesses));
   const refs = buildBoardGrid(boardEl, {
-    rows: 6,
+    rows,
     cols: 5,
     captureRefs: true
   });
+  boardEl.setAttribute("aria-busy", "true");
   if (!refs) return;
   for (const row of refs) {
     for (const tile of row) {
@@ -1679,8 +1688,21 @@ function applyTheme(preference, options = {}) {
 
 async function initPlay(code, lang, guessesCount, options = {}) {
   const initTimer = startPerfMeasure("ui.initPlay");
+  /* Lock input through the skeleton + fetch window. Without this,
+     `handleKey()` could fire before `resetGame()` initializes
+     `guesses` / `currentRow`, and `guesses[currentRow]` would throw.
+     `resetGame()` clears `locked` when real data arrives. CodeRabbit
+     critical on PR #197. */
+  locked = true;
   showPlay();
-  mountSkeletonBoard();
+  /* Mount the skeleton only on cold loads. If `boardEl` already holds
+     a real grid (e.g. user navigated to a new puzzle mid-session),
+     wiping it now would point `tileGrid` at detached nodes until
+     `resetGame()` rebuilds. The existing grid stays visible until
+     real data arrives. Copilot on PR #197. */
+  if (boardEl && !boardEl.firstChild) {
+    mountSkeletonBoard(guessesCount);
+  }
   if (!physicalKeyboardBound) {
     document.addEventListener("keydown", handlePhysicalKey);
     physicalKeyboardBound = true;

--- a/public/styles.css
+++ b/public/styles.css
@@ -703,6 +703,26 @@ body.high-contrast .tile.absent {
   box-shadow: inset 0 0 0 2px var(--tile-contrast-shadow);
 }
 
+/* Skeleton state (issue #191). Shown briefly while /api/puzzle is in
+   flight — replaces the "Loading puzzle…" bare-text gap with a soft
+   pulsing 6×5 grid. Real `buildBoard()` clears the skeleton when
+   actual cols/maxGuesses arrive. */
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 0.35; }
+  50%      { opacity: 0.65; }
+}
+
+.tile.is-skeleton {
+  background: var(--tile-bg);
+  border-color: var(--tile-border);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .tile.is-skeleton {
+    animation: skeleton-pulse 1.5s ease-in-out infinite;
+  }
+}
+
 .message {
   min-height: 1.5rem;
   color: var(--accent);

--- a/public/sw.js
+++ b/public/sw.js
@@ -51,6 +51,11 @@
 // challengesEnabled flags from /api/meta and hides the matching header
 // nav links when each is false.
 //
+// v12: invalidates stale app.js + styles.css for the skeleton play
+// board (#191). Adds `mountSkeletonBoard` + a `tile-skeleton` keyframe;
+// without the bump returning PWA users would see the pre-skeleton
+// HTML/CSS that doesn't reference the new assets.
+//
 // v11: invalidates stale app.js + styles.css for the playful tile
 // reactions (#182) + keyboard `:active` flash (#185) — adds five
 // keyframes + JS triggers + a CSS scale on `.key:active`/.is-pressed.
@@ -59,7 +64,7 @@
 //
 // v3: adds `push` + `notificationclick` listeners for the daily-puzzle
 // Web Push notification flow (#92).
-const CACHE_NAME = 'wordle-cache-v11';
+const CACHE_NAME = 'wordle-cache-v12';
 const STATIC_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
Closes #191.

## Why

`/api/puzzle` typically resolves in <100ms, but the empty-area below `"Loading puzzle…"` reads unloved when it is visible (slow network, cold service worker, large JS parse).

## What

```js
async function initPlay(code, lang, guessesCount, options = {}) {
  const initTimer = startPerfMeasure("ui.initPlay");
  showPlay();
  mountSkeletonBoard();   // <-- new
  // ... fetch /api/puzzle ...
}
```

`mountSkeletonBoard()` is called immediately after `showPlay()`, before the fetch. It renders a 6×5 grid via the same `buildBoardGrid` partial used by the real board, then tags each tile with `.is-skeleton`. CSS opacity-pulses the tiles at 1.5s intervals (under `prefers-reduced-motion: no-preference`).

When `/api/puzzle` resolves and `resetGame()` calls `buildBoard()` with the real dimensions, `buildBoardGrid` rewrites `boardEl.innerHTML` and the skeleton is replaced in place. If the real puzzle is 3- or 8-letter the grid resizes briefly — acceptable for a sub-100ms transition. 6×5 matches the dominant Wordle shape so most loads see no resize.

## CSS

```css
@keyframes skeleton-pulse {
  0%, 100% { opacity: 0.35; }
  50%      { opacity: 0.65; }
}

.tile.is-skeleton {
  background: var(--tile-bg);
  border-color: var(--tile-border);
}

@media (prefers-reduced-motion: no-preference) {
  .tile.is-skeleton {
    animation: skeleton-pulse 1.5s ease-in-out infinite;
  }
}
```

Keyframes live outside the media query (inert without a reference); only the `animation:` reference itself is gated.

## Test plan

- [x] `npm run check` passes (67 suites, 1167 tests)
- [x] Manual: skeleton flashes briefly between page-load and board-ready
- [x] Manual: no content-shift when the real board takes over (5-letter case)
- [ ] 3- or 8-letter puzzles: brief grid resize is tolerable
- [ ] `prefers-reduced-motion: reduce`: pulse stops; skeleton tiles still visible (static)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a skeleton loading state showing a pulsing placeholder board while puzzle data loads.
  * Respects motion-preference settings for the pulse animation.

* **Bug Fixes / Accessibility**
  * Prevents keyboard input before the game board is ready.
  * Uses an ARIA busy marker to suppress screen-reader announcements during loading.

* **Chores**
  * Updated offline cache version to ensure the new loading experience is available offline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/wordle-local/pull/197)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->