### PR TITLE
test(ui): fix scheduled CI browser-specific Playwright failures (supersedes #220)

### DIFF
--- a/data/leaderboard.json
+++ b/data/leaderboard.json
@@ -1,6 +1,56 @@
 {
   "version": 1,
-  "updatedAt": "1970-01-01T00:00:00.000Z",
-  "profiles": [],
-  "resultsByProfile": {}
+  "updatedAt": "2026-05-19T12:15:22.969Z",
+  "profiles": [
+    {
+      "id": "dc7d4363-b1a9-4c74-8c71-73f6fabc33bd",
+      "name": "Ava UEQGVG",
+      "createdAt": "2026-05-19T12:14:36.702Z",
+      "updatedAt": "2026-05-19T12:14:36.785Z"
+    },
+    {
+      "id": "f3e3118a-871e-4cf7-b6cf-6166737340e6",
+      "name": "Ava JAPXU",
+      "createdAt": "2026-05-19T12:14:55.632Z",
+      "updatedAt": "2026-05-19T12:14:55.776Z"
+    },
+    {
+      "id": "4a399398-da62-43aa-9fb9-61f489695771",
+      "name": "Ava TLGYLU",
+      "createdAt": "2026-05-19T12:15:22.877Z",
+      "updatedAt": "2026-05-19T12:15:22.969Z"
+    }
+  ],
+  "resultsByProfile": {
+    "dc7d4363-b1a9-4c74-8c71-73f6fabc33bd": {
+      "2026-05-19|en|YFRQP": {
+        "date": "2026-05-19",
+        "won": true,
+        "attempts": 1,
+        "maxGuesses": 6,
+        "submissionCount": 1,
+        "updatedAt": "2026-05-19T12:14:36.785Z"
+      }
+    },
+    "f3e3118a-871e-4cf7-b6cf-6166737340e6": {
+      "2026-05-19|en|YFRQP": {
+        "date": "2026-05-19",
+        "won": true,
+        "attempts": 1,
+        "maxGuesses": 6,
+        "submissionCount": 1,
+        "updatedAt": "2026-05-19T12:14:55.776Z"
+      }
+    },
+    "4a399398-da62-43aa-9fb9-61f489695771": {
+      "2026-05-19|en|YFRQP": {
+        "date": "2026-05-19",
+        "won": true,
+        "attempts": 1,
+        "maxGuesses": 6,
+        "submissionCount": 1,
+        "updatedAt": "2026-05-19T12:15:22.969Z"
+      }
+    }
+  }
 }

--- a/data/leaderboard.json
+++ b/data/leaderboard.json
@@ -1,56 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-05-19T12:15:22.969Z",
-  "profiles": [
-    {
-      "id": "dc7d4363-b1a9-4c74-8c71-73f6fabc33bd",
-      "name": "Ava UEQGVG",
-      "createdAt": "2026-05-19T12:14:36.702Z",
-      "updatedAt": "2026-05-19T12:14:36.785Z"
-    },
-    {
-      "id": "f3e3118a-871e-4cf7-b6cf-6166737340e6",
-      "name": "Ava JAPXU",
-      "createdAt": "2026-05-19T12:14:55.632Z",
-      "updatedAt": "2026-05-19T12:14:55.776Z"
-    },
-    {
-      "id": "4a399398-da62-43aa-9fb9-61f489695771",
-      "name": "Ava TLGYLU",
-      "createdAt": "2026-05-19T12:15:22.877Z",
-      "updatedAt": "2026-05-19T12:15:22.969Z"
-    }
-  ],
-  "resultsByProfile": {
-    "dc7d4363-b1a9-4c74-8c71-73f6fabc33bd": {
-      "2026-05-19|en|YFRQP": {
-        "date": "2026-05-19",
-        "won": true,
-        "attempts": 1,
-        "maxGuesses": 6,
-        "submissionCount": 1,
-        "updatedAt": "2026-05-19T12:14:36.785Z"
-      }
-    },
-    "f3e3118a-871e-4cf7-b6cf-6166737340e6": {
-      "2026-05-19|en|YFRQP": {
-        "date": "2026-05-19",
-        "won": true,
-        "attempts": 1,
-        "maxGuesses": 6,
-        "submissionCount": 1,
-        "updatedAt": "2026-05-19T12:14:55.776Z"
-      }
-    },
-    "4a399398-da62-43aa-9fb9-61f489695771": {
-      "2026-05-19|en|YFRQP": {
-        "date": "2026-05-19",
-        "won": true,
-        "attempts": 1,
-        "maxGuesses": 6,
-        "submissionCount": 1,
-        "updatedAt": "2026-05-19T12:15:22.969Z"
-      }
-    }
-  }
+  "updatedAt": "1970-01-01T00:00:00.000Z",
+  "profiles": [],
+  "resultsByProfile": {}
 }

--- a/tests/ui/admin-shell.spec.js
+++ b/tests/ui/admin-shell.spec.js
@@ -672,7 +672,9 @@ test("admin shell lock button clears unlocked session", async ({ page }) => {
   await page.click("#unlockForm button[type=submit]");
   await expect(page.locator("#shellPanel")).toBeVisible();
 
-  await page.locator("#lockSessionBtn").evaluate((button) => button.click());
+  const lockSessionBtn = page.locator("#lockSessionBtn");
+  await lockSessionBtn.waitFor({ state: "visible" });
+  await lockSessionBtn.evaluate((button) => button.click());
   await expect(page.locator("#unlockPanel")).toBeVisible();
   await expect(page.locator("#shellPanel")).toBeHidden();
   await expect(page.locator("#adminUpdated")).toContainText("Session locked");

--- a/tests/ui/admin-shell.spec.js
+++ b/tests/ui/admin-shell.spec.js
@@ -673,8 +673,9 @@ test("admin shell lock button clears unlocked session", async ({ page }) => {
   await expect(page.locator("#shellPanel")).toBeVisible();
 
   const lockSessionBtn = page.locator("#lockSessionBtn");
-  await lockSessionBtn.waitFor({ state: "visible" });
-  await lockSessionBtn.evaluate((button) => button.click());
+  await expect(lockSessionBtn).toBeVisible();
+  await expect(lockSessionBtn).toBeEnabled();
+  await lockSessionBtn.click();
   await expect(page.locator("#unlockPanel")).toBeVisible();
   await expect(page.locator("#shellPanel")).toBeHidden();
   await expect(page.locator("#adminUpdated")).toContainText("Session locked");

--- a/tests/ui/admin-shell.spec.js
+++ b/tests/ui/admin-shell.spec.js
@@ -672,7 +672,7 @@ test("admin shell lock button clears unlocked session", async ({ page }) => {
   await page.click("#unlockForm button[type=submit]");
   await expect(page.locator("#shellPanel")).toBeVisible();
 
-  await page.click("#lockSessionBtn");
+  await page.locator("#lockSessionBtn").evaluate((button) => button.click());
   await expect(page.locator("#unlockPanel")).toBeVisible();
   await expect(page.locator("#shellPanel")).toBeHidden();
   await expect(page.locator("#adminUpdated")).toContainText("Session locked");

--- a/tests/ui/create-play.spec.js
+++ b/tests/ui/create-play.spec.js
@@ -238,7 +238,7 @@ test("settings toggles meet 44px touch-target height at mobile viewport", async 
   await page.goto("/", { waitUntil: "commit" });
   await waitForLanguages(page);
 
-  const toggles = await page.locator(".settings .toggle").all();
+  const toggles = await page.locator(".settings .toggle:visible").all();
   expect(toggles.length).toBeGreaterThan(0);
   for (const toggle of toggles) {
     const box = await toggle.boundingBox();
@@ -247,13 +247,15 @@ test("settings toggles meet 44px touch-target height at mobile viewport", async 
   }
 });
 
-test("share link copy shows confirmation", async ({ page, context }) => {
+test("share link copy shows confirmation", async ({ page, context, browserName }) => {
   test.setTimeout(60000);
   /* Headless Chromium needs clipboard-write granted explicitly for
      `navigator.clipboard.writeText` to resolve. Without this the handler
      falls into the `execCommand` fallback, which is fine but harder to
      reason about in tests. */
-  await context.grantPermissions(["clipboard-write"]);
+  if (browserName === "chromium") {
+    await context.grantPermissions(["clipboard-write"]);
+  }
   await page.goto("/?word=yfrqp&lang=en", gotoOptions);
   await page.waitForSelector("#playPanel:not(.hidden)", { timeout: 10000 });
   await page.click("#shareCopyBtn");


### PR DESCRIPTION
## Summary

Supersedes #220 with the Copilot review comment addressed.

This branch contains the three commits from #220 plus one additional commit (`781ccb5`) that replaces the `locator.evaluate(button => button.click())` workaround in the admin-shell lock-session test with a proper Playwright-actionability path: `expect(lockSessionBtn).toBeVisible()` + `.toBeEnabled()` + `.click()`.

## Root cause re-analysis

The original webkit flake was not an actionability problem — it was a timing one. `public/admin/app.js:663` disables `#lockSessionBtn` while `state.loading || state.importing` is true, so a `page.click("#lockSessionBtn")` racing the post-unlock `state.loading=false` transition rejects in webkit (Playwright errors on disabled element click in webkit faster than the auto-retry catches the enable).

Switching to `expect(...).toBeEnabled()` makes the test auto-wait through Playwright's normal retry loop, and the click then goes through the full actionability pipeline (scroll-into-view, overlay-check, stable bounding box, enabled) — so a real-user regression would still fail the test.

## Class-wide sweep

`grep -rn "evaluate.*\.click()\|evaluate.*=>.*click" tests/` — confirmed this was the only DOM-evaluate-click bypass in the repo.

## Validation

- [x] `npm run check` locally (lint, schema, i18n, markdown, claims, locks, proto, secrets, audit, guardrails, 1219 jest tests passed).
- [ ] `npm run test:ui` — not runnable in this sandbox (no browsers); CI will exercise across chromium/firefox/webkit.

## Review focus

1. Does `toBeEnabled()` auto-wait match the intended interaction model better than the prior DOM-click workaround?
2. Cross-browser stability — webkit was the original flake source; please confirm the green CI run before merging.

## Closing notes

Once CI is green and review approves, merging this PR can replace merging #220.

---
_Generated by [Claude Code](https://claude.ai/code/session_011AcJYRUjrJFobTDsTuySp9)_