### PR TITLE
fix(i18n): localize failed puzzle results (closes #213)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -234,6 +234,15 @@ function setMessage(text) {
   messageEl.textContent = text;
 }
 
+function getMeaningSuffix(value) {
+  const meaning = typeof value === "string" ? value.trim() : "";
+  if (!meaning) return "";
+  const formatted = window.i18n
+    ? window.i18n.t("play.meaningPrefix", { meaning })
+    : `Meaning: ${meaning}`;
+  return ` ${formatted}`;
+}
+
 function setSrStatus(text) {
   if (!srStatusEl) return;
   srStatusEl.textContent = text;
@@ -1230,19 +1239,10 @@ async function submitGuess() {
     if (data.isCorrect) {
       locked = true;
       await upsertDailyResult(true, currentRow + 1, maxGuesses);
-      const meaning =
-        typeof data.answerMeaning === "string" && data.answerMeaning.trim()
-          ? data.answerMeaning.trim()
-          : "";
       const baseMessage = window.i18n
         ? window.i18n.t("play.solvedFormat", { tries: currentRow + 1, max: maxGuesses })
         : `Solved in ${currentRow + 1}/${maxGuesses}!`;
-      const suffix = meaning
-        ? ` ${window.i18n
-          ? window.i18n.t("play.solvedMeaningPrefix", { meaning })
-          : `Meaning: ${meaning}`}`
-        : "";
-      setMessage(`${baseMessage}${suffix}`);
+      setMessage(`${baseMessage}${getMeaningSuffix(data.answerMeaning)}`);
       return;
     }
 
@@ -1250,19 +1250,10 @@ async function submitGuess() {
       locked = true;
       await upsertDailyResult(false, maxGuesses, maxGuesses);
       if (data.answer) {
-        const meaning =
-          typeof data.answerMeaning === "string" && data.answerMeaning.trim()
-            ? data.answerMeaning.trim()
-            : "";
         const baseMessage = window.i18n
           ? window.i18n.t("play.outOfTriesAnswer", { answer: data.answer })
           : `Out of tries. Word was ${data.answer}.`;
-        const suffix = meaning
-          ? ` ${window.i18n
-            ? window.i18n.t("play.solvedMeaningPrefix", { meaning })
-            : `Meaning: ${meaning}`}`
-          : "";
-        setMessage(`${baseMessage}${suffix}`);
+        setMessage(`${baseMessage}${getMeaningSuffix(data.answerMeaning)}`);
       } else {
         setMessage(window.i18n ? window.i18n.t("play.outOfTries") : "Out of tries.");
       }

--- a/public/app.js
+++ b/public/app.js
@@ -1250,13 +1250,21 @@ async function submitGuess() {
       locked = true;
       await upsertDailyResult(false, maxGuesses, maxGuesses);
       if (data.answer) {
-        const suffix =
+        const meaning =
           typeof data.answerMeaning === "string" && data.answerMeaning.trim()
-            ? ` Meaning: ${data.answerMeaning.trim()}`
+            ? data.answerMeaning.trim()
             : "";
-        setMessage(`Out of tries. Word was ${data.answer}.${suffix}`);
+        const baseMessage = window.i18n
+          ? window.i18n.t("play.outOfTriesAnswer", { answer: data.answer })
+          : `Out of tries. Word was ${data.answer}.`;
+        const suffix = meaning
+          ? ` ${window.i18n
+            ? window.i18n.t("play.solvedMeaningPrefix", { meaning })
+            : `Meaning: ${meaning}`}`
+          : "";
+        setMessage(`${baseMessage}${suffix}`);
       } else {
-        setMessage("Out of tries.");
+        setMessage(window.i18n ? window.i18n.t("play.outOfTries") : "Out of tries.");
       }
       return;
     }

--- a/public/js/i18n-en.js
+++ b/public/js/i18n-en.js
@@ -79,6 +79,8 @@ window.__i18nMessagesEn = {
     "encodedNote": "Encoded links aren't private.",
     "solvedFormat": "Solved in {tries}/{max}!",
     "solvedMeaningPrefix": "Meaning: {meaning}",
+    "outOfTries": "Out of tries.",
+    "outOfTriesAnswer": "Out of tries. Word was {answer}.",
     "guessNotInList": "Not in word list.",
     "guessTooShort": "Guess must be {length} letters."
   },

--- a/public/js/i18n-en.js
+++ b/public/js/i18n-en.js
@@ -78,7 +78,7 @@ window.__i18nMessagesEn = {
     "aboutShareLinks": "About share links",
     "encodedNote": "Encoded links aren't private.",
     "solvedFormat": "Solved in {tries}/{max}!",
-    "solvedMeaningPrefix": "Meaning: {meaning}",
+    "meaningPrefix": "Meaning: {meaning}",
     "outOfTries": "Out of tries.",
     "outOfTriesAnswer": "Out of tries. Word was {answer}.",
     "guessNotInList": "Not in word list.",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -70,7 +70,7 @@
     "aboutShareLinks": "About share links",
     "encodedNote": "Encoded links aren't private.",
     "solvedFormat": "Solved in {tries}/{max}!",
-    "solvedMeaningPrefix": "Meaning: {meaning}",
+    "meaningPrefix": "Meaning: {meaning}",
     "outOfTries": "Out of tries.",
     "outOfTriesAnswer": "Out of tries. Word was {answer}.",
     "guessNotInList": "Not in word list.",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -71,6 +71,8 @@
     "encodedNote": "Encoded links aren't private.",
     "solvedFormat": "Solved in {tries}/{max}!",
     "solvedMeaningPrefix": "Meaning: {meaning}",
+    "outOfTries": "Out of tries.",
+    "outOfTriesAnswer": "Out of tries. Word was {answer}.",
     "guessNotInList": "Not in word list.",
     "guessTooShort": "Guess must be {length} letters."
   },

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -71,6 +71,8 @@
     "encodedNote": "Los enlaces codificados no son privados.",
     "solvedFormat": "¡Resuelto en {tries}/{max}!",
     "solvedMeaningPrefix": "Significado: {meaning}",
+    "outOfTries": "Se acabaron los intentos.",
+    "outOfTriesAnswer": "Se acabaron los intentos. La palabra era {answer}.",
     "guessNotInList": "No está en la lista de palabras.",
     "guessTooShort": "El intento debe tener {length} letras."
   },

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -70,7 +70,7 @@
     "aboutShareLinks": "Sobre los enlaces",
     "encodedNote": "Los enlaces codificados no son privados.",
     "solvedFormat": "¡Resuelto en {tries}/{max}!",
-    "solvedMeaningPrefix": "Significado: {meaning}",
+    "meaningPrefix": "Significado: {meaning}",
     "outOfTries": "Se acabaron los intentos.",
     "outOfTriesAnswer": "Se acabaron los intentos. La palabra era {answer}.",
     "guessNotInList": "No está en la lista de palabras.",

--- a/tests/ui/create-play.spec.js
+++ b/tests/ui/create-play.spec.js
@@ -84,6 +84,33 @@ test("reveals a local meaning after final failed guess", async ({ page }) => {
   await expect(page.locator("#message")).toContainText("Meaning:");
 });
 
+test("localizes the final failed guess result in Spanish", async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("localePreference", "es"));
+  await page.goto("/", gotoOptions);
+  await waitForLanguages(page);
+  await page.selectOption("#langSelect", "en");
+  await page.fill("#wordInput", "CRANE");
+  await page.click("form#createForm button[type=submit]");
+  await page.waitForSelector("#playPanel:not(.hidden)");
+  await page.click("#board");
+
+  const failedGuesses = ["SLATE", "CRATE", "STONE", "TRAIL", "ABATE", "ADORE"];
+  for (let i = 0; i < failedGuesses.length; i += 1) {
+    await page.keyboard.type(failedGuesses[i]);
+    await page.keyboard.press("Enter");
+    await expect(
+      page.locator(
+        `#board .row:nth-child(${i + 1}) .tile.absent, #board .row:nth-child(${i + 1}) .tile.present, #board .row:nth-child(${i + 1}) .tile.correct`
+      )
+    ).toHaveCount(5);
+  }
+
+  await expect(page.locator("#message")).toContainText(
+    "Se acabaron los intentos. La palabra era CRANE."
+  );
+  await expect(page.locator("#message")).toContainText("Significado:");
+});
+
 test("daily mode requires a player name and updates leaderboard stats", async ({ page }) => {
   const playerName = `Ava ${RUN_TOKEN}`;
   await page.goto(`/?word=yfrqp&lang=en&daily=1&day=${todayLocalDate()}`, gotoOptions);


### PR DESCRIPTION
## Summary

Completes the remaining i18n parity work for end-of-game word meanings:

- routes the failed-puzzle result through locale keys instead of hardcoded English;
- adds English and Spanish strings for the generic and answer-reveal loss states;
- reuses the existing localized meaning prefix;
- regenerates the checked-in English locale bundle;
- adds a Chromium UI test covering a Spanish loss result with the revealed answer and meaning.

## Product decision

Missing definitions remain a silent omission. The result still renders normally without a meaning suffix, rather than showing a noisy `Definition unavailable` message. This matches the recommendation recorded in issue #213 and preserves the existing graceful behavior.

## Validation

- `npm run check` — 70 suites, 1,236 tests passed
- `PLAYWRIGHT_BROWSERS=chromium npx playwright test tests/ui/create-play.spec.js --project=chromium` — 17 passed
- `npm run lint`
- `npm run i18n:check`
- `npm run i18n:bundle:check`
- `git diff --check`

## Risk

Low. The API and meaning lookup are unchanged; this only changes client message composition and locale resources.

Closes #213.