### PR TITLE
test(ui): fix webkit lock-button failure + harden firefox bootstrap flake

### DIFF
--- a/tests/ui/admin-shell.spec.js
+++ b/tests/ui/admin-shell.spec.js
@@ -675,7 +675,15 @@ test("admin shell lock button clears unlocked session", async ({ page }) => {
   const lockSessionBtn = page.locator("#lockSessionBtn");
   await expect(lockSessionBtn).toBeVisible();
   await expect(lockSessionBtn).toBeEnabled();
-  await lockSessionBtn.click();
+  // WebKit intermittently reports this button "outside of the viewport"
+  // after Playwright's actionability scroll and loops the click action
+  // until the 30s timeout — a known WebKit hit-test race for an element
+  // that is genuinely in normal flow (it lives in the shell header).
+  // Activate via keyboard instead: #lockSessionBtn is a native <button>
+  // with a click listener (public/admin/app.js:2357), so focusing it and
+  // pressing Enter dispatches the same real click event without the
+  // point-based viewport hit test that chokes WebKit.
+  await lockSessionBtn.press("Enter");
   await expect(page.locator("#unlockPanel")).toBeVisible();
   await expect(page.locator("#shellPanel")).toBeHidden();
   await expect(page.locator("#adminUpdated")).toContainText("Session locked");

--- a/tests/ui/stats-backend.spec.js
+++ b/tests/ui/stats-backend.spec.js
@@ -73,7 +73,19 @@ async function openDaily(page, day, options = {}) {
   // Wait for `domcontentloaded` so bootstrap has had a chance to run
   // before we probe for `#playPanel`.
   await page.waitForLoadState("domcontentloaded");
-  await page.waitForSelector("#playPanel:not(.hidden)");
+  // Under several parallel firefox contexts on a single CI worker the
+  // bootstrap that strips `.hidden` from #playPanel occasionally stalls
+  // past the per-page timeout (the documented race from #142 / PR #143).
+  // Reload once and re-probe so a stalled bootstrap self-heals inside the
+  // helper — cheaper and more deterministic than burning a whole
+  // test-level retry. Both probes stay within the 120s test budget.
+  try {
+    await page.waitForSelector("#playPanel:not(.hidden)", { timeout: 30000 });
+  } catch {
+    await page.reload(gotoOptions);
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForSelector("#playPanel:not(.hidden)");
+  }
   if (expectProfilePanel) {
     await expect(page.locator("#profilePanel")).toBeVisible();
   }

--- a/tests/ui/stats-backend.spec.js
+++ b/tests/ui/stats-backend.spec.js
@@ -78,9 +78,13 @@ async function openDaily(page, day, options = {}) {
   // past the per-page timeout (the documented race from #142 / PR #143).
   // Reload once and re-probe so a stalled bootstrap self-heals inside the
   // helper — cheaper and more deterministic than burning a whole
-  // test-level retry. Both probes stay within the 120s test budget.
+  // test-level retry. Both probes use the same explicit 30s budget, so the
+  // worst case is a deterministic 60s — comfortably within the 120s test
+  // budget — rather than 30s plus the 60s page default.
+  const probeReady = () =>
+    page.waitForSelector("#playPanel:not(.hidden)", { timeout: 30000 });
   try {
-    await page.waitForSelector("#playPanel:not(.hidden)", { timeout: 30000 });
+    await probeReady();
   } catch (err) {
     // Only self-heal the documented bootstrap stall, which surfaces as a
     // wait timeout. Re-throw anything else (closed page/context, navigation
@@ -91,7 +95,7 @@ async function openDaily(page, day, options = {}) {
     }
     await page.reload(gotoOptions);
     await page.waitForLoadState("domcontentloaded");
-    await page.waitForSelector("#playPanel:not(.hidden)");
+    await probeReady();
   }
   if (expectProfilePanel) {
     await expect(page.locator("#profilePanel")).toBeVisible();

--- a/tests/ui/stats-backend.spec.js
+++ b/tests/ui/stats-backend.spec.js
@@ -81,7 +81,14 @@ async function openDaily(page, day, options = {}) {
   // test-level retry. Both probes stay within the 120s test budget.
   try {
     await page.waitForSelector("#playPanel:not(.hidden)", { timeout: 30000 });
-  } catch {
+  } catch (err) {
+    // Only self-heal the documented bootstrap stall, which surfaces as a
+    // wait timeout. Re-throw anything else (closed page/context, navigation
+    // error, bad selector) so real failures stay loud instead of being
+    // masked by a reload.
+    if (err.name !== "TimeoutError") {
+      throw err;
+    }
     await page.reload(gotoOptions);
     await page.waitForLoadState("domcontentloaded");
     await page.waitForSelector("#playPanel:not(.hidden)");


### PR DESCRIPTION
## Summary

- Issue: #223
- Scope: Fix the two scheduled/`workflow_dispatch` Playwright UI-gate failures (a WebKit-specific lock-button timeout and a firefox bootstrap flake) — test-harness only, no production code.
- Epic: n/a

These were surfaced by manual CI run [#620](https://github.com/curdriceaurora/wordle-local/actions/runs/26631911337) once the `qs` audit-gate fix (#222) let the run reach the UI steps. `npm run check` was already green; only `test:ui` was red.

## In Scope

- `tests/ui/admin-shell.spec.js`: activate `#lockSessionBtn` via `press("Enter")` instead of `.click()` to avoid WebKit's point-based viewport hit-test race (same native-button click handler fires; `public/admin/app.js:2357`).
- `tests/ui/stats-backend.spec.js`: `openDaily` self-heals a stalled bootstrap — probe `#playPanel:not(.hidden)` on a 30s budget, and on `TimeoutError` only, reload once and re-probe (shared 30s-budget helper; non-timeout errors rethrown).

## Out of Scope

- Any production/runtime code (`server.js`, `public/**`, `lib/**`) — unchanged.
- The broader documented firefox `waitUntil:"commit"` race across other spec files — left to the existing retry strategy.
- CodeRabbit "Docstring Coverage" pre-merge warning — no UI spec uses JSDoc and there is no docstring gate in `npm run check`; adding JSDoc to Playwright specs would break the established convention. Pre-existing test files are also 0%.

## Risk Review

- Primary risks:
  - `press("Enter")` exercises a slightly different activation path than a pointer click.
  - The self-heal reload could mask a genuine failure.
- Mitigations:
  - `#lockSessionBtn` is a native `<button>` with a `click` listener, so Enter dispatches a real click event; `toBeVisible`/`toBeEnabled` asserts are retained as guards.
  - The `catch` only reloads on `TimeoutError` and rethrows everything else (closed page/context, navigation error, bad selector), so real failures stay loud.

## Review-Nit Preflight (Required)

- N/A — tests-only change. No docs/schema/API/endpoint/JSON-schema/dynamic-key/store-mutation/rate-limit surface is touched. The applicable item — deterministic timing — holds: probes use explicit fixed timeouts within the 120s test budget (no real-clock dependency added).

## Validation

- [x] `npm test` (jest) — 1219 passed, 1 skipped.
- [x] `npm run test:ui` — validated in CI via `workflow_dispatch` runs (webkit/firefox browsers can't be installed in the dev sandbox; download host not in the network allowlist):
  - Run **#622** (SHA `385e974`): full 3-browser suite `success`.
  - Run **#624** (SHA `8e15a21`): full 3-browser suite `success`, incl. the previously-failing "Run UI Tests" step.
- Notes:
  - Also `eslint` clean and full `npm run check` green locally on each commit (pre-push gate).

## Review Focus

1. WebKit lock-button activation: does keyboard `Enter` faithfully exercise the lock flow? (handler is `click`-bound; Enter on a focused button dispatches click.)
2. `openDaily` self-heal: timeout-only reload, symmetric 30s budgets, non-timeout rethrow.
3. No behavioral change on the happy path (selector resolves within 30s → `catch` never runs).

## Copilot Review Loop

- [x] Copilot auto-review ran on pushes; threads addressed.
- [x] Both Copilot review nits resolved with a fix commit + thread reply (`8e15a21`, `dbd479b`); CodeRabbit returned "no actionable comments". 0 open threads.
- [x] Sticky `<!-- pr-watch-status -->` present and reflecting latest green CI.

## Post-Merge Learning Update (Required)

- [ ] After merge, add to `docs/review-preflight.md` → Merged PR Learnings Log: "Prefer keyboard activation for native buttons that hit WebKit's 'outside of the viewport' click race; narrow self-heal `catch` blocks to the specific timeout error."

Closes #223.

https://claude.ai/code/session_012Xv6TDd3hpGGjzeiM86soX