### PR TITLE
feat(security): support encrypted data mounts (closes #203)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,12 @@ RATE_LIMIT_MAX=300
 RATE_LIMIT_WINDOW_MS=900000
 NODE_ENV=development
 
+# Host directory mounted at /app/data by Docker Compose. Leave this at
+# ./data for normal local use. For encryption at rest, point it at the
+# mounted plaintext view of an encrypted filesystem; never point it at
+# the ciphertext directory itself.
+# WORDLE_DATA_DIR=./data
+
 # Optional memory tuning for definitions
 LOW_MEMORY_DEFINITIONS=false
 DEFINITIONS_MODE=memory

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The header has a language switcher (English, Spanish). Selection persists in the
 - **Opt-in browser push notifications** when the daily puzzle is ready ([docs/notifications.md](docs/notifications.md)).
 - **Outbound webhooks** with HMAC-signed deliveries, retry queue, and recovery on boot ([docs/webhooks.md](docs/webhooks.md)).
 - **Backup / restore** — versioned, schema-checked archives applied atomically ([docs/backup-restore.md](docs/backup-restore.md)).
+- **Optional encryption at rest** — mount `data/` from an encrypted host filesystem ([runbook](docs/security/data-encryption-at-rest.md)).
 - **Usage analytics** — admin dashboard with offline charting ([docs/admin-analytics.md](docs/admin-analytics.md)).
 - **UI internationalization** — English + Spanish at strict per-key parity, switchable from the header ([docs/i18n.md](docs/i18n.md)).
 

--- a/advanced-settings.md
+++ b/advanced-settings.md
@@ -71,6 +71,10 @@ Set `ADMIN_KEY` to protect admin endpoints. When set, include `x-admin-key: <val
 - `PORT` — default 3000.
 - `HOST` — default 0.0.0.0.
 - `NODE_ENV` — `development` or `production`.
+- `WORDLE_DATA_DIR` — Docker Compose host path mounted at `/app/data`
+  (default `./data`). Point this at the mounted plaintext view of an
+  encrypted filesystem for encryption at rest; see
+  [the encryption runbook](docs/security/data-encryption-at-rest.md).
 - `JSON_BODY_LIMIT` — max JSON payload size for API requests (default `12mb`).
 - `PROVIDER_MANUAL_MAX_FILE_BYTES` — max bytes per manual upload file (default `8388608` / 8 MiB).
 - `APP_CONFIG_PATH` — optional override path for persisted runtime overrides (`data/app-config.json` by default).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
       DEFINITION_SHARD_CACHE_SIZE: ${DEFINITION_SHARD_CACHE_SIZE:-6}
       PERF_LOGGING: ${PERF_LOGGING:-false}
     volumes:
-      - ./data:/app/data
+      # Point WORDLE_DATA_DIR at the mounted plaintext view of an
+      # encrypted host filesystem. See docs/security/data-encryption-at-rest.md.
+      - ${WORDLE_DATA_DIR:-./data}:/app/data
     restart: unless-stopped
     # B7 / #126: readiness probe. /readyz returns 200 when the
     # process is up AND not shutting down AND no restore/backup is

--- a/docs/admin-security-checklist.md
+++ b/docs/admin-security-checklist.md
@@ -56,6 +56,9 @@ Use this checklist for any release that touches `/api/admin/*`, provider imports
    - `ADMIN_KEY`
    - `TRUST_PROXY` and `TRUST_PROXY_HOPS` appropriate for topology
    - explicit admin rate-limit overrides only when justified
+   - an encrypted host filesystem for `data/` when offline disk or
+     snapshot theft is in the deployment threat model; see
+     [`docs/security/data-encryption-at-rest.md`](security/data-encryption-at-rest.md)
 
 ## Common pitfalls
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -341,7 +341,10 @@ archive offline:
 
 The archive is plaintext. `data/leaderboard.json` and
 `data/classes.json` contain profile names and per-game timing. Treat
-backups as sensitive; encrypt at rest if you are sharing them off-host.
+backups as sensitive. The encrypted-data mount protects files that
+remain inside that filesystem, but a downloaded backup leaves that
+boundary and must be encrypted separately before off-host storage.
+See [`docs/security/data-encryption-at-rest.md`](security/data-encryption-at-rest.md).
 
 ## Configured data paths
 
@@ -372,7 +375,7 @@ logic the stores use; tracked separately.
 
 - Selective per-file restore (all-or-nothing only)
 - Cross-host migration (archives are local to a single node)
-- Encryption / password protection
+- Built-in archive encryption / password protection
 - Continuous backups, retention policies
 - Backup with non-default `STATS_STORE_PATH` /
   `CLASSES_STORE_PATH` / `ADMIN_JOBS_STORE_PATH` /

--- a/docs/security/data-encryption-at-rest.md
+++ b/docs/security/data-encryption-at-rest.md
@@ -51,6 +51,11 @@ The default remains `./data`. The configured directory must contain the
 entire repository `data/` tree, including schemas and bundled dictionary
 assets. Never set `WORDLE_DATA_DIR` to the ciphertext directory.
 
+The container runs Wordle as UID/GID `1000:1000`. The mounted plaintext
+directory must be writable by that identity. The commands below set that
+ownership explicitly. If your deployment runs the container with a
+different Compose `user:`, use that UID/GID instead.
+
 Check the resolved mount before starting:
 
 ```bash
@@ -72,7 +77,7 @@ is the usual local-disk option.
    ```bash
    sudo mkdir -p /srv/wordle-data
    sudo cp -a ./data/. /srv/wordle-data/
-   sudo chown -R "$(id -u):$(id -g)" /srv/wordle-data
+   sudo chown -R 1000:1000 /srv/wordle-data
    ```
 
 4. Set the absolute mount path in `.env`:
@@ -105,14 +110,29 @@ mounted plaintext view.
 
 Stop Wordle before migration, then:
 
+On Linux, allow the Docker daemon and the container's UID to traverse the
+FUSE mount by enabling this line in `/etc/fuse.conf`:
+
+```ini
+user_allow_other
+```
+
+The host administrator must make that change. Then create and mount the
+encrypted directory with `-allow_other`:
+
 ```bash
 mkdir -p "$HOME/.local/share/wordle-data.cipher"
 mkdir -p "$HOME/.local/share/wordle-data"
 gocryptfs -init "$HOME/.local/share/wordle-data.cipher"
-gocryptfs "$HOME/.local/share/wordle-data.cipher" \
+gocryptfs -allow_other "$HOME/.local/share/wordle-data.cipher" \
   "$HOME/.local/share/wordle-data"
 cp -a ./data/. "$HOME/.local/share/wordle-data/"
+sudo chown -R 1000:1000 "$HOME/.local/share/wordle-data"
 ```
+
+`-allow_other` permits other host identities to reach the mount, but
+normal Unix permissions still apply; the ownership change grants the
+container's `node` user write access.
 
 Set the mountpoint—not the ciphertext directory—in `.env`:
 
@@ -131,8 +151,14 @@ docker compose down
 fusermount -u "$HOME/.local/share/wordle-data"
 ```
 
-Use the equivalent FUSE unmount command supplied by your operating system
-when `fusermount` is unavailable.
+On macOS, use:
+
+```bash
+umount "$HOME/.local/share/wordle-data"
+```
+
+For other systems, use the unmount command supplied by the installed FUSE
+implementation.
 
 ## Key rotation
 

--- a/docs/security/data-encryption-at-rest.md
+++ b/docs/security/data-encryption-at-rest.md
@@ -1,0 +1,181 @@
+# Data encryption at rest
+
+This runbook addresses issue #203 by choosing host-level filesystem
+encryption instead of application-level per-file encryption.
+
+## Threat model
+
+Encryption at rest protects the persisted `data/` tree when an attacker
+obtains an offline disk image, snapshot, detached volume, or copy of the
+ciphertext directory without also obtaining the unlock key.
+
+It does not protect against:
+
+- compromise of the running Wordle process or host while the encrypted
+  filesystem is mounted;
+- an attacker who can read process memory, deployment secrets, or the
+  mounted plaintext directory;
+- application-level authorization failures;
+- plaintext backup archives downloaded from the admin Data tab.
+
+The application must see plaintext while it is running. The storage
+layer encrypts bytes before they reach the backing disk.
+
+## Why host-level encryption
+
+The `data/` tree is not one JSON store. It includes mutable stores,
+provider artifacts, word pools, dictionaries, schemas, backup staging,
+restore rollback directories, health probes, and streaming backup I/O.
+Wrapping only selected JSON writes would create a misleading partial
+security boundary and complicate atomic rename and restore guarantees.
+
+Host-level encryption covers the whole tree transparently, preserving
+the existing file formats, locks, atomic writes, backup/restore paths,
+and test behavior. The application does not receive or retain the
+encryption key.
+
+Do not put a filesystem key in `.env`. Environment variables are visible
+to the running process and often to container inspection tooling. Unlock
+the encrypted filesystem before starting Wordle, then mount its plaintext
+view into the container.
+
+## Docker Compose configuration
+
+Compose mounts `WORDLE_DATA_DIR` at `/app/data`:
+
+```bash
+WORDLE_DATA_DIR=/absolute/path/to/plaintext-mount
+```
+
+The default remains `./data`. The configured directory must contain the
+entire repository `data/` tree, including schemas and bundled dictionary
+assets. Never set `WORDLE_DATA_DIR` to the ciphertext directory.
+
+Check the resolved mount before starting:
+
+```bash
+docker compose config
+```
+
+## Option A: encrypted host volume
+
+For a server or VM, prefer a host volume protected by the platform's
+native encrypted block storage or full-disk encryption. On Linux, LUKS
+is the usual local-disk option.
+
+1. Provision and unlock the encrypted volume using the host or cloud
+   platform's documented procedure.
+2. Mount its plaintext filesystem, for example at
+   `/srv/wordle-data`.
+3. Stop Wordle and copy the complete data tree:
+
+   ```bash
+   sudo mkdir -p /srv/wordle-data
+   sudo cp -a ./data/. /srv/wordle-data/
+   sudo chown -R "$(id -u):$(id -g)" /srv/wordle-data
+   ```
+
+4. Set the absolute mount path in `.env`:
+
+   ```bash
+   WORDLE_DATA_DIR=/srv/wordle-data
+   ```
+
+5. Start Wordle and verify the data-backed routes:
+
+   ```bash
+   docker compose up --build -d
+   curl -fsS http://127.0.0.1:3000/api/health
+   curl -fsS http://127.0.0.1:3000/api/meta
+   ```
+
+6. After verifying the migrated state, securely remove the old plaintext
+   copy according to the storage medium's guarantees. Deleting files is
+   not a reliable secure erase on SSDs or copy-on-write filesystems.
+
+Configure the host so the encrypted volume is unlocked and mounted before
+Compose starts. If the mount is absent, stop rather than silently starting
+against an empty fallback directory.
+
+## Option B: gocryptfs directory
+
+For a small Linux self-hosted deployment without a dedicated encrypted
+block volume, gocryptfs provides an encrypted backing directory and a
+mounted plaintext view.
+
+Stop Wordle before migration, then:
+
+```bash
+mkdir -p "$HOME/.local/share/wordle-data.cipher"
+mkdir -p "$HOME/.local/share/wordle-data"
+gocryptfs -init "$HOME/.local/share/wordle-data.cipher"
+gocryptfs "$HOME/.local/share/wordle-data.cipher" \
+  "$HOME/.local/share/wordle-data"
+cp -a ./data/. "$HOME/.local/share/wordle-data/"
+```
+
+Set the mountpoint—not the ciphertext directory—in `.env`:
+
+```bash
+WORDLE_DATA_DIR=/home/your-user/.local/share/wordle-data
+```
+
+Then run the Compose and route verification commands from the previous
+section. Inspect the ciphertext directory while the mount is active:
+filenames and file contents there must not expose the plaintext dataset.
+
+Unmount only after Wordle has stopped:
+
+```bash
+docker compose down
+fusermount -u "$HOME/.local/share/wordle-data"
+```
+
+Use the equivalent FUSE unmount command supplied by your operating system
+when `fusermount` is unavailable.
+
+## Key rotation
+
+Always take and test a separate encrypted backup before changing keys.
+Stop Wordle so no writes occur during maintenance.
+
+For gocryptfs, rotate the wrapping password interactively:
+
+```bash
+docker compose down
+gocryptfs -passwd "$HOME/.local/share/wordle-data.cipher"
+```
+
+Mount again with the new password, verify the files, start Wordle, and
+delete `gocryptfs.conf.bak` only after successful verification. The
+backup config can retain access using the previous password.
+
+For LUKS, use the host's supported keyslot procedure. A typical
+passphrase change uses:
+
+```bash
+sudo cryptsetup luksChangeKey /dev/<encrypted-device>
+```
+
+Cloud-managed encrypted volumes have provider-specific rotation
+semantics; follow that platform's procedure and confirm whether rotation
+changes only the wrapping key or re-encrypts data.
+
+## Recovery and key loss
+
+Store recovery material separately from the encrypted disk and from
+off-host ciphertext backups. Test recovery before relying on it.
+
+If every valid key, passphrase, keyslot, and recovery copy is lost, the
+data is unrecoverable by design. The Wordle application has no bypass or
+recovery key.
+
+## Backups
+
+Admin backup archives are plaintext ZIP files. Creating an archive reads
+through the mounted plaintext view, so the downloaded file is not
+automatically encrypted by the data volume.
+
+Keep archives inside encrypted storage or encrypt them with an
+independent backup tool before copying them elsewhere. Do not assume the
+encrypted live-data mount protects files after they leave that mount.


### PR DESCRIPTION
## Summary

Adds an operator-supported encryption-at-rest path for the complete `data/` tree using host-level filesystem encryption.

- Compose now accepts `WORDLE_DATA_DIR` as the host directory mounted at `/app/data`.
- A new security runbook defines the offline-exfiltration threat model and documents encrypted-volume and gocryptfs setup.
- The runbook includes migration, verification, key rotation, recovery, key-loss, and plaintext-backup guidance.
- README, advanced settings, the admin security checklist, and backup documentation link to the new boundary.

## Architecture decision

Issue #203 allowed OS-level or application-level encryption. This chooses OS-level encryption because `data/` spans mutable JSON stores, provider artifacts, dictionaries, schemas, backup staging, restore rollback directories, health probes, and streaming backup I/O. Per-file wrapping would risk partial coverage and disturb existing atomic rename and restore guarantees.

The issue suggested sourcing the key from an application environment variable. This implementation deliberately keeps the filesystem key outside the application process and container environment. The host unlocks the encrypted filesystem before Wordle starts, then Compose mounts only its plaintext view. That better matches the stated offline disk/snapshot theft threat model and avoids exposing the key through process or container inspection.

## Validation

- `npm run check` — 70 suites, 1,236 tests passed
- `npm run markdown:check`
- `npm run claims:check`
- `git diff --check`
- `WORDLE_DATA_DIR=/tmp/wordle-encrypted-plain docker compose config` — resolves the bind source to the configured directory and target to `/app/data`

## Risk

Low runtime risk: application persistence code is unchanged. The main risk is operator misconfiguration—pointing Compose at the ciphertext directory or an empty/unmounted path—which the runbook calls out explicitly.

Closes #203.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Data directory mount path is now configurable via environment variable for Docker Compose deployments
  * Added support for encryption at rest with comprehensive operational documentation

* **Documentation**
  * New security runbook covering encryption at rest implementation options and procedures
  * Updated configuration documentation, admin security checklist, and backup procedures for encrypted deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->