### PR TITLE
Add coverage tests for CSV format, provider artifact sharing, and VAPID store

### DIFF
--- a/tests/csv-format.test.js
+++ b/tests/csv-format.test.js
@@ -76,7 +76,7 @@ describe("buildCsv", () => {
 
   test("handles non-array row as empty line", () => {
     const result = buildCsv([["a"], null, ["b"]]);
-    expect(result).toBe("a" + CRLF + "" + CRLF + "b" + CRLF);
+    expect(result).toBe("a" + CRLF + CRLF + "b" + CRLF);
   });
 
   test("prepends UTF-8 BOM when bom option is true", () => {

--- a/tests/csv-format.test.js
+++ b/tests/csv-format.test.js
@@ -1,0 +1,205 @@
+"use strict";
+
+const {
+  buildCsv,
+  escapeField,
+  parseBulkNames,
+  UTF8_BOM,
+  CRLF
+} = require("../lib/csv-format");
+
+describe("escapeField", () => {
+  test("returns empty string for null and undefined", () => {
+    expect(escapeField(null)).toBe("");
+    expect(escapeField(undefined)).toBe("");
+  });
+
+  test("returns empty string for empty string", () => {
+    expect(escapeField("")).toBe("");
+  });
+
+  test("passes through simple values without special chars", () => {
+    expect(escapeField("hello")).toBe("hello");
+    expect(escapeField("abc123")).toBe("abc123");
+    expect(escapeField(42)).toBe("42");
+  });
+
+  test("wraps value containing comma in quotes", () => {
+    expect(escapeField("a,b")).toBe('"a,b"');
+  });
+
+  test("wraps value containing double-quote and doubles internal quotes", () => {
+    expect(escapeField('say "hello"')).toBe('"say ""hello"""');
+  });
+
+  test("wraps value containing CRLF", () => {
+    expect(escapeField("line1\r\nline2")).toBe('"line1\r\nline2"');
+  });
+
+  test("wraps value containing newline", () => {
+    expect(escapeField("line1\nline2")).toBe('"line1\nline2"');
+  });
+});
+
+describe("buildCsv", () => {
+  test("returns empty string for empty rows", () => {
+    expect(buildCsv([])).toBe("");
+  });
+
+  test("returns BOM only when bom option is set and rows is empty", () => {
+    expect(buildCsv([], { bom: true })).toBe(UTF8_BOM);
+  });
+
+  test("returns empty string for null input", () => {
+    expect(buildCsv(null)).toBe("");
+  });
+
+  test("builds single row", () => {
+    const result = buildCsv([["a", "b", "c"]]);
+    expect(result).toBe("a,b,c" + CRLF);
+  });
+
+  test("builds multiple rows", () => {
+    const rows = [
+      ["name", "age"],
+      ["Alice", "30"],
+      ["Bob", "25"]
+    ];
+    const result = buildCsv(rows);
+    expect(result).toBe("name,age" + CRLF + "Alice,30" + CRLF + "Bob,25" + CRLF);
+  });
+
+  test("escapes fields with special characters", () => {
+    const result = buildCsv([['hello, world', 'say "hi"', "normal"]]);
+    expect(result).toBe('"hello, world","say ""hi""",normal' + CRLF);
+  });
+
+  test("handles non-array row as empty line", () => {
+    const result = buildCsv([["a"], null, ["b"]]);
+    expect(result).toBe("a" + CRLF + "" + CRLF + "b" + CRLF);
+  });
+
+  test("prepends UTF-8 BOM when bom option is true", () => {
+    const result = buildCsv([["a"]], { bom: true });
+    expect(result).toBe(UTF8_BOM + "a" + CRLF);
+  });
+});
+
+describe("parseBulkNames", () => {
+  test("returns error for non-string input", () => {
+    const result = parseBulkNames(42);
+    expect(result.names).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toBe("Input must be a string.");
+  });
+
+  test("returns empty names for empty input", () => {
+    const result = parseBulkNames("");
+    expect(result.names).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("parses single name", () => {
+    const result = parseBulkNames("Alice");
+    expect(result.names).toEqual(["Alice"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("parses multiple names separated by newlines", () => {
+    const result = parseBulkNames("Alice\nBob\nCharlie");
+    expect(result.names).toEqual(["Alice", "Bob", "Charlie"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("handles CRLF line endings", () => {
+    const result = parseBulkNames("Alice\r\nBob\r\nCharlie");
+    expect(result.names).toEqual(["Alice", "Bob", "Charlie"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("strips UTF-8 BOM", () => {
+    const result = parseBulkNames(UTF8_BOM + "Alice\nBob");
+    expect(result.names).toEqual(["Alice", "Bob"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("trims whitespace from names", () => {
+    const result = parseBulkNames("  Alice  \n  Bob  ");
+    expect(result.names).toEqual(["Alice", "Bob"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("skips empty lines", () => {
+    const result = parseBulkNames("Alice\n\nBob\n");
+    expect(result.names).toEqual(["Alice", "Bob"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("extracts only first column from CSV data", () => {
+    const result = parseBulkNames("Alice,30,Engineer\nBob,25,Designer");
+    expect(result.names).toEqual(["Alice", "Bob"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("handles quoted fields", () => {
+    const result = parseBulkNames('"Alice"\n"Bob"');
+    expect(result.names).toEqual(["Alice", "Bob"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("handles quoted fields with embedded commas", () => {
+    const result = parseBulkNames('"Smith, Alice"\n"Doe, Bob"');
+    expect(result.names).toEqual(["Smith, Alice", "Doe, Bob"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("handles escaped double-quotes inside quoted field", () => {
+    const result = parseBulkNames('"Alice ""The Great"""');
+    expect(result.names).toEqual(['Alice "The Great"']);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("rejects unbalanced quotes", () => {
+    const result = parseBulkNames('"Alice\nBob');
+    expect(result.names).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/unbalanced quote/i);
+  });
+
+  test("rejects unexpected character after closing quote", () => {
+    const result = parseBulkNames('"Alice"x');
+    expect(result.names).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/unexpected character after closing quote/i);
+  });
+
+  test("rejects unexpected quote after unquoted field", () => {
+    const result = parseBulkNames('Alice"');
+    expect(result.names).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/unexpected quote after unquoted field/i);
+  });
+
+  test("enforces line limit", () => {
+    const lines = Array.from({ length: 1001 }, (_, i) => `Name${i}`).join("\n");
+    const result = parseBulkNames(lines);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/exceeded.*rows/i);
+  });
+
+  test("respects custom line limit option", () => {
+    const result = parseBulkNames("Alice\nBob\nCharlie", { lineLimit: 2 });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/exceeded.*rows/i);
+  });
+});
+
+describe("exports", () => {
+  test("UTF8_BOM is the BOM character", () => {
+    expect(UTF8_BOM).toBe("\uFEFF");
+  });
+
+  test("CRLF is carriage-return + newline", () => {
+    expect(CRLF).toBe("\r\n");
+  });
+});

--- a/tests/provider-artifact-shared.test.js
+++ b/tests/provider-artifact-shared.test.js
@@ -1,0 +1,304 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  MAX_WORD_LENGTH,
+  MIN_WORD_LENGTH,
+  RELATIVE_PATH_PATTERN,
+  SOURCE_MANIFEST_TYPES,
+  SUPPORTED_VARIANT_IDS,
+  WORD_PATTERN,
+  normalizeCommit,
+  normalizePolicyVersion,
+  normalizeRelativePath,
+  normalizeVariant,
+  resolveWithinRoot,
+  writeFileAtomic,
+  writeJsonAtomic
+} = require("../lib/provider-artifact-shared");
+
+function errorFactory(code, message, options) {
+  const err = new Error(message);
+  err.code = code;
+  if (options?.cause) err.cause = options.cause;
+  return err;
+}
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "lhw-provider-artifact-"));
+}
+
+describe("constants", () => {
+  test("MIN_WORD_LENGTH is 3", () => {
+    expect(MIN_WORD_LENGTH).toBe(3);
+  });
+
+  test("MAX_WORD_LENGTH is 12", () => {
+    expect(MAX_WORD_LENGTH).toBe(12);
+  });
+
+  test("WORD_PATTERN matches uppercase letters only", () => {
+    expect(WORD_PATTERN.test("CAT")).toBe(true);
+    expect(WORD_PATTERN.test("ABC123")).toBe(false);
+    expect(WORD_PATTERN.test("cat")).toBe(false);
+  });
+
+  test("SUPPORTED_VARIANT_IDS is frozen and contains expected variants", () => {
+    expect(SUPPORTED_VARIANT_IDS).toEqual(["en-GB", "en-US", "en-CA", "en-AU", "en-ZA"]);
+    expect(Object.isFrozen(SUPPORTED_VARIANT_IDS)).toBe(true);
+  });
+
+  test("SOURCE_MANIFEST_TYPES is frozen", () => {
+    expect(SOURCE_MANIFEST_TYPES.REMOTE_FETCH).toBe("provider-source-fetch");
+    expect(SOURCE_MANIFEST_TYPES.MANUAL_UPLOAD).toBe("provider-source-manual-upload");
+    expect(Object.isFrozen(SOURCE_MANIFEST_TYPES)).toBe(true);
+  });
+
+  test("RELATIVE_PATH_PATTERN matches safe relative paths", () => {
+    expect(RELATIVE_PATH_PATTERN.test("en-US/abc/file.txt")).toBe(true);
+    expect(RELATIVE_PATH_PATTERN.test("../escape")).toBe(false);
+    expect(RELATIVE_PATH_PATTERN.test("/absolute")).toBe(false);
+  });
+});
+
+describe("normalizeVariant", () => {
+  test("passes through valid variant", () => {
+    const result = normalizeVariant("en-US", {
+      errorFactory,
+      supportedVariants: new Set(SUPPORTED_VARIANT_IDS)
+    });
+    expect(result).toBe("en-US");
+  });
+
+  test("trims whitespace", () => {
+    const result = normalizeVariant("  en-US  ", {
+      errorFactory,
+      supportedVariants: new Set(SUPPORTED_VARIANT_IDS)
+    });
+    expect(result).toBe("en-US");
+  });
+
+  test("throws for unsupported variant", () => {
+    expect(() =>
+      normalizeVariant("fr-FR", {
+        errorFactory,
+        supportedVariants: new Set(SUPPORTED_VARIANT_IDS)
+      })
+    ).toThrow(/variant must be one of/);
+  });
+
+  test("throws when supportedVariants is missing or empty", () => {
+    expect(() =>
+      normalizeVariant("en-US", { errorFactory })
+    ).toThrow("normalizeVariant requires a non-empty supportedVariants Set.");
+
+    expect(() =>
+      normalizeVariant("en-US", { errorFactory, supportedVariants: new Set() })
+    ).toThrow("normalizeVariant requires a non-empty supportedVariants Set.");
+  });
+
+  test("throws when errorFactory is missing", () => {
+    expect(() =>
+      normalizeVariant("en-US", { supportedVariants: new Set(SUPPORTED_VARIANT_IDS) })
+    ).toThrow("normalizeVariant requires an errorFactory function.");
+  });
+});
+
+describe("normalizeCommit", () => {
+  test("passes through valid 40-char hex SHA", () => {
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    expect(normalizeCommit(sha, { errorFactory })).toBe(sha);
+  });
+
+  test("trims whitespace", () => {
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    expect(normalizeCommit(`  ${sha}  `, { errorFactory })).toBe(sha);
+  });
+
+  test("throws for non-40-char hex", () => {
+    expect(() =>
+      normalizeCommit("short", { errorFactory })
+    ).toThrow(/commit must be a 40-character/);
+  });
+
+  test("throws when errorFactory is missing", () => {
+    expect(() =>
+      normalizeCommit("0123456789abcdef0123456789abcdef01234567", {})
+    ).toThrow("normalizeCommit requires an errorFactory function.");
+  });
+});
+
+describe("normalizePolicyVersion", () => {
+  test("defaults to v1 when no value given", () => {
+    expect(normalizePolicyVersion(undefined, { errorFactory })).toBe("v1");
+    expect(normalizePolicyVersion("", { errorFactory })).toBe("v1");
+  });
+
+  test("passes through valid policy version", () => {
+    expect(normalizePolicyVersion("v2", { errorFactory })).toBe("v2");
+    expect(normalizePolicyVersion("strict-2024", { errorFactory })).toBe("strict-2024");
+  });
+
+  test("throws for invalid policy version", () => {
+    expect(() =>
+      normalizePolicyVersion("this is way too long for a valid policy version string!", { errorFactory })
+    ).toThrow(/policyVersion/);
+  });
+
+  test("throws when errorFactory is missing", () => {
+    expect(() =>
+      normalizePolicyVersion("v1", {})
+    ).toThrow("normalizePolicyVersion requires an errorFactory function.");
+  });
+});
+
+describe("normalizeRelativePath", () => {
+  test("passes through valid relative path", () => {
+    expect(normalizeRelativePath("en-US/abc/file.txt", { errorFactory })).toBe("en-US/abc/file.txt");
+  });
+
+  test("trims whitespace", () => {
+    expect(normalizeRelativePath("  file.txt  ", { errorFactory })).toBe("file.txt");
+  });
+
+  test("throws for empty path", () => {
+    expect(() =>
+      normalizeRelativePath("", { errorFactory })
+    ).toThrow(/must be a non-empty path/);
+  });
+
+  test("throws for absolute path", () => {
+    expect(() =>
+      normalizeRelativePath("/etc/passwd", { errorFactory })
+    ).toThrow(/must be a safe relative path/);
+  });
+
+  test("throws for path traversal", () => {
+    expect(() =>
+      normalizeRelativePath("../escape", { errorFactory })
+    ).toThrow(/must be a safe relative path/);
+  });
+
+  test("uses custom fieldName and errorCode", () => {
+    expect(() =>
+      normalizeRelativePath("/abs", {
+        errorFactory,
+        fieldName: "customPath",
+        errorCode: "CUSTOM_ERR"
+      })
+    ).toThrow(/customPath must be a safe relative path/);
+  });
+
+  test("throws when errorFactory is missing", () => {
+    expect(() =>
+      normalizeRelativePath("file.txt", {})
+    ).toThrow("normalizeRelativePath requires an errorFactory function.");
+  });
+});
+
+describe("resolveWithinRoot", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("resolves valid relative path within root", () => {
+    const result = resolveWithinRoot(tmpDir, "sub/file.txt", { errorFactory });
+    expect(result.normalized).toBe("sub/file.txt");
+    expect(result.resolved).toBe(path.join(tmpDir, "sub/file.txt"));
+  });
+
+  test("throws for path that escapes root", () => {
+    expect(() =>
+      resolveWithinRoot(tmpDir, "../escape", { errorFactory })
+    ).toThrow(/safe relative path/);
+  });
+
+  test("throws for absolute path", () => {
+    expect(() =>
+      resolveWithinRoot(tmpDir, "/etc/passwd", { errorFactory })
+    ).toThrow(/must be a safe relative path/);
+  });
+
+  test("uses custom fieldName and errorCode", () => {
+    expect(() =>
+      resolveWithinRoot(tmpDir, "../escape", {
+        errorFactory,
+        fieldName: "myPath",
+        errorCode: "BAD_PATH"
+      })
+    ).toThrow(/myPath must be a safe relative path/);
+  });
+});
+
+describe("writeFileAtomic", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("writes file content atomically", async () => {
+    const filePath = path.join(tmpDir, "test.txt");
+    await writeFileAtomic(filePath, "hello world", { errorFactory });
+    expect(fs.readFileSync(filePath, "utf8")).toBe("hello world");
+  });
+
+  test("throws with error code on failure", async () => {
+    const filePath = path.join(tmpDir, "nonexistent", "test.txt");
+    await expect(
+      writeFileAtomic(filePath, "data", { errorFactory })
+    ).rejects.toMatchObject({
+      code: "PERSISTENCE_WRITE_FAILED"
+    });
+  });
+
+  test("uses custom error code", async () => {
+    const filePath = path.join(tmpDir, "nonexistent", "test.txt");
+    await expect(
+      writeFileAtomic(filePath, "data", { errorFactory, errorCode: "CUSTOM_WRITE_ERR" })
+    ).rejects.toMatchObject({
+      code: "CUSTOM_WRITE_ERR"
+    });
+  });
+});
+
+describe("writeJsonAtomic", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("writes JSON content with trailing newline", async () => {
+    const filePath = path.join(tmpDir, "data.json");
+    await writeJsonAtomic(filePath, { key: "value" }, { errorFactory });
+    const content = fs.readFileSync(filePath, "utf8");
+    expect(content).toBe('{\n  "key": "value"\n}\n');
+  });
+
+  test("throws on failure", async () => {
+    const filePath = path.join(tmpDir, "nonexistent", "data.json");
+    await expect(
+      writeJsonAtomic(filePath, { key: "value" }, { errorFactory })
+    ).rejects.toMatchObject({
+      code: "PERSISTENCE_WRITE_FAILED"
+    });
+  });
+});

--- a/tests/vapid-store.test.js
+++ b/tests/vapid-store.test.js
@@ -100,7 +100,7 @@ describe("VapidStore constructor", () => {
   test("requires filePath option", () => {
     expect(() => new VapidStore()).toThrow(VapidStoreError);
     expect(() => new VapidStore({})).toThrow(VapidStoreError);
-    expect(() => new VapidStore({ filePath: "/tmp/keys.json" })).not.toThrow();
+    expect(() => new VapidStore({ filePath: path.join(os.tmpdir(), "keys.json") })).not.toThrow();
   });
 
   test("initializes state to null", () => {

--- a/tests/vapid-store.test.js
+++ b/tests/vapid-store.test.js
@@ -1,0 +1,285 @@
+"use strict";
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  VapidStore,
+  VapidStoreError,
+  normalizeKeys,
+  SCHEMA_VERSION
+} = require("../lib/vapid-store");
+
+function tempPath(name = "vapid-keys.json") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lhw-vapid-"));
+  return path.join(dir, name);
+}
+
+function validRawKeys(overrides = {}) {
+  return {
+    publicKey: "B".repeat(87),
+    privateKey: "x".repeat(43),
+    subject: "mailto:admin@example.com",
+    ...overrides
+  };
+}
+
+function makeGenerate() {
+  return () => ({
+    publicKey: "B".repeat(87),
+    privateKey: "x".repeat(43)
+  });
+}
+
+describe("VapidStoreError", () => {
+  test("sets name, code, and message", () => {
+    const err = new VapidStoreError("TEST_CODE", "test message");
+    expect(err.name).toBe("VapidStoreError");
+    expect(err.code).toBe("TEST_CODE");
+    expect(err.message).toBe("test message");
+  });
+
+  test("attaches cause when provided", () => {
+    const cause = new Error("underlying");
+    const err = new VapidStoreError("ERR", "msg", { cause });
+    expect(err.cause).toBe(cause);
+  });
+});
+
+describe("SCHEMA_VERSION", () => {
+  test("is 1", () => {
+    expect(SCHEMA_VERSION).toBe(1);
+  });
+});
+
+describe("normalizeKeys", () => {
+  test("passes through valid keys", () => {
+    const raw = validRawKeys();
+    const result = normalizeKeys(raw);
+    expect(result).toEqual({
+      publicKey: raw.publicKey,
+      privateKey: raw.privateKey,
+      subject: raw.subject
+    });
+  });
+
+  test("throws for non-object", () => {
+    expect(() => normalizeKeys(null)).toThrow(VapidStoreError);
+    expect(() => normalizeKeys("string")).toThrow(VapidStoreError);
+    expect(() => normalizeKeys([])).toThrow(VapidStoreError);
+  });
+
+  test("throws when publicKey is missing or wrong length", () => {
+    expect(() => normalizeKeys(validRawKeys({ publicKey: "" }))).toThrow(VapidStoreError);
+    expect(() => normalizeKeys(validRawKeys({ publicKey: "short" }))).toThrow(VapidStoreError);
+    expect(() => normalizeKeys(validRawKeys({ publicKey: "B".repeat(201) }))).toThrow(VapidStoreError);
+  });
+
+  test("throws when privateKey is missing or wrong length", () => {
+    expect(() => normalizeKeys(validRawKeys({ privateKey: "" }))).toThrow(VapidStoreError);
+    expect(() => normalizeKeys(validRawKeys({ privateKey: "short" }))).toThrow(VapidStoreError);
+    expect(() => normalizeKeys(validRawKeys({ privateKey: "x".repeat(101) }))).toThrow(VapidStoreError);
+  });
+
+  test("throws when subject is missing or invalid", () => {
+    expect(() => normalizeKeys(validRawKeys({ subject: "" }))).toThrow(VapidStoreError);
+    expect(() => normalizeKeys(validRawKeys({ subject: "plaintext" }))).toThrow(VapidStoreError);
+    expect(() => normalizeKeys(validRawKeys({ subject: "mailto:" + "a".repeat(257) }))).toThrow(VapidStoreError);
+  });
+
+  test("accepts https: subject", () => {
+    const raw = validRawKeys({ subject: "https://example.com" });
+    const result = normalizeKeys(raw);
+    expect(result.subject).toBe("https://example.com");
+  });
+});
+
+describe("VapidStore constructor", () => {
+  test("requires filePath option", () => {
+    expect(() => new VapidStore()).toThrow(VapidStoreError);
+    expect(() => new VapidStore({})).toThrow(VapidStoreError);
+    expect(() => new VapidStore({ filePath: "/tmp/keys.json" })).not.toThrow();
+  });
+
+  test("initializes state to null", () => {
+    const fp = tempPath();
+    const store = new VapidStore({ filePath: fp });
+    expect(store.state).toBeNull();
+    expect(store.filePath).toBe(fp);
+    fs.rmSync(path.dirname(fp), { recursive: true, force: true });
+  });
+});
+
+describe("VapidStore loadSync / reloadSync", () => {
+  let filePath;
+  let store;
+
+  beforeEach(() => {
+    filePath = tempPath();
+    store = new VapidStore({ filePath });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(path.dirname(filePath), { recursive: true, force: true }).catch(() => {});
+  });
+
+  test("returns null when file does not exist", () => {
+    expect(store.loadSync()).toBeNull();
+  });
+
+  test("returns null for invalid JSON", () => {
+    fs.writeFileSync(filePath, "not-json", "utf8");
+    expect(store.loadSync()).toBeNull();
+    expect(store.state).toBeNull();
+  });
+
+  test("returns null for unsupported shape", () => {
+    fs.writeFileSync(filePath, JSON.stringify({ version: 999 }), "utf8");
+    expect(store.loadSync()).toBeNull();
+    expect(store.state).toBeNull();
+  });
+
+  test("returns null for missing keys field", () => {
+    fs.writeFileSync(filePath, JSON.stringify({ version: 1 }), "utf8");
+    expect(store.loadSync()).toBeNull();
+  });
+
+  test("loads valid store file", () => {
+    const raw = validRawKeys();
+    const data = { version: 1, keys: raw, updatedAt: "2026-01-01T00:00:00.000Z" };
+    fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+    const result = store.loadSync();
+    expect(result.version).toBe(1);
+    expect(result.keys.publicKey).toBe(raw.publicKey);
+    expect(result.keys.privateKey).toBe(raw.privateKey);
+    expect(result.keys.subject).toBe(raw.subject);
+  });
+
+  test("loadSync caches result in state", () => {
+    const raw = validRawKeys();
+    const data = { version: 1, keys: raw, updatedAt: "2026-01-01T00:00:00.000Z" };
+    fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+    store.loadSync();
+    expect(store.state).not.toBeNull();
+    const second = store.loadSync();
+    expect(second.version).toBe(1);
+  });
+
+  test("reloadSync clears cache and re-reads", () => {
+    const raw = validRawKeys();
+    const data = { version: 1, keys: raw, updatedAt: "2026-01-01T00:00:00.000Z" };
+    fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+    store.loadSync();
+    expect(store.state).not.toBeNull();
+
+    fs.writeFileSync(filePath, JSON.stringify({ wrong: true }), "utf8");
+    const result = store.reloadSync();
+    expect(result).toBeNull();
+    expect(store.state).toBeNull();
+  });
+
+  test("handles missing updatedAt gracefully", () => {
+    const raw = validRawKeys();
+    const data = { version: 1, keys: raw };
+    fs.writeFileSync(filePath, `${JSON.stringify(data)}\n`, "utf8");
+    const result = store.loadSync();
+    expect(result.updatedAt).toBeTruthy();
+  });
+
+  test("handles invalid keys in file gracefully", () => {
+    const data = { version: 1, keys: { publicKey: "short", privateKey: "also-short", subject: "bad" } };
+    fs.writeFileSync(filePath, `${JSON.stringify(data)}\n`, "utf8");
+    expect(store.loadSync()).toBeNull();
+    expect(store.state).toBeNull();
+  });
+});
+
+describe("VapidStore getKeysSync", () => {
+  let filePath;
+  let store;
+
+  beforeEach(() => {
+    filePath = tempPath();
+    store = new VapidStore({ filePath });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(path.dirname(filePath), { recursive: true, force: true }).catch(() => {});
+  });
+
+  test("returns null when no keys exist", () => {
+    expect(store.getKeysSync()).toBeNull();
+  });
+
+  test("returns keys from loaded store", () => {
+    const raw = validRawKeys();
+    const data = { version: 1, keys: raw, updatedAt: "2026-01-01T00:00:00.000Z" };
+    fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+    const result = store.getKeysSync();
+    expect(result.publicKey).toBe(raw.publicKey);
+    expect(result.privateKey).toBe(raw.privateKey);
+    expect(result.subject).toBe(raw.subject);
+  });
+});
+
+describe("VapidStore ensureKeysSync", () => {
+  let filePath;
+  let store;
+
+  beforeEach(() => {
+    filePath = tempPath();
+    store = new VapidStore({ filePath });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(path.dirname(filePath), { recursive: true, force: true }).catch(() => {});
+  });
+
+  test("throws when generate function is missing", () => {
+    expect(() => store.ensureKeysSync()).toThrow(VapidStoreError);
+    expect(() => store.ensureKeysSync({})).toThrow(VapidStoreError);
+  });
+
+  test("generates and persists keys when none exist", () => {
+    const result = store.ensureKeysSync({ generate: makeGenerate() });
+    expect(result.publicKey).toBe("B".repeat(87));
+    expect(result.privateKey).toBe("x".repeat(43));
+    expect(result.subject).toBe("mailto:admin@localhost");
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  test("uses custom subject when provided", () => {
+    const result = store.ensureKeysSync({
+      generate: makeGenerate(),
+      subject: "mailto:admin@custom.com"
+    });
+    expect(result.subject).toBe("mailto:admin@custom.com");
+  });
+
+  test("falls back to default subject when custom subject is invalid", () => {
+    const result = store.ensureKeysSync({
+      generate: makeGenerate(),
+      subject: "invalid-subject"
+    });
+    expect(result.subject).toBe("mailto:admin@localhost");
+  });
+
+  test("returns existing keys without generating again", () => {
+    const generate = jest.fn(makeGenerate());
+    store.ensureKeysSync({ generate });
+    expect(generate).toHaveBeenCalledTimes(1);
+
+    const second = store.ensureKeysSync({ generate });
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(second.publicKey).toBe("B".repeat(87));
+  });
+
+  test("persisted keys survive reload", () => {
+    store.ensureKeysSync({ generate: makeGenerate() });
+    store.reloadSync();
+    const keys = store.getKeysSync();
+    expect(keys.publicKey).toBe("B".repeat(87));
+  });
+});


### PR DESCRIPTION
## Summary
- add focused tests for CSV formatting behavior
- add provider artifact sharing test coverage
- add VAPID store test coverage, including persistence and edge cases
- move advanced settings doc under `docs/` and align related script/package references

## Notes
- this PR includes the existing branch commits