### PR TITLE
feat(reliability): per-store deep health checks in /readyz (closes #205)

### DIFF
--- a/lib/admin-jobs-store.js
+++ b/lib/admin-jobs-store.js
@@ -225,7 +225,7 @@ class AdminJobsStore {
 
   // B7 follow-up / #205 — see lib/store-health-probe.js.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   async list(options = {}) {

--- a/lib/admin-jobs-store.js
+++ b/lib/admin-jobs-store.js
@@ -2,6 +2,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const SCHEMA_VERSION = 1;
 const DEFAULT_MAX_JOBS = 400;
@@ -220,6 +221,11 @@ class AdminJobsStore {
   async getSnapshot() {
     await this.load();
     return clone(this.state);
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   async list(options = {}) {

--- a/lib/app-config-store.js
+++ b/lib/app-config-store.js
@@ -2,6 +2,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const SCHEMA_VERSION = 1;
 const WINDOWS_RENAME_OVERWRITE_CODES = new Set(["EEXIST", "EPERM", "EACCES"]);
@@ -334,6 +335,14 @@ class AppConfigStore {
       return this.loadSync();
     }
     return clone(this.state);
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js. Async even
+  // though the store's read API is sync: the probe is fs.readFile +
+  // JSON.parse and there's no reason to bundle it into a sync wrapper
+  // when /readyz aggregates with Promise.all anyway.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   getOverridesSync() {

--- a/lib/app-config-store.js
+++ b/lib/app-config-store.js
@@ -342,7 +342,7 @@ class AppConfigStore {
   // JSON.parse and there's no reason to bundle it into a sync wrapper
   // when /readyz aggregates with Promise.all anyway.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   getOverridesSync() {

--- a/lib/challenge-config-store.js
+++ b/lib/challenge-config-store.js
@@ -301,7 +301,7 @@ class ChallengeConfigStore {
 
   // B7 follow-up / #205 — see lib/store-health-probe.js.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   async reload() {

--- a/lib/challenge-config-store.js
+++ b/lib/challenge-config-store.js
@@ -4,6 +4,7 @@ const fsp = require("node:fs/promises");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const STORE_VERSION = 1;
 const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -296,6 +297,11 @@ class ChallengeConfigStore {
 
   async getSnapshot() {
     return this.load();
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   async reload() {

--- a/lib/challenge-results-store.js
+++ b/lib/challenge-results-store.js
@@ -218,7 +218,7 @@ class ChallengeResultsStore {
 
   // B7 follow-up / #205 — see lib/store-health-probe.js.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   async reload() {

--- a/lib/challenge-results-store.js
+++ b/lib/challenge-results-store.js
@@ -5,6 +5,7 @@ const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
 const { isValidProfileName } = require("./profile-name");
+const { probeStoreFile } = require("./store-health-probe");
 
 const STORE_VERSION = 1;
 const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -213,6 +214,11 @@ class ChallengeResultsStore {
 
   async getSnapshot() {
     return this.load();
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   async reload() {

--- a/lib/classes-store.js
+++ b/lib/classes-store.js
@@ -298,7 +298,7 @@ class ClassesStore {
 
   // B7 follow-up / #205 — see lib/store-health-probe.js.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   async listClasses(options = {}) {

--- a/lib/classes-store.js
+++ b/lib/classes-store.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const fsp = fs.promises;
 
@@ -293,6 +294,11 @@ class ClassesStore {
     await this.load();
     await this.#awaitPendingWrites();
     return clone(this.state);
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   async listClasses(options = {}) {

--- a/lib/language-registry.js
+++ b/lib/language-registry.js
@@ -2,6 +2,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const REGISTRY_SCHEMA_VERSION = 1;
 const RELATIVE_PATH_PATTERN = /^(?!\/)(?!.*\.\.)[A-Za-z0-9._/-]{1,255}$/;
@@ -276,6 +277,12 @@ class LanguageRegistryStore {
   reloadSync() {
     this.cache = null;
     return this.loadSync();
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js. Async even
+  // though the registry's read API is sync.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   getEnabledLanguagesSync() {

--- a/lib/language-registry.js
+++ b/lib/language-registry.js
@@ -282,7 +282,7 @@ class LanguageRegistryStore {
   // B7 follow-up / #205 — see lib/store-health-probe.js. Async even
   // though the registry's read API is sync.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.cache !== null });
   }
 
   getEnabledLanguagesSync() {

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const fsp = fs.promises;
 
@@ -469,6 +470,16 @@ class LeaderboardStore {
   async getSnapshot() {
     await this.load();
     return clone(this.state);
+  }
+
+  // B7 follow-up / #205. Lightweight read+parse probe of the
+  // on-disk store, used by /readyz to detect "in-memory cache
+  // diverges from disk" failure modes (file removed, permission
+  // stripped, truncated). Delegates to the shared helper so every
+  // store has identical semantics; see lib/store-health-probe.js
+  // for the contract (ENOENT = healthy pre-bootstrap; 2s timeout).
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   async replace(nextState) {

--- a/lib/leaderboard-store.js
+++ b/lib/leaderboard-store.js
@@ -479,7 +479,7 @@ class LeaderboardStore {
   // store has identical semantics; see lib/store-health-probe.js
   // for the contract (ENOENT = healthy pre-bootstrap; 2s timeout).
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   async replace(nextState) {

--- a/lib/push-subscription-store.js
+++ b/lib/push-subscription-store.js
@@ -267,7 +267,7 @@ class PushSubscriptionStore {
 
   // B7 follow-up / #205 — see lib/store-health-probe.js.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   async reload() {

--- a/lib/push-subscription-store.js
+++ b/lib/push-subscription-store.js
@@ -4,6 +4,7 @@ const fsp = require("node:fs/promises");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const STORE_VERSION = 1;
 const ENDPOINT_HASH_PATTERN = /^[a-f0-9]{16}$/;
@@ -262,6 +263,11 @@ class PushSubscriptionStore {
 
   async getSnapshot() {
     return this.load();
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   async reload() {

--- a/lib/schedule-store.js
+++ b/lib/schedule-store.js
@@ -315,7 +315,7 @@ class ScheduleStore {
 
   // B7 follow-up / #205 — see lib/store-health-probe.js.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   async reload() {

--- a/lib/schedule-store.js
+++ b/lib/schedule-store.js
@@ -4,6 +4,7 @@ const fsp = require("node:fs/promises");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const DEFAULT_RETENTION_DAYS = 90;
 const SCHEDULE_VERSION = 1;
@@ -310,6 +311,11 @@ class ScheduleStore {
 
   async getSnapshot() {
     return this.load();
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   async reload() {

--- a/lib/store-health-probe.js
+++ b/lib/store-health-probe.js
@@ -1,0 +1,85 @@
+"use strict";
+
+// Lightweight read probe used by every store's `healthCheck()`
+// method (B7 follow-up / #205). The probe answers the question
+// "could this store still serve a snapshot RIGHT NOW from disk?"
+// without going through the cached in-memory `getSnapshot()` —
+// because the operator-facing failure mode the probe is designed
+// to catch is "on-disk state diverged from cache" (file removed,
+// permission revoked, truncated mid-write, partial restore).
+//
+// Probe shape: read the file as UTF-8, parse as JSON. Both ops are
+// the minimum useful coverage — they catch every failure mode an
+// upstream operator would care about EXCEPT schema-invalid-but-
+// parseable content. That last category is caught at the next real
+// `load()` call (which every request that uses the store performs)
+// — covering it here would mean shipping the per-store schema
+// validator into the health probe, which is heavier than the issue
+// asks for and adds maintenance debt.
+//
+// ENOENT is treated as healthy: a store's file may not exist yet
+// if no caller has triggered the bootstrap-on-first-write path
+// (e.g., a fresh deployment with no leaderboard rows). The store
+// itself handles that state gracefully via the documented
+// bootstrap-on-ENOENT pattern in `lib/locks.md`. A probe that
+// returned 503 from `/readyz` for a fresh deployment would be
+// noise, not signal.
+//
+// 2s timeout is per the #205 acceptance criterion. Bounded by
+// `Promise.race` against a setTimeout — the underlying fsp.readFile
+// + JSON.parse on these small JSON files (<1 MiB typically) is
+// sub-10ms in practice; the 2s budget is a safety net against a
+// genuinely-stuck disk, not a normal-path cap.
+
+const fsp = require("node:fs/promises");
+
+const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 2000;
+
+async function probeStoreFile(filePath, options = {}) {
+  if (typeof filePath !== "string" || filePath.length === 0) {
+    return { ok: false, error: "store filePath is empty or not a string" };
+  }
+  const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
+    ? options.timeoutMs
+    : DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
+  return Promise.race([
+    (async () => {
+      try {
+        const raw = await fsp.readFile(filePath, "utf8");
+        JSON.parse(raw);
+        return { ok: true };
+      } catch (err) {
+        if (err && err.code === "ENOENT") {
+          // Pre-bootstrap state — the store hasn't been written to
+          // disk yet. The first mutation will create the file via
+          // the bootstrap-on-ENOENT path. Treating this as healthy
+          // because a fresh deployment is a healthy deployment.
+          return { ok: true, note: "file not yet created (pre-bootstrap)" };
+        }
+        return {
+          ok: false,
+          error: err && err.message ? err.message : String(err)
+        };
+      }
+    })(),
+    new Promise((resolve) => {
+      const t = setTimeout(
+        () =>
+          resolve({
+            ok: false,
+            error: `health probe timeout (>${timeoutMs}ms)`
+          }),
+        timeoutMs
+      );
+      // Unref so the timer doesn't keep the event loop alive past
+      // the probe's promise settling. Without this, a fast-resolving
+      // probe still leaves a 2s timer pending.
+      if (typeof t.unref === "function") t.unref();
+    })
+  ]);
+}
+
+module.exports = {
+  probeStoreFile,
+  DEFAULT_HEALTH_PROBE_TIMEOUT_MS
+};

--- a/lib/store-health-probe.js
+++ b/lib/store-health-probe.js
@@ -17,23 +17,55 @@
 // validator into the health probe, which is heavier than the issue
 // asks for and adds maintenance debt.
 //
-// ENOENT is treated as healthy: a store's file may not exist yet
-// if no caller has triggered the bootstrap-on-first-write path
-// (e.g., a fresh deployment with no leaderboard rows). The store
-// itself handles that state gracefully via the documented
-// bootstrap-on-ENOENT pattern in `lib/locks.md`. A probe that
-// returned 503 from `/readyz` for a fresh deployment would be
-// noise, not signal.
+// ENOENT semantics depend on `expectExists` (Codex P2 on PR #216):
 //
-// 2s timeout is per the #205 acceptance criterion. Bounded by
-// `Promise.race` against a setTimeout — the underlying fsp.readFile
-// + JSON.parse on these small JSON files (<1 MiB typically) is
-// sub-10ms in practice; the 2s budget is a safety net against a
-// genuinely-stuck disk, not a normal-path cap.
+//   - `expectExists: false` (default) — ENOENT = healthy. Fresh
+//     deployments before any store has been written to disk should
+//     not 503 /readyz. The store itself handles ENOENT via the
+//     documented bootstrap-on-ENOENT pattern in `lib/locks.md`.
+//
+//   - `expectExists: true` — ENOENT = unhealthy. A store that has
+//     already loaded successfully (`this.state` populated) but then
+//     finds its file missing has diverged from disk; that's exactly
+//     the failure mode the probe exists to catch. Each store's
+//     `healthCheck()` passes `expectExists: this.state !== null` so
+//     the probe distinguishes pre-bootstrap from after-load.
+//
+// 2s timeout is per the #205 acceptance criterion. AbortController
+// cancels the underlying `fsp.readFile()` when the timeout wins,
+// so a genuinely-stuck disk doesn't accumulate hung threadpool I/O
+// across repeated readiness probes (Copilot on PR #216 caught the
+// uncancelled readFile + uncleared timer). The 2s budget is a
+// safety net; healthy probes are sub-10ms in practice.
+//
+// Error messages are sanitized before surfacing through /readyz
+// (Copilot on PR #216): fs error messages typically include the
+// full file path, which would leak filesystem layout to any
+// unauthenticated caller of the health endpoint. We strip to
+// `err.code` + a generic shape descriptor.
 
 const fsp = require("node:fs/promises");
 
 const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 2000;
+const ERROR_MESSAGE_MAX_LEN = 200;
+
+// Build a non-path-leaking error string from an arbitrary error.
+// fs errors (with `.code`) become `<CODE>: read failed` etc. —
+// no path, no node-internal stack. JSON parse errors carry only
+// position info, no path, so they pass through truncated to 200
+// chars. Everything else gets truncated similarly as a safety net.
+function sanitizeProbeError(err) {
+  if (!err) return "unknown error";
+  if (typeof err.code === "string" && err.code.length > 0) {
+    return `${err.code}: store read/parse failed`;
+  }
+  if (err.name === "SyntaxError") {
+    const msg = String(err.message || "JSON parse failed").slice(0, ERROR_MESSAGE_MAX_LEN);
+    return msg;
+  }
+  const msg = String(err.message || err);
+  return msg.slice(0, ERROR_MESSAGE_MAX_LEN);
+}
 
 async function probeStoreFile(filePath, options = {}) {
   if (typeof filePath !== "string" || filePath.length === 0) {
@@ -42,44 +74,78 @@ async function probeStoreFile(filePath, options = {}) {
   const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
     ? options.timeoutMs
     : DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
-  return Promise.race([
-    (async () => {
-      try {
-        const raw = await fsp.readFile(filePath, "utf8");
-        JSON.parse(raw);
-        return { ok: true };
-      } catch (err) {
-        if (err && err.code === "ENOENT") {
-          // Pre-bootstrap state — the store hasn't been written to
-          // disk yet. The first mutation will create the file via
-          // the bootstrap-on-ENOENT path. Treating this as healthy
-          // because a fresh deployment is a healthy deployment.
-          return { ok: true, note: "file not yet created (pre-bootstrap)" };
+  const expectExists = options.expectExists === true;
+
+  // AbortController so a slow/stuck disk doesn't leak threadpool I/O
+  // across repeated probes (Copilot on PR #216). The readFile branch
+  // honors `signal`; when the timeout wins, we abort the read so it
+  // resolves promptly with an AbortError instead of continuing in
+  // the background.
+  const controller = new AbortController();
+  let timeoutHandle = null;
+  let settled = false;
+  function clearTimer() {
+    if (timeoutHandle !== null) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
+  }
+
+  const timeoutPromise = new Promise((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      controller.abort();
+      resolve({
+        ok: false,
+        error: `health probe timeout (>${timeoutMs}ms)`
+      });
+    }, timeoutMs);
+    if (typeof timeoutHandle.unref === "function") timeoutHandle.unref();
+  });
+
+  const probePromise = (async () => {
+    try {
+      const raw = await fsp.readFile(filePath, { encoding: "utf8", signal: controller.signal });
+      JSON.parse(raw);
+      return { ok: true };
+    } catch (err) {
+      if (err && err.code === "ENOENT") {
+        if (expectExists) {
+          // Codex P2 on PR #216: store had cached state but the
+          // file is now gone — operator-visible failure mode.
+          return { ok: false, error: "ENOENT: store file removed after load" };
         }
-        return {
-          ok: false,
-          error: err && err.message ? err.message : String(err)
-        };
+        // Pre-bootstrap state — the store hasn't been written to
+        // disk yet. First mutation will create the file via the
+        // bootstrap-on-ENOENT path. Healthy.
+        return { ok: true, note: "file not yet created (pre-bootstrap)" };
       }
-    })(),
-    new Promise((resolve) => {
-      const t = setTimeout(
-        () =>
-          resolve({
-            ok: false,
-            error: `health probe timeout (>${timeoutMs}ms)`
-          }),
-        timeoutMs
-      );
-      // Unref so the timer doesn't keep the event loop alive past
-      // the probe's promise settling. Without this, a fast-resolving
-      // probe still leaves a 2s timer pending.
-      if (typeof t.unref === "function") t.unref();
-    })
-  ]);
+      // AbortError when the timeout signaled us — the timeout
+      // branch will resolve with its own message. Return an
+      // arbitrary "lost the race" result; Promise.race won't pick
+      // it because timeoutPromise resolves first.
+      if (err && (err.name === "AbortError" || err.code === "ABORT_ERR")) {
+        return { ok: false, error: "probe aborted" };
+      }
+      return { ok: false, error: sanitizeProbeError(err) };
+    }
+  })().then((result) => {
+    // Read branch settled first — clear the timer so it doesn't
+    // fire later (timer is unref'd but still scheduled work).
+    if (!settled) {
+      settled = true;
+      clearTimer();
+    }
+    return result;
+  });
+
+  return Promise.race([probePromise, timeoutPromise]);
 }
 
 module.exports = {
   probeStoreFile,
-  DEFAULT_HEALTH_PROBE_TIMEOUT_MS
+  sanitizeProbeError,
+  DEFAULT_HEALTH_PROBE_TIMEOUT_MS,
+  ERROR_MESSAGE_MAX_LEN
 };

--- a/lib/vapid-store.js
+++ b/lib/vapid-store.js
@@ -4,6 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 // Dedicated store for the VAPID keypair so the private half stays out
 // of any user-visible export path. The earlier design persisted these
@@ -96,6 +97,12 @@ class VapidStore {
     this.filePath = options.filePath;
     this.logger = options.logger || defaultLogger;
     this.state = null;
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js. Async even
+  // though the store's read API is sync.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   loadSync() {

--- a/lib/vapid-store.js
+++ b/lib/vapid-store.js
@@ -102,7 +102,7 @@ class VapidStore {
   // B7 follow-up / #205 — see lib/store-health-probe.js. Async even
   // though the store's read API is sync.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   loadSync() {

--- a/lib/webhook-delivery-store.js
+++ b/lib/webhook-delivery-store.js
@@ -4,6 +4,7 @@ const fsp = require("node:fs/promises");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const STORE_VERSION = 1;
 const STATUSES = Object.freeze(["queued", "running", "succeeded", "failed", "canceled"]);
@@ -236,6 +237,11 @@ class WebhookDeliveryStore {
 
   async getSnapshot() {
     return this.load();
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   async reload() {

--- a/lib/webhook-delivery-store.js
+++ b/lib/webhook-delivery-store.js
@@ -241,7 +241,7 @@ class WebhookDeliveryStore {
 
   // B7 follow-up / #205 — see lib/store-health-probe.js.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   async reload() {

--- a/lib/webhook-store.js
+++ b/lib/webhook-store.js
@@ -4,6 +4,7 @@ const fsp = require("node:fs/promises");
 const path = require("node:path");
 const nodeCrypto = require("node:crypto");
 const { logger: defaultLogger } = require("./logger");
+const { probeStoreFile } = require("./store-health-probe");
 
 const STORE_VERSION = 1;
 const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -304,6 +305,11 @@ class WebhookStore {
 
   async getSnapshot() {
     return this.load();
+  }
+
+  // B7 follow-up / #205 — see lib/store-health-probe.js.
+  async healthCheck() {
+    return probeStoreFile(this.filePath);
   }
 
   async reload() {

--- a/lib/webhook-store.js
+++ b/lib/webhook-store.js
@@ -309,7 +309,7 @@ class WebhookStore {
 
   // B7 follow-up / #205 — see lib/store-health-probe.js.
   async healthCheck() {
-    return probeStoreFile(this.filePath);
+    return probeStoreFile(this.filePath, { expectExists: this.state !== null });
   }
 
   async reload() {

--- a/routes/health.js
+++ b/routes/health.js
@@ -12,17 +12,25 @@
 //
 // /readyz — readiness. Returns 200 only when the process is in a
 // state to serve regular traffic — i.e., not shutting down, not in
-// the middle of a backup data-mutation swap, and not restoring.
-// Returns 503 with structured detail otherwise. Use this from a
-// load balancer or reverse proxy to withhold traffic during the
-// drain windows so in-flight requests can complete cleanly.
+// the middle of a backup data-mutation swap, not restoring, AND
+// every wired store passes a lightweight read+parse probe of its
+// on-disk file. Returns 503 with structured detail otherwise. Use
+// this from a load balancer or reverse proxy to withhold traffic
+// during the drain windows so in-flight requests can complete
+// cleanly.
 //
-// Out of scope (per #126): per-store deep health (would be a
-// follow-up — currently a store with a corrupt file on disk would
-// still return 200 from /readyz because the bytes-on-disk state
-// isn't probed here).
+// Per-store deep health (#205, B7 follow-up): when the host passes
+// a `stores: [{ name, store }]` dep, each `store.healthCheck()` is
+// invoked with a 2 s timeout. Any failure adds the store name to
+// the response `reasons` array and forces 503. The probe lives in
+// `lib/store-health-probe.js` and exercises fs.readFile + JSON.parse
+// — catches "in-memory cache diverged from disk" failure modes
+// (file removed, permission stripped, truncated) without going
+// through the store's cached snapshot.
 
 const express = require("express");
+
+const DEFAULT_STORE_HEALTH_TIMEOUT_MS = 2000;
 
 function createHealthRouter(deps) {
   const router = express.Router();
@@ -40,7 +48,16 @@ function createHealthRouter(deps) {
     getShutdownInFlight,
     // Optional version string the operator can use to confirm which
     // build is responding. Falls back to "unknown" when not supplied.
-    appVersion = "unknown"
+    appVersion = "unknown",
+    // Optional named store list for the /readyz deep-health probe
+    // (#205). Each entry: { name: string, store: { healthCheck() } }
+    // — the store must expose `healthCheck()` returning a Promise
+    // for `{ ok: boolean, error?: string }`. Pass null/[] to skip
+    // deep probes entirely.
+    stores = null,
+    // Per-store timeout for the deep-health probe. Defaults to
+    // 2000 ms per #205 acceptance.
+    storeHealthTimeoutMs = DEFAULT_STORE_HEALTH_TIMEOUT_MS
   } = deps;
 
   if (!restoreInProgressRef || typeof restoreInProgressRef.value !== "boolean") {
@@ -52,25 +69,102 @@ function createHealthRouter(deps) {
   if (typeof getShutdownInFlight !== "function") {
     throw new TypeError("createHealthRouter: getShutdownInFlight() function is required.");
   }
+  if (stores !== null && stores !== undefined && !Array.isArray(stores)) {
+    throw new TypeError("createHealthRouter: stores must be an array of { name, store } entries.");
+  }
+  if (Array.isArray(stores)) {
+    for (const entry of stores) {
+      if (!entry || typeof entry.name !== "string" || !entry.name) {
+        throw new TypeError("createHealthRouter: every stores[] entry needs a non-empty `name`.");
+      }
+      if (!entry.store || typeof entry.store.healthCheck !== "function") {
+        throw new TypeError(
+          `createHealthRouter: stores[].store.healthCheck() must be a function (failing entry: ${entry.name}).`
+        );
+      }
+    }
+  }
+
+  // Probe a single store with the per-probe timeout. Never throws —
+  // any rejection becomes an unhealthy result. The timeout is a
+  // belt-and-suspenders cap on top of probeStoreFile's own internal
+  // timeout; if a store's healthCheck() is a custom impl that
+  // doesn't honor a timeout, this race still bounds the wait.
+  async function probeOne(entry) {
+    try {
+      const result = await Promise.race([
+        Promise.resolve().then(() => entry.store.healthCheck()),
+        new Promise((resolve) => {
+          const t = setTimeout(
+            () =>
+              resolve({
+                ok: false,
+                error: `store healthCheck timeout (>${storeHealthTimeoutMs}ms)`
+              }),
+            storeHealthTimeoutMs
+          );
+          if (typeof t.unref === "function") t.unref();
+        })
+      ]);
+      if (result && typeof result === "object" && typeof result.ok === "boolean") {
+        return { name: entry.name, ...result };
+      }
+      // Defensive: a store that returns a non-conforming shape
+      // shouldn't crash the route — surface as unhealthy with an
+      // explicit reason.
+      return {
+        name: entry.name,
+        ok: false,
+        error: "healthCheck() returned non-conforming shape"
+      };
+    } catch (err) {
+      return {
+        name: entry.name,
+        ok: false,
+        error: err && err.message ? err.message : String(err)
+      };
+    }
+  }
 
   router.get("/healthz", (_req, res) => {
     res.setHeader("Cache-Control", "no-store");
     res.status(200).json({ status: "ok", version: appVersion });
   });
 
-  router.get("/readyz", (_req, res) => {
+  router.get("/readyz", async (_req, res) => {
     res.setHeader("Cache-Control", "no-store");
     const reasons = [];
     if (getShutdownInFlight()) reasons.push("shutting_down");
     if (restoreInProgressRef.value) reasons.push("restore_in_progress");
     if (dataMutationLockRef.value) reasons.push("data_mutation_locked");
+
+    // Deep-health probes run only when the surface-level state is
+    // clear — no point probing stores if we're already 503ing on
+    // shutdown/restore/lock. Keeps the happy-path /readyz latency
+    // bounded by the surface check (sub-1ms) when traffic is
+    // already being diverted.
+    let storeResults = [];
+    if (reasons.length === 0 && Array.isArray(stores) && stores.length > 0) {
+      storeResults = await Promise.all(stores.map(probeOne));
+      for (const r of storeResults) {
+        if (!r.ok) reasons.push(`store_unhealthy:${r.name}`);
+      }
+    }
+
     if (reasons.length === 0) {
-      return res.status(200).json({ status: "ready", version: appVersion });
+      return res.status(200).json({
+        status: "ready",
+        version: appVersion,
+        // Empty stores array when no deep probes ran (surface-only
+        // mode); populated with the per-store results when they did.
+        stores: storeResults
+      });
     }
     return res.status(503).json({
       status: "not_ready",
       version: appVersion,
-      reasons
+      reasons,
+      stores: storeResults
     });
   });
 
@@ -78,3 +172,4 @@ function createHealthRouter(deps) {
 }
 
 module.exports = createHealthRouter;
+module.exports.DEFAULT_STORE_HEALTH_TIMEOUT_MS = DEFAULT_STORE_HEALTH_TIMEOUT_MS;

--- a/routes/health.js
+++ b/routes/health.js
@@ -56,9 +56,17 @@ function createHealthRouter(deps) {
     // deep probes entirely.
     stores = null,
     // Per-store timeout for the deep-health probe. Defaults to
-    // 2000 ms per #205 acceptance.
-    storeHealthTimeoutMs = DEFAULT_STORE_HEALTH_TIMEOUT_MS
+    // 2000 ms per #205 acceptance. Validated below — non-finite /
+    // non-positive values fall back to the default rather than
+    // letting setTimeout(NaN) / setTimeout(0) cause /readyz to
+    // report stores unhealthy when they're fine (Copilot on PR #216).
+    storeHealthTimeoutMs: rawStoreHealthTimeoutMs = DEFAULT_STORE_HEALTH_TIMEOUT_MS
   } = deps;
+
+  const storeHealthTimeoutMs =
+    Number.isFinite(rawStoreHealthTimeoutMs) && rawStoreHealthTimeoutMs > 0
+      ? rawStoreHealthTimeoutMs
+      : DEFAULT_STORE_HEALTH_TIMEOUT_MS;
 
   if (!restoreInProgressRef || typeof restoreInProgressRef.value !== "boolean") {
     throw new TypeError("createHealthRouter: restoreInProgressRef.value (boolean) is required.");
@@ -90,6 +98,12 @@ function createHealthRouter(deps) {
   // belt-and-suspenders cap on top of probeStoreFile's own internal
   // timeout; if a store's healthCheck() is a custom impl that
   // doesn't honor a timeout, this race still bounds the wait.
+  //
+  // Returned shape: { name, ok, error?, note? }. We spread the
+  // store's result FIRST so our `name` field wins — Copilot on
+  // PR #216 caught: a store that returns a `name` field in its
+  // healthCheck result would override the route-level name and
+  // mis-tag `store_unhealthy:<name>` in /readyz reasons.
   async function probeOne(entry) {
     try {
       const result = await Promise.race([
@@ -107,7 +121,8 @@ function createHealthRouter(deps) {
         })
       ]);
       if (result && typeof result === "object" && typeof result.ok === "boolean") {
-        return { name: entry.name, ...result };
+        // Spread BEFORE name so name wins regardless of result shape.
+        return { ...result, name: entry.name };
       }
       // Defensive: a store that returns a non-conforming shape
       // shouldn't crash the route — surface as unhealthy with an
@@ -118,10 +133,17 @@ function createHealthRouter(deps) {
         error: "healthCheck() returned non-conforming shape"
       };
     } catch (err) {
+      // Sanitize the surfaced error so /readyz (mounted before auth)
+      // doesn't leak fs paths / internal stack traces to callers.
+      // Copilot on PR #216. The probe helper already sanitizes;
+      // this guard covers the case where a store's custom
+      // healthCheck() throws an unsanitized fs error directly.
+      const code = err && typeof err.code === "string" ? `${err.code}: ` : "";
+      const raw = err && err.message ? String(err.message) : String(err);
       return {
         name: entry.name,
         ok: false,
-        error: err && err.message ? err.message : String(err)
+        error: `${code}store healthCheck failed`.slice(0, 200) || raw.slice(0, 200)
       };
     }
   }

--- a/server.js
+++ b/server.js
@@ -3205,7 +3205,25 @@ app.use(
     restoreInProgressRef,
     dataMutationLockRef,
     getShutdownInFlight: () => shutdownInFlight,
-    appVersion: APP_VERSION
+    appVersion: APP_VERSION,
+    // B7 follow-up / #205: per-store deep-health probes. Each
+    // entry's `healthCheck()` is invoked with a 2 s timeout by
+    // /readyz when the surface-level checks are clear. A failure
+    // surfaces as `reasons: ["store_unhealthy:<name>"]` in the 503.
+    stores: [
+      { name: "leaderboard", store: leaderboardStore },
+      { name: "classes", store: classesStore },
+      { name: "admin-jobs", store: adminJobsStore },
+      { name: "schedule", store: scheduleStore },
+      { name: "webhooks", store: webhookStore },
+      { name: "webhook-deliveries", store: webhookDeliveryStore },
+      { name: "push-subscriptions", store: pushSubscriptionStore },
+      { name: "challenge-config", store: challengeConfigStore },
+      { name: "challenge-results", store: challengeResultsStore },
+      { name: "app-config", store: appConfigStore },
+      { name: "language-registry", store: languageRegistryStore },
+      { name: "vapid", store: vapidStore }
+    ]
   })
 );
 app.use(

--- a/tests/health-routes.test.js
+++ b/tests/health-routes.test.js
@@ -315,7 +315,13 @@ describe("/readyz — per-store deep-health (#205)", () => {
     expect(res.status).toBe(503);
     expect(res.body.reasons).toContain("store_unhealthy:throwing-store");
     const entry = res.body.stores.find((s) => s.name === "throwing-store");
-    expect(entry.error).toMatch(/synchronous boom/);
+    expect(entry.ok).toBe(false);
+    // Error is SANITIZED — original "synchronous boom" message is
+    // stripped to a generic surface so /readyz (mounted pre-auth)
+    // doesn't leak internal details to unauthenticated callers.
+    // Copilot on PR #216.
+    expect(entry.error).toMatch(/store healthCheck failed/);
+    expect(entry.error).not.toMatch(/synchronous boom/);
   });
 
   test("a healthCheck() returning non-conforming shape is treated as unhealthy", async () => {
@@ -364,4 +370,58 @@ describe("/readyz — per-store deep-health (#205)", () => {
   test("DEFAULT_STORE_HEALTH_TIMEOUT_MS is 2000", () => {
     expect(createHealthRouter.DEFAULT_STORE_HEALTH_TIMEOUT_MS).toBe(2000);
   });
+
+  // Copilot on PR #216
+  test("a store healthCheck() that returns a `name` field cannot override the route-level name", async () => {
+    // If the spread were "{ name: entry.name, ...result }", a
+    // hostile-or-buggy store could rename itself in /readyz output.
+    // Verify the correct ordering: result spread FIRST, name last.
+    const stores = [
+      {
+        name: "legit-name",
+        store: {
+          healthCheck: async () => ({
+            ok: false,
+            error: "broken",
+            name: "evil-impostor"
+          })
+        }
+      }
+    ];
+    const res = await request(buildAppWithStores({ stores })).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.reasons).toContain("store_unhealthy:legit-name");
+    expect(res.body.reasons).not.toContain("store_unhealthy:evil-impostor");
+    const entry = res.body.stores.find((s) => s.name === "legit-name");
+    expect(entry).toBeTruthy();
+    // The route preserves the store's other fields, just not name.
+    expect(entry.error).toBe("broken");
+    expect(entry.name).toBe("legit-name");
+  });
+
+  // Copilot on PR #216
+  test.each([NaN, 0, -100, "2000", undefined])(
+    "invalid storeHealthTimeoutMs (%p) falls back to default",
+    async (badValue) => {
+      const stores = [
+        { name: "ok-store", store: { healthCheck: async () => ({ ok: true }) } }
+      ];
+      const app = express();
+      app.use(
+        createHealthRouter({
+          restoreInProgressRef: { value: false },
+          dataMutationLockRef: { value: false },
+          getShutdownInFlight: () => false,
+          stores,
+          storeHealthTimeoutMs: badValue
+        })
+      );
+      const res = await request(app).get("/readyz");
+      // If validation failed, setTimeout(NaN) etc. would either fire
+      // immediately (mis-reporting the store as unhealthy) or behave
+      // unpredictably. With the validator the default kicks in and
+      // the store is healthy.
+      expect(res.status).toBe(200);
+    }
+  );
 });

--- a/tests/health-routes.test.js
+++ b/tests/health-routes.test.js
@@ -172,3 +172,196 @@ describe("/readyz", () => {
     expect(res.headers["cache-control"]).toBe("no-store");
   });
 });
+
+// B7 follow-up / #205: per-store deep-health aggregation in /readyz.
+// /readyz invokes each `stores[].store.healthCheck()` with a 2s
+// timeout when the surface-level state is clear. Any failure adds
+// the store name to `reasons` and forces 503.
+describe("/readyz — per-store deep-health (#205)", () => {
+  function buildAppWithStores({ stores, refs = makeRefs(), storeHealthTimeoutMs }) {
+    const app = express();
+    app.use(
+      createHealthRouter({
+        restoreInProgressRef: refs.restore,
+        dataMutationLockRef: refs.dataLock,
+        getShutdownInFlight: () => refs.shutdownInFlight,
+        appVersion: refs.version || "test-1.0.0",
+        stores,
+        storeHealthTimeoutMs
+      })
+    );
+    return app;
+  }
+
+  test("constructor validates stores shape", () => {
+    expect(() =>
+      createHealthRouter({
+        restoreInProgressRef: { value: false },
+        dataMutationLockRef: { value: false },
+        getShutdownInFlight: () => false,
+        stores: "not-an-array"
+      })
+    ).toThrow(/stores must be an array/);
+
+    expect(() =>
+      createHealthRouter({
+        restoreInProgressRef: { value: false },
+        dataMutationLockRef: { value: false },
+        getShutdownInFlight: () => false,
+        stores: [{ name: "", store: { healthCheck: () => Promise.resolve({ ok: true }) } }]
+      })
+    ).toThrow(/non-empty `name`/);
+
+    expect(() =>
+      createHealthRouter({
+        restoreInProgressRef: { value: false },
+        dataMutationLockRef: { value: false },
+        getShutdownInFlight: () => false,
+        stores: [{ name: "foo", store: { not_healthCheck: () => {} } }]
+      })
+    ).toThrow(/healthCheck\(\) must be a function/);
+  });
+
+  test("returns 200 when every store is healthy", async () => {
+    const stores = [
+      { name: "leaderboard", store: { healthCheck: async () => ({ ok: true }) } },
+      { name: "classes", store: { healthCheck: async () => ({ ok: true }) } },
+      { name: "schedule", store: { healthCheck: async () => ({ ok: true }) } }
+    ];
+    const res = await request(buildAppWithStores({ stores })).get("/readyz");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ready");
+    expect(res.body.stores).toHaveLength(3);
+    expect(res.body.stores.every((s) => s.ok === true)).toBe(true);
+    expect(res.body.stores.map((s) => s.name).sort()).toEqual([
+      "classes",
+      "leaderboard",
+      "schedule"
+    ]);
+  });
+
+  test("returns 503 with store name in reasons when ANY store is unhealthy", async () => {
+    const stores = [
+      { name: "leaderboard", store: { healthCheck: async () => ({ ok: true }) } },
+      {
+        name: "classes",
+        store: {
+          healthCheck: async () => ({ ok: false, error: "ENOENT: file disappeared" })
+        }
+      },
+      { name: "schedule", store: { healthCheck: async () => ({ ok: true }) } }
+    ];
+    const res = await request(buildAppWithStores({ stores })).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("not_ready");
+    expect(res.body.reasons).toContain("store_unhealthy:classes");
+    expect(res.body.reasons).not.toContain("store_unhealthy:leaderboard");
+    // The failing store's error message surfaces in the per-store
+    // breakdown so the operator can drill in.
+    const classesEntry = res.body.stores.find((s) => s.name === "classes");
+    expect(classesEntry).toBeTruthy();
+    expect(classesEntry.ok).toBe(false);
+    expect(classesEntry.error).toMatch(/ENOENT/);
+  });
+
+  test("multiple unhealthy stores all appear in reasons", async () => {
+    const stores = [
+      { name: "a", store: { healthCheck: async () => ({ ok: false, error: "err-a" }) } },
+      { name: "b", store: { healthCheck: async () => ({ ok: true }) } },
+      { name: "c", store: { healthCheck: async () => ({ ok: false, error: "err-c" }) } }
+    ];
+    const res = await request(buildAppWithStores({ stores })).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.reasons.sort()).toEqual([
+      "store_unhealthy:a",
+      "store_unhealthy:c"
+    ]);
+  });
+
+  test("a hanging healthCheck() is bounded by the per-store timeout", async () => {
+    // healthCheck never resolves — would hang the request indefinitely
+    // without the timeout. We set a 50 ms timeout for the test so the
+    // race fires in well under a second.
+    const stores = [
+      {
+        name: "hung-store",
+        store: { healthCheck: () => new Promise(() => {}) }
+      }
+    ];
+    const before = Date.now();
+    const res = await request(
+      buildAppWithStores({ stores, storeHealthTimeoutMs: 50 })
+    ).get("/readyz");
+    const elapsed = Date.now() - before;
+    expect(elapsed).toBeLessThan(500); // generous slack on top of 50 ms cap
+    expect(res.status).toBe(503);
+    expect(res.body.reasons).toContain("store_unhealthy:hung-store");
+    const entry = res.body.stores.find((s) => s.name === "hung-store");
+    expect(entry.error).toMatch(/timeout/);
+  });
+
+  test("a healthCheck() that throws synchronously becomes an unhealthy result, not a 500", async () => {
+    const stores = [
+      {
+        name: "throwing-store",
+        store: {
+          healthCheck: () => {
+            throw new Error("synchronous boom");
+          }
+        }
+      }
+    ];
+    const res = await request(buildAppWithStores({ stores })).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.reasons).toContain("store_unhealthy:throwing-store");
+    const entry = res.body.stores.find((s) => s.name === "throwing-store");
+    expect(entry.error).toMatch(/synchronous boom/);
+  });
+
+  test("a healthCheck() returning non-conforming shape is treated as unhealthy", async () => {
+    const stores = [
+      { name: "weird-store", store: { healthCheck: async () => null } },
+      { name: "missing-ok", store: { healthCheck: async () => ({}) } }
+    ];
+    const res = await request(buildAppWithStores({ stores })).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.reasons).toContain("store_unhealthy:weird-store");
+    expect(res.body.reasons).toContain("store_unhealthy:missing-ok");
+  });
+
+  test("surface-level state short-circuits BEFORE store probes (skips deep-health)", async () => {
+    // Don't run deep probes when we'll 503 anyway. Saves the 2s/store
+    // worst-case latency when traffic is already being diverted.
+    let probeCalled = false;
+    const stores = [
+      {
+        name: "would-probe",
+        store: {
+          healthCheck: async () => {
+            probeCalled = true;
+            return { ok: true };
+          }
+        }
+      }
+    ];
+    const res = await request(
+      buildAppWithStores({ stores, refs: makeRefs({ shutdownInFlight: true }) })
+    ).get("/readyz");
+    expect(res.status).toBe(503);
+    expect(res.body.reasons).toContain("shutting_down");
+    expect(probeCalled).toBe(false);
+    // When surface checks short-circuit, the stores array in the
+    // response is empty (deep probes didn't run).
+    expect(res.body.stores).toEqual([]);
+  });
+
+  test("stores=null (or omitted) means no deep-health is performed; 200 with surface check only", async () => {
+    const res = await request(buildAppWithStores({ stores: null })).get("/readyz");
+    expect(res.status).toBe(200);
+    expect(res.body.stores).toEqual([]);
+  });
+
+  test("DEFAULT_STORE_HEALTH_TIMEOUT_MS is 2000", () => {
+    expect(createHealthRouter.DEFAULT_STORE_HEALTH_TIMEOUT_MS).toBe(2000);
+  });
+});

--- a/tests/store-health-probe.test.js
+++ b/tests/store-health-probe.test.js
@@ -98,15 +98,89 @@ describe("probeStoreFile", () => {
   });
 
   test("probe doesn't keep the event loop alive past resolution", async () => {
-    // Regression test for the timer.unref() — without it, a fast
-    // probe would still leave a 2s timer pending. We can't directly
-    // observe handle counts in Jest, but we can verify the promise
-    // settles immediately (well under the 2s default timeout).
     const filePath = await makeTempFile(JSON.stringify({ version: 1 }));
     const before = Date.now();
     const result = await probeStoreFile(filePath);
     const elapsed = Date.now() - before;
     expect(result.ok).toBe(true);
     expect(elapsed).toBeLessThan(500);
+  });
+
+  // Codex P2 on PR #216
+  describe("expectExists semantics", () => {
+    test("expectExists=false (default): ENOENT returns ok:true (pre-bootstrap)", async () => {
+      const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "store-health-probe-"));
+      TEMP_DIRS.push(dir);
+      const filePath = path.join(dir, "missing.json");
+      const result = await probeStoreFile(filePath, { expectExists: false });
+      expect(result.ok).toBe(true);
+      expect(result.note).toMatch(/pre-bootstrap/);
+    });
+
+    test("expectExists=true: ENOENT returns ok:false (file gone after load)", async () => {
+      const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "store-health-probe-"));
+      TEMP_DIRS.push(dir);
+      const filePath = path.join(dir, "missing.json");
+      const result = await probeStoreFile(filePath, { expectExists: true });
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/ENOENT/);
+      expect(result.error).toMatch(/removed after load/);
+    });
+
+    test("expectExists=true: existing valid file is still healthy", async () => {
+      const filePath = await makeTempFile(JSON.stringify({ version: 1 }));
+      const result = await probeStoreFile(filePath, { expectExists: true });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  // Copilot on PR #216: error messages must not leak fs paths.
+  describe("error sanitization", () => {
+    test("fs error messages do NOT include the file path", async () => {
+      // Passing a directory to readFile yields EISDIR with the path
+      // in the raw message — verify it doesn't leak through.
+      const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "store-health-probe-"));
+      TEMP_DIRS.push(dir);
+      const result = await probeStoreFile(dir);
+      expect(result.ok).toBe(false);
+      expect(result.error).not.toContain(dir);
+      // Error CODE is still surfaced for operator triage.
+      expect(result.error).toMatch(/EISDIR|EACCES|store read\/parse failed/);
+    });
+
+    test("JSON parse errors don't reveal the path either", async () => {
+      const filePath = await makeTempFile("{not valid");
+      const result = await probeStoreFile(filePath);
+      expect(result.ok).toBe(false);
+      expect(result.error).not.toContain(filePath);
+    });
+  });
+
+  // Copilot on PR #216: timeout fires AbortController to cancel
+  // the underlying fsp.readFile so threadpool I/O doesn't pile up.
+  test("timeout cancels in-flight readFile via AbortController", async () => {
+    let capturedSignal = null;
+    const spy = jest.spyOn(fsp, "readFile").mockImplementation((_p, opts) => {
+      capturedSignal = opts && opts.signal;
+      return new Promise((_resolve, reject) => {
+        if (capturedSignal) {
+          capturedSignal.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            err.code = "ABORT_ERR";
+            reject(err);
+          });
+        }
+      });
+    });
+    try {
+      const result = await probeStoreFile("/tmp/whatever.json", { timeoutMs: 50 });
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/timeout/);
+      expect(capturedSignal).toBeTruthy();
+      expect(capturedSignal.aborted).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/tests/store-health-probe.test.js
+++ b/tests/store-health-probe.test.js
@@ -1,0 +1,112 @@
+"use strict";
+
+// Unit tests for lib/store-health-probe.js (B7 follow-up / #205).
+// Each store's healthCheck() delegates here; this file pins the
+// helper's contract directly with real filesystem operations.
+
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const os = require("node:os");
+
+const {
+  probeStoreFile,
+  DEFAULT_HEALTH_PROBE_TIMEOUT_MS
+} = require("../lib/store-health-probe");
+
+const TEMP_DIRS = [];
+
+afterAll(async () => {
+  await Promise.all(
+    TEMP_DIRS.map((dir) => fsp.rm(dir, { recursive: true, force: true }).catch(() => {}))
+  );
+});
+
+async function makeTempFile(contents) {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "store-health-probe-"));
+  TEMP_DIRS.push(dir);
+  const filePath = path.join(dir, "store.json");
+  await fsp.writeFile(filePath, contents, "utf8");
+  return filePath;
+}
+
+describe("probeStoreFile", () => {
+  test("returns ok:true for a valid JSON file", async () => {
+    const filePath = await makeTempFile(JSON.stringify({ version: 1, items: [] }));
+    const result = await probeStoreFile(filePath);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("returns ok:true with pre-bootstrap note for ENOENT", async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "store-health-probe-"));
+    TEMP_DIRS.push(dir);
+    const filePath = path.join(dir, "never-created.json");
+    const result = await probeStoreFile(filePath);
+    expect(result.ok).toBe(true);
+    expect(result.note).toMatch(/pre-bootstrap/);
+  });
+
+  test("returns ok:false with parse error for malformed JSON", async () => {
+    const filePath = await makeTempFile("{ not valid json");
+    const result = await probeStoreFile(filePath);
+    expect(result.ok).toBe(false);
+    expect(typeof result.error).toBe("string");
+    // Node's JSON parser error messages vary across versions; match
+    // a stable substring.
+    expect(result.error).toMatch(/JSON|Unexpected/i);
+  });
+
+  test("returns ok:false with parse error for empty file", async () => {
+    const filePath = await makeTempFile("");
+    const result = await probeStoreFile(filePath);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/JSON|empty/i);
+  });
+
+  test("returns ok:false on non-string filePath", async () => {
+    const result = await probeStoreFile(null);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/empty or not a string/);
+  });
+
+  test("returns ok:false on empty filePath", async () => {
+    const result = await probeStoreFile("");
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/empty or not a string/);
+  });
+
+  test("honors a per-call timeoutMs override (mock-driven)", async () => {
+    // Force the readFile path to hang by spying on fsp.readFile to
+    // return a never-resolving promise. The timeout branch should
+    // then win the race.
+    const spy = jest.spyOn(fsp, "readFile").mockImplementation(() => new Promise(() => {}));
+    try {
+      const before = Date.now();
+      const result = await probeStoreFile("/tmp/anything.json", { timeoutMs: 50 });
+      const elapsed = Date.now() - before;
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/health probe timeout/);
+      // Should land near the 50 ms cap, definitely under the 2 s
+      // default — proves the override is being honored.
+      expect(elapsed).toBeLessThan(500);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("DEFAULT_HEALTH_PROBE_TIMEOUT_MS is 2000", () => {
+    expect(DEFAULT_HEALTH_PROBE_TIMEOUT_MS).toBe(2000);
+  });
+
+  test("probe doesn't keep the event loop alive past resolution", async () => {
+    // Regression test for the timer.unref() — without it, a fast
+    // probe would still leave a 2s timer pending. We can't directly
+    // observe handle counts in Jest, but we can verify the promise
+    // settles immediately (well under the 2s default timeout).
+    const filePath = await makeTempFile(JSON.stringify({ version: 1 }));
+    const before = Date.now();
+    const result = await probeStoreFile(filePath);
+    const elapsed = Date.now() - before;
+    expect(result.ok).toBe(true);
+    expect(elapsed).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
## Summary

- New `lib/store-health-probe.js` helper does a 2 s-bounded `fsp.readFile` + `JSON.parse` probe per store.
- Every store (12 of them) gets a `healthCheck()` method that delegates to the shared probe.
- `/readyz` aggregates store probes via `Promise.all` when the surface-level state is clear; any failure surfaces as `store_unhealthy:<name>` in the 503 `reasons` array.
- Closes #205. Follow-up to PR #155 (B7).

## What this fixes

Pre-#205, `/readyz` only checked the in-process surface state (`shutdownInFlight`, `restoreInProgressRef`, `dataMutationLockRef`). A store whose on-disk file got corrupted, removed, or permission-stripped after boot would still return 200 — the cached in-memory state would mask the problem until a real request triggered a load.

The deep probe catches: file removed, permission revoked, truncated mid-write, garbage-content (parse failure), and bounds the wait at 2 s per store so a hung disk can't hang `/readyz` indefinitely.

## Response shapes

**Healthy:**
```json
200 {
  "status": "ready",
  "version": "1.0.0",
  "stores": [{ "name": "leaderboard", "ok": true }, ...]
}
```

**Unhealthy store:**
```json
503 {
  "status": "not_ready",
  "version": "1.0.0",
  "reasons": ["store_unhealthy:classes"],
  "stores": [
    { "name": "leaderboard", "ok": true },
    { "name": "classes", "ok": false, "error": "ENOENT: file disappeared" }
  ]
}
```

**Surface-level short-circuit** (skips deep probes entirely):
```json
503 { "status": "not_ready", "reasons": ["shutting_down"], "stores": [] }
```

## Implementation choices

- **ENOENT = healthy**. Stores' bootstrap-on-first-write path means a file may not exist yet (no caller has triggered a write). A probe that returned 503 for a fresh deployment would be noise.
- **Surface checks short-circuit deep probes**. No point probing stores if `/readyz` will 503 on shutdown/restore/lock anyway — saves up to 2 s × 12 stores worst case during graceful shutdown drain.
- **Two-layer timeout**. The probe helper has its own 2 s timeout; the route's `Promise.race` adds a per-probe timeout cap on top. Belt-and-suspenders against a custom-impl `healthCheck()` that doesn't honor a timeout.
- **Single source of truth** in `lib/store-health-probe.js`. Each store's `healthCheck()` is a 3-line delegator — adding a new store gets correct probe semantics by reusing the same helper.

## Test plan

- [x] +9 tests in `tests/store-health-probe.test.js` covering valid JSON, ENOENT-as-healthy, malformed/empty file, non-string/empty filePath, mock-driven timeout override, default-timeout constant, event-loop hygiene.
- [x] +10 tests in `tests/health-routes.test.js` `per-store deep-health` describe covering constructor validation, all-healthy 200, one-unhealthy 503 with correct name, multiple-unhealthy aggregation, hung healthCheck bounded by timeout, sync-throw becomes unhealthy, non-conforming shape becomes unhealthy, surface-level short-circuit, `stores=null` skip, default-constant pinned.
- [x] `npm run check` green (2368 tests in combined suite; was 2349).

## Acceptance vs. #205

- [x] Each store exposes a `healthCheck()` method (12 stores).
- [x] `/readyz` aggregates store probes; returns 503 with JSON body listing unhealthy stores by name.
- [x] ≤ 2 s per store check (default; configurable).
- [x] Integration test simulates corrupted store + asserts 503 with correct store name.
- [x] docker-compose healthcheck unchanged (contract is additive-only).
- [x] `npm run check` green.

## Out of scope (per #205)

- Write probes (read-only sufficient).
- External dependency health (none in this app).
- Prometheus metrics export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)