### PR TITLE
ui: drop marketing-slop footer + status writes (#181)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -17,7 +17,6 @@ const guessInput = document.getElementById("guessInput");
 const randomBtn = document.getElementById("randomBtn");
 const createStatus = document.getElementById("createStatus");
 const hintEl = document.querySelector(".hint");
-const updatedEl = document.getElementById("updated");
 const shareLinkInput = document.getElementById("shareLink");
 const shareCopyBtn = document.getElementById("shareCopyBtn");
 const themeSelect = document.getElementById("themeSelect");
@@ -1755,7 +1754,6 @@ async function initPlay(code, lang, guessesCount, options = {}) {
     });
     renderDailyPlayerPanels();
   }
-  updatedEl.textContent = "Game ready";
   updateShareLink(
     buildShareLink(code, puzzleLang, maxGuesses, {
       dailyMode,
@@ -1773,7 +1771,6 @@ function initCreate() {
   clearStatsServiceUnavailable();
   renderDailyPlayerPanels();
   showCreate();
-  updatedEl.textContent = "Create mode";
 }
 
 async function startPuzzle(code, lang, guessesCount) {

--- a/public/index.html
+++ b/public/index.html
@@ -305,11 +305,6 @@
       </section>
     </main>
 
-    <footer class="footer">
-      <span data-i18n="footer.tagline">Custom Wordle · Local hosting</span>
-      <span id="updated" data-i18n="footer.ready">Ready</span>
-    </footer>
-
     <div
       id="shareModal"
       class="modal"

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -139,10 +139,6 @@
     "loading": "Loading…",
     "errorPrefix": "Error: {message}"
   },
-  "footer": {
-    "tagline": "Custom Wordle · Local hosting",
-    "ready": "Ready"
-  },
   "share": {
     "modalTitle": "About share links",
     "modalBody1": "Encoding makes the URL travel-safe. Anyone with this link sees the puzzle word — there's no password.",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -139,10 +139,6 @@
     "loading": "Cargando…",
     "errorPrefix": "Error: {message}"
   },
-  "footer": {
-    "tagline": "Wordle personalizado · Alojamiento local",
-    "ready": "Listo"
-  },
   "share": {
     "modalTitle": "Sobre los enlaces para compartir",
     "modalBody1": "La codificación hace que la URL sea segura para enviar. Cualquiera con el enlace ve la palabra del puzle — no hay contraseña.",

--- a/public/styles.css
+++ b/public/styles.css
@@ -60,7 +60,6 @@
   --key-hover-bg: #334155;
   --key-absent-shadow: rgba(248, 250, 252, 0.18);
   --key-contrast-shadow: rgba(15, 23, 42, 0.4);
-  --footer-border: rgba(148, 163, 184, 0.2);
   --overlay-bg: rgba(2, 6, 23, 0.7);
   --modal-bg: rgba(15, 23, 42, 0.9);
   --modal-border: rgba(148, 163, 184, 0.2);
@@ -149,7 +148,6 @@ html.theme-light {
   --key-hover-bg: #cbd5e1;
   --key-absent-shadow: rgba(15, 23, 42, 0.14);
   --key-contrast-shadow: rgba(15, 23, 42, 0.16);
-  --footer-border: rgba(15, 23, 42, 0.12);
   --overlay-bg: rgba(15, 23, 42, 0.32);
   --modal-bg: rgba(255, 255, 255, 0.98);
   --modal-border: rgba(15, 23, 42, 0.16);
@@ -900,19 +898,6 @@ body.high-contrast .key.absent {
   box-shadow: inset 0 0 0 2px var(--key-contrast-shadow);
 }
 
-.footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--space-md);
-  padding: 1rem clamp(1.5rem, 4vw, 4rem) 2rem;
-  color: var(--muted);
-  border-top: 1px solid var(--footer-border);
-  width: 100%;
-  min-width: 0;
-}
-
 .link-button {
   border: 1px solid var(--chip-border);
   background: transparent;
@@ -1143,12 +1128,6 @@ body.high-contrast .key.absent {
     padding: 0.85rem;
   }
 
-  .footer {
-    flex-direction: column;
-    gap: var(--space-xs);
-    padding: 0.85rem clamp(1rem, 3vw, 2rem) 1.5rem;
-  }
-
   .player-stats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1229,10 +1208,6 @@ body.high-contrast .key.absent {
     padding: 1.15rem;
   }
 
-  .footer {
-    padding: 0.65rem 0.85rem 1.25rem;
-  }
-
 }
 
 @media (max-width: 360px) {
@@ -1261,10 +1236,6 @@ body.high-contrast .key.absent {
   .leaderboard-panel {
     padding: 0.65rem;
     gap: 0.65rem;
-  }
-
-  .footer {
-    padding: 0.5rem 0.65rem 1rem;
   }
 
 }
@@ -1304,10 +1275,6 @@ body.high-contrast .key.absent {
   .modal-card {
     width: min(32rem, 98vw);
     padding: 0.85rem;
-  }
-
-  .footer {
-    padding: 0.45rem 0.5rem 0.85rem;
   }
 
   .stat-card {
@@ -1619,11 +1586,6 @@ body.high-contrast .key.absent {
 
   .share {
     gap: var(--space-sm);
-  }
-
-  .footer {
-    padding: 0.4rem clamp(0.75rem, 2.5vw, 1.5rem) 0.65rem;
-    font-size: var(--fs-sm);
   }
 
   .modal-card {

--- a/tests/ui/create-play.spec.js
+++ b/tests/ui/create-play.spec.js
@@ -117,7 +117,6 @@ test("daily mode requires a player name and updates leaderboard stats", async ({
 test("strict mode enforces revealed hints", async ({ page }) => {
   await page.goto("/?word=yfrqp&lang=en", gotoOptions);
   await page.waitForSelector("#playPanel:not(.hidden)");
-  await expect(page.locator("#updated")).toContainText("Game ready");
   await page.check("#strictToggle");
   await page.click("#board");
   await page.keyboard.type("CRATE");
@@ -139,7 +138,6 @@ test("strict mode requires repeated letters when revealed", async ({ page }) => 
   await page.fill("#wordInput", "LEVEL");
   await page.click("form#createForm button[type=submit]");
   await page.waitForSelector("#playPanel:not(.hidden)");
-  await expect(page.locator("#updated")).toContainText("Game ready");
   await page.check("#strictToggle");
   await page.click("#board");
   await page.keyboard.type("ALLOT");


### PR DESCRIPTION
Closes #181.

Four low-value strings deleted, plus the entire `<footer>` surface they lived on (the footer existed only to hold them).

## Strings removed

| Before | Where | Verdict |
|---|---|---|
| `"Custom Wordle · Local hosting"` | `<footer>` tagline | Marketing copy inside the app |
| `"Ready"` | `#updated` status | Static label, no action attached |
| `"Game ready"` | hardcoded English literal in `app.js:1757` | The rendered board is the indicator |
| `"Create mode"` | hardcoded English literal in `app.js:1775` | The visible panel is the indicator |

The bottom two also bypassed the i18n system — Spanish users saw English regardless.

## Class-wide cleanup (per project rule #4)

- Removed `<footer class="footer">` element entirely (was a wrapper for the two slop spans only)
- Deleted `.footer` CSS rules across **6 locations** (base + 5 breakpoint variants)
- Deleted `--footer-border` token from `:root` and `html.theme-light` (only referenced by the now-deleted `.footer` rule)
- Removed `footer.tagline` and `footer.ready` keys from `en.json` and `es.json` (the entire `footer` namespace — both keys gone, nothing else used it)
- Removed unused `const updatedEl = ...` lookup from `app.js`
- Removed two `expect(page.locator("#updated")).toContainText("Game ready")` assertions from `tests/ui/create-play.spec.js` — `#playPanel:not(.hidden)` already gates play readiness; the `"Game ready"` check was a redundant cross-check on the same state

Net change: **-56 lines**, no behavior loss.

## Test plan

- [x] `npm run check` passes (67 suites, 1167 tests)
- [x] Visual: footer area is now empty (no border-top, no static labels)
- [x] Both strict-mode Playwright tests still pass against the `#playPanel` readiness gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)