### PR TITLE
feat(security): CSP tightening — drop style-src unsafe-inline, add tests + docs (closes #201)

### DIFF
--- a/docs/security/csp.md
+++ b/docs/security/csp.md
@@ -1,0 +1,52 @@
+# Content Security Policy
+
+The server sets `Content-Security-Policy` on every response via
+[helmet](https://helmetjs.github.io/) (see `server.js`).
+
+## Active policy
+
+| Directive | Value | Rationale |
+| --- | --- | --- |
+| `default-src` | `'self'` | Deny all unspecified content sources by default |
+| `base-uri` | `'self'` | Prevent `<base>` hijacking |
+| `form-action` | `'self'` | Restrict form submissions to same-origin |
+| `frame-ancestors` | `'self'` | Prevent clickjacking from cross-origin frames |
+| `font-src` | `'self' https: data:` | Self-hosted fonts + preloaded woff2 data URIs |
+| `img-src` | `'self' data:` | Favicon / inline image data URIs |
+| `object-src` | `'none'` | Block plugin-executed content (Flash, etc.) |
+| `script-src` | `'self' 'unsafe-inline'` | See note below |
+| `script-src-attr` | `'none'` | Block inline event handlers (`onclick=`, etc.) |
+| `style-src` | `'self' https:` | No inline styles; external sheets only |
+| `upgrade-insecure-requests` | disabled | See note below |
+
+## Notes
+
+### `script-src 'unsafe-inline'`
+
+Two synchronous pre-paint scripts in `public/index.html` and
+`public/admin/index.html` read `localStorage` to apply the stored theme
+and locale **before** the stylesheet downloads. Making them `defer` (or
+moving them to external files) would re-introduce a flash of
+unstyled/wrong-theme content on load.
+
+The correct long-term fix is nonce-based CSP, which requires the server to
+inject a unique nonce into the HTML template on each request and include
+it in the `script-src` directive. That upgrade is tracked separately.
+
+Until then, the policy intentionally allows `'unsafe-inline'` in
+`script-src`. Note that `script-src-attr: 'none'` still blocks inline
+event handlers, which covers the most common XSS injection points.
+
+### `upgrade-insecure-requests` disabled
+
+Chromium and Firefox exempt loopback from this directive, but WebKit does
+not — it attempts `https://localhost:<port>/<asset>` and fails the TLS
+handshake, breaking every subresource on an HTTP-only local deployment.
+Add `upgrade-insecure-requests` at the reverse-proxy layer (or under a
+`NODE_ENV` gate) when deploying behind HTTPS termination.
+
+## Testing
+
+`tests/csp-headers.integration.test.js` asserts that `GET /` and
+`GET /admin` both return the header and that `style-src` carries no
+`'unsafe-inline'`.

--- a/public/admin/admin.css
+++ b/public/admin/admin.css
@@ -281,3 +281,35 @@
     gap: 0.4rem;
   }
 }
+
+/* ── classroom-report.html ─────────────────────────────────────────── */
+.report-page {
+  margin: 1.5rem;
+  font-family: system-ui, sans-serif;
+}
+.report-page .report-meta {
+  margin-bottom: 1rem;
+}
+.report-page table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.report-page th,
+.report-page td {
+  border: 1px solid #888;
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+}
+.report-page thead {
+  background: #eee;
+}
+.report-page .status-won { color: #1a7f37; }
+.report-page .status-lost { color: #b32a2a; }
+.report-page .status-not-started { color: #666; }
+.report-page .key-input {
+  margin-bottom: 1rem;
+}
+@media print {
+  .report-page .key-input { display: none; }
+  .report-page button { display: none; }
+}

--- a/public/admin/classroom-report.html
+++ b/public/admin/classroom-report.html
@@ -6,39 +6,8 @@
     <meta name="robots" content="noindex" />
     <title>Class participation report</title>
     <link rel="stylesheet" href="/admin/admin.css" />
-    <style>
-      body {
-        margin: 1.5rem;
-        font-family: system-ui, sans-serif;
-      }
-      .report-meta {
-        margin-bottom: 1rem;
-      }
-      table {
-        width: 100%;
-        border-collapse: collapse;
-      }
-      th, td {
-        border: 1px solid #888;
-        padding: 0.4rem 0.6rem;
-        text-align: left;
-      }
-      thead {
-        background: #eee;
-      }
-      .status-won { color: #1a7f37; }
-      .status-lost { color: #b32a2a; }
-      .status-not-started { color: #666; }
-      .key-input {
-        margin-bottom: 1rem;
-      }
-      @media print {
-        .key-input { display: none; }
-        button { display: none; }
-      }
-    </style>
   </head>
-  <body>
+  <body class="report-page">
     <header>
       <h1 id="reportTitle">Class participation report</h1>
       <p class="report-meta" id="reportMeta"></p>

--- a/public/sw.js
+++ b/public/sw.js
@@ -69,7 +69,7 @@
 //
 // v3: adds `push` + `notificationclick` listeners for the daily-puzzle
 // Web Push notification flow (#92).
-const CACHE_NAME = 'wordle-cache-v13';
+const CACHE_NAME = 'wordle-cache-v14';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/server.js
+++ b/server.js
@@ -3159,9 +3159,15 @@ app.use(helmet({
       frameAncestors: ["'self'"],
       imgSrc: ["'self'", "data:"],
       objectSrc: ["'none'"],
+      // 'unsafe-inline' required for two synchronous pre-paint scripts in
+      // public/index.html and public/admin/index.html (theme + lang detection).
+      // These must run before the stylesheet to avoid FOUC; extracting them to
+      // external files would require `defer`, breaking the pre-paint guarantee.
+      // Nonce-based CSP is the correct long-term fix but needs server-side
+      // templating. See docs/security/csp.md for the full policy rationale.
       scriptSrc: ["'self'", "'unsafe-inline'"],
       scriptSrcAttr: ["'none'"],
-      styleSrc: ["'self'", "https:", "'unsafe-inline'"],
+      styleSrc: ["'self'", "https:"],
       // Explicitly disable Helmet's default `upgrade-insecure-requests`.
       // The directive instructs the browser to rewrite every HTTP
       // subresource URL to HTTPS before fetching. Chromium and

--- a/tests/csp-headers.integration.test.js
+++ b/tests/csp-headers.integration.test.js
@@ -1,0 +1,71 @@
+"use strict";
+
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+const request = require("supertest");
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv() {
+  Object.keys(process.env).forEach((key) => {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  });
+  Object.assign(process.env, ORIGINAL_ENV);
+}
+
+function loadApp() {
+  jest.resetModules();
+  resetEnv();
+  process.env.NODE_ENV = "test";
+  // Minimal data paths so server can start cleanly.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "csp-test-"));
+  process.env.LEADERBOARD_STORE_PATH = path.join(tmp, "leaderboard.json");
+  process.env.CLASSES_STORE_PATH = path.join(tmp, "classes.json");
+  return require("../server");
+}
+
+afterEach(resetEnv);
+
+describe("Content-Security-Policy header", () => {
+  let app;
+  beforeAll(() => { app = loadApp(); });
+
+  test("GET / includes CSP header", async () => {
+    const res = await request(app).get("/");
+    expect(res.headers["content-security-policy"]).toBeDefined();
+  });
+
+  test("GET /admin includes CSP header", async () => {
+    const res = await request(app).get("/admin");
+    expect(res.headers["content-security-policy"]).toBeDefined();
+  });
+
+  test("CSP default-src is self", async () => {
+    const res = await request(app).get("/");
+    const csp = res.headers["content-security-policy"];
+    expect(csp).toMatch(/default-src 'self'/);
+  });
+
+  test("CSP has no unsafe-eval", async () => {
+    const res = await request(app).get("/");
+    const csp = res.headers["content-security-policy"];
+    expect(csp).not.toMatch(/unsafe-eval/);
+  });
+
+  test("CSP style-src has no unsafe-inline", async () => {
+    const res = await request(app).get("/");
+    const csp = res.headers["content-security-policy"];
+    // Verify style-src directive does not contain 'unsafe-inline'.
+    // This confirms classroom-report.html styles were extracted to admin.css.
+    const styleSrc = csp.split(";").find((d) => d.trim().startsWith("style-src"));
+    expect(styleSrc).toBeDefined();
+    expect(styleSrc).not.toMatch(/unsafe-inline/);
+  });
+
+  test("CSP object-src is none", async () => {
+    const res = await request(app).get("/");
+    const csp = res.headers["content-security-policy"];
+    expect(csp).toMatch(/object-src 'none'/);
+  });
+});


### PR DESCRIPTION
## Summary

- Removes `'unsafe-inline'` from `style-src` by extracting the one remaining inline stylesheet (`classroom-report.html`) into `admin.css` under a `.report-page` scope
- Adds justification comment to `script-src 'unsafe-inline'` (pre-paint theme/lang scripts that cannot be deferred without FOUC)
- Adds 6 integration test assertions covering CSP presence and policy shape on `GET /` and `GET /admin`
- Adds `docs/security/csp.md` documenting the full policy and both noted exceptions

## Changes

| File | Change |
|------|--------|
| `server.js` | Drop `'unsafe-inline'` from `style-src`; add justification comment to `script-src` |
| `public/admin/classroom-report.html` | Remove `<style>` block; add `class="report-page"` to `<body>` |
| `public/admin/admin.css` | Append `.report-page`-scoped rules (same values, just scoped to avoid conflicting with admin/index.html tables) |
| `tests/csp-headers.integration.test.js` | New: 6 integration assertions |
| `docs/security/csp.md` | New: full policy table + rationale |

## Policy after this PR

```
default-src 'self'
base-uri 'self'
form-action 'self'
frame-ancestors 'self'
font-src 'self' https: data:
img-src 'self' data:
object-src 'none'
script-src 'self' 'unsafe-inline'   ← justified (pre-paint scripts)
script-src-attr 'none'
style-src 'self' https:             ← unsafe-inline removed ✓
```

## Test plan

- [x] `tests/csp-headers.integration.test.js` — 6/6 green
- [x] `npm run check` — 69/69 suites, 1174 tests green
- [x] Pre-push hook green

Closes #201

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>